### PR TITLE
Use bRestrict and Move Schematic Components

### DIFF
--- a/Hardware/SparkFun_ProtoShield_Kit_rev31.brd
+++ b/Hardware/SparkFun_ProtoShield_Kit_rev31.brd
@@ -48,8 +48,8 @@
 <layer number="38" name="bTest" color="7" fill="1" visible="no" active="yes"/>
 <layer number="39" name="tKeepout" color="4" fill="11" visible="no" active="yes"/>
 <layer number="40" name="bKeepout" color="1" fill="11" visible="no" active="yes"/>
-<layer number="41" name="tRestrict" color="4" fill="10" visible="no" active="yes"/>
-<layer number="42" name="bRestrict" color="1" fill="10" visible="no" active="yes"/>
+<layer number="41" name="tRestrict" color="4" fill="10" visible="yes" active="yes"/>
+<layer number="42" name="bRestrict" color="1" fill="10" visible="yes" active="yes"/>
 <layer number="43" name="vRestrict" color="2" fill="10" visible="no" active="yes"/>
 <layer number="44" name="Drills" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="45" name="Holes" color="7" fill="1" visible="yes" active="yes"/>
@@ -1034,6 +1034,12 @@ ProtoShield</text>
 <wire x1="24.13" y1="8.255" x2="24.13" y2="12.065" width="0.254" layer="22"/>
 <wire x1="24.765" y1="12.7" x2="24.13" y2="12.065" width="0.254" layer="22"/>
 <wire x1="29.7942" y1="13.0302" x2="31.0642" y2="13.0302" width="0.2032" layer="22"/>
+<wire x1="20.574" y1="60.198" x2="20.574" y2="60.579" width="0.254" layer="42"/>
+<wire x1="20.574" y1="60.579" x2="22.606" y2="60.579" width="0.254" layer="42"/>
+<wire x1="22.606" y1="60.579" x2="22.606" y2="60.198" width="0.254" layer="42"/>
+<wire x1="22.606" y1="59.309" x2="22.606" y2="58.801" width="0.254" layer="42"/>
+<wire x1="22.606" y1="58.801" x2="20.574" y2="58.801" width="0.254" layer="42"/>
+<wire x1="20.574" y1="58.801" x2="20.574" y2="59.309" width="0.254" layer="42"/>
 </plain>
 <libraries>
 <library name="SparkFun-Aesthetics">
@@ -4456,16 +4462,6 @@ These rules have been curated by SparkFuns DFM commitee. After doing much resear
 <wire x1="24.892" y1="60.579" x2="18.034" y2="60.579" width="0.254" layer="1"/>
 <wire x1="18.034" y1="60.579" x2="17.145" y2="59.69" width="0.254" layer="1"/>
 </signal>
-<signal name="N$2">
-<wire x1="23.114" y1="60.452" x2="22.606" y2="60.96" width="0.2794" layer="16"/>
-<wire x1="22.606" y1="60.96" x2="20.574" y2="60.96" width="0.2794" layer="16"/>
-<wire x1="20.574" y1="60.96" x2="20.066" y2="60.452" width="0.2794" layer="16"/>
-</signal>
-<signal name="N$9">
-<wire x1="20.066" y1="58.928" x2="20.574" y2="58.42" width="0.2794" layer="16"/>
-<wire x1="20.574" y1="58.42" x2="22.606" y2="58.42" width="0.2794" layer="16"/>
-<wire x1="22.606" y1="58.42" x2="23.114" y2="58.928" width="0.2794" layer="16"/>
-</signal>
 <signal name="A0">
 <contactref element="JP10" pad="6"/>
 <contactref element="JP8" pad="A0"/>
@@ -4588,8 +4584,8 @@ These rules have been curated by SparkFuns DFM commitee. After doing much resear
 <approved hash="19,16,e642ea60ec31e013"/>
 <approved hash="19,16,fc4242605dd1e3f3"/>
 <approved hash="19,16,e5c25be05db1e393"/>
-<approved hash="19,16,c77904b318493935"/>
 <approved hash="19,16,ca641a7707cd3448"/>
+<approved hash="19,16,c77904b318493935"/>
 <approved hash="19,16,ea45a867b7d4f5f6"/>
 <approved hash="19,16,a9b34724023e0f3f"/>
 <approved hash="19,16,e042fe60e1d3fff1"/>

--- a/Hardware/SparkFun_ProtoShield_Kit_rev31.sch
+++ b/Hardware/SparkFun_ProtoShield_Kit_rev31.sch
@@ -22848,165 +22848,165 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <text x="170.942" y="11.43" size="2.54" layer="94" font="vector">Nathan Seidle</text>
 <text x="238.76" y="7.62" size="2.54" layer="94" font="vector">v31</text>
 <text x="170.688" y="7.62" size="1.778" layer="94" font="vector" ratio="7">Toni Klopfenstein &amp; Ho Yun "Bobby" Chan</text>
-<wire x1="0" y1="50.8" x2="73.66" y2="50.8" width="0.1524" layer="97" style="shortdash"/>
-<wire x1="73.66" y1="50.8" x2="73.66" y2="0" width="0.1524" layer="97" style="shortdash"/>
-<wire x1="73.66" y1="50.8" x2="116.84" y2="50.8" width="0.1524" layer="97" style="shortdash"/>
-<wire x1="116.84" y1="50.8" x2="116.84" y2="0" width="0.1524" layer="97" style="shortdash"/>
-<wire x1="175.26" y1="185.42" x2="172.72" y2="185.42" width="0.1524" layer="97" style="longdash"/>
-<wire x1="172.72" y1="185.42" x2="172.72" y2="35.56" width="0.1524" layer="97" style="shortdash"/>
-<wire x1="114.3" y1="185.42" x2="116.84" y2="185.42" width="0.1524" layer="97" style="longdash"/>
-<wire x1="116.84" y1="185.42" x2="116.84" y2="50.8" width="0.1524" layer="97" style="shortdash"/>
+<wire x1="172.72" y1="185.42" x2="172.72" y2="68.58" width="0.1524" layer="97" style="shortdash"/>
 <text x="43.18" y="175.26" size="2.032" layer="97" font="vector" ratio="15">Arduino Shield</text>
 <text x="121.92" y="175.26" size="2.032" layer="97" font="vector" ratio="15">Arduino Headers Connections</text>
 <text x="195.58" y="175.26" size="2.032" layer="97" font="vector" ratio="15">Prototyping Hardware</text>
-<text x="78.74" y="43.18" size="2.032" layer="97" font="vector" ratio="15">Breadboard Footprint</text>
-<text x="20.32" y="43.18" size="2.032" layer="97" font="vector" ratio="15">BlueSMiRF Footprint</text>
-<text x="27.94" y="2.54" size="1.778" layer="97" font="vector">Note: Disable jumpers 1-4 to 
+<text x="101.6" y="58.42" size="2.032" layer="97" font="vector" ratio="15">Breadboard Footprint</text>
+<text x="25.4" y="58.42" size="2.032" layer="97" font="vector" ratio="15">BlueSMiRF Footprint</text>
+<text x="40.64" y="10.16" size="1.778" layer="97" font="vector">Note: Disable jumpers 1-4 to 
 create customizable 
 6-pin header for prototyping.</text>
-<text x="43.18" y="111.76" size="1.651" layer="95" font="vector">Arduino_R3_Shield</text>
-<text x="17.78" y="76.2" size="1.778" layer="95" font="vector" rot="R90">Reset</text>
-<text x="27.94" y="165.1" size="1.778" layer="95" font="vector">A0</text>
-<text x="27.94" y="162.56" size="1.778" layer="95" font="vector">A1</text>
-<text x="27.94" y="160.02" size="1.778" layer="95" font="vector">A2</text>
-<text x="27.94" y="157.48" size="1.778" layer="95" font="vector">A3</text>
-<text x="27.94" y="152.4" size="1.778" layer="95" font="vector">A5</text>
-<text x="27.94" y="154.94" size="1.778" layer="95" font="vector">A4</text>
+<text x="43.18" y="116.84" size="1.651" layer="95" font="vector">Arduino_R3_Shield</text>
+<text x="17.78" y="88.9" size="1.778" layer="95" font="vector" rot="R90">Reset</text>
+<text x="27.94" y="170.18" size="1.778" layer="95" font="vector">A0</text>
+<text x="27.94" y="167.64" size="1.778" layer="95" font="vector">A1</text>
+<text x="27.94" y="165.1" size="1.778" layer="95" font="vector">A2</text>
+<text x="27.94" y="162.56" size="1.778" layer="95" font="vector">A3</text>
+<text x="27.94" y="157.48" size="1.778" layer="95" font="vector">A5</text>
+<text x="27.94" y="160.02" size="1.778" layer="95" font="vector">A4</text>
+<wire x1="0" y1="68.58" x2="91.44" y2="68.58" width="0.1524" layer="95" style="shortdash"/>
+<wire x1="91.44" y1="68.58" x2="114.3" y2="68.58" width="0.1524" layer="95" style="shortdash"/>
+<wire x1="114.3" y1="68.58" x2="147.32" y2="68.58" width="0.1524" layer="95" style="shortdash"/>
+<wire x1="147.32" y1="68.58" x2="248.92" y2="68.58" width="0.1524" layer="95" style="shortdash"/>
+<wire x1="147.32" y1="35.56" x2="147.32" y2="68.58" width="0.1524" layer="95" style="shortdash"/>
+<wire x1="91.44" y1="68.58" x2="91.44" y2="0" width="0.1524" layer="95" style="shortdash"/>
+<wire x1="114.3" y1="185.42" x2="114.3" y2="68.58" width="0.1524" layer="95" style="shortdash"/>
 </plain>
 <instances>
-<instance part="ICSP" gate="G$1" x="78.74" y="73.66"/>
-<instance part="R1" gate="G$1" x="226.06" y="109.22" rot="R90"/>
-<instance part="R2" gate="G$1" x="238.76" y="109.22" rot="R90"/>
-<instance part="LED1" gate="G$1" x="226.06" y="121.92"/>
-<instance part="LED2" gate="G$1" x="238.76" y="121.92"/>
-<instance part="GND2" gate="1" x="238.76" y="99.06"/>
-<instance part="GND3" gate="1" x="226.06" y="99.06"/>
-<instance part="JP4" gate="G$1" x="226.06" y="134.62" rot="R270"/>
-<instance part="JP9" gate="G$1" x="238.76" y="134.62" rot="R270"/>
-<instance part="JP12" gate="G$1" x="96.52" y="149.86" rot="R180"/>
-<instance part="JP10" gate="G$1" x="22.86" y="157.48"/>
+<instance part="ICSP" gate="G$1" x="78.74" y="86.36"/>
+<instance part="R1" gate="G$1" x="220.98" y="111.76" rot="R90"/>
+<instance part="R2" gate="G$1" x="233.68" y="111.76" rot="R90"/>
+<instance part="LED1" gate="G$1" x="220.98" y="124.46"/>
+<instance part="LED2" gate="G$1" x="233.68" y="124.46"/>
+<instance part="GND2" gate="1" x="233.68" y="101.6"/>
+<instance part="GND3" gate="1" x="220.98" y="101.6"/>
+<instance part="JP4" gate="G$1" x="220.98" y="137.16" rot="R270"/>
+<instance part="JP9" gate="G$1" x="233.68" y="137.16" rot="R270"/>
+<instance part="JP12" gate="G$1" x="96.52" y="154.94" rot="R180"/>
+<instance part="JP10" gate="G$1" x="22.86" y="162.56"/>
 <instance part="FRAME1" gate="G$1" x="0" y="0"/>
 <instance part="FRAME1" gate="V" x="147.32" y="0"/>
-<instance part="GND1" gate="1" x="20.32" y="63.5"/>
-<instance part="5V_RAIL" gate="G$1" x="127" y="116.84"/>
-<instance part="GND_RAIL" gate="G$1" x="149.86" y="116.84"/>
-<instance part="P+2" gate="G$1" x="139.7" y="144.78"/>
-<instance part="GND4" gate="1" x="162.56" y="86.36"/>
-<instance part="BB1" gate="G$1" x="93.98" y="27.94"/>
-<instance part="R4" gate="G$1" x="198.12" y="127" rot="R90"/>
-<instance part="GND5" gate="1" x="198.12" y="99.06"/>
-<instance part="JP3" gate="G$1" x="210.82" y="116.84" rot="R180"/>
+<instance part="GND1" gate="1" x="20.32" y="78.74"/>
+<instance part="5V_RAIL" gate="G$1" x="124.46" y="121.92"/>
+<instance part="GND_RAIL" gate="G$1" x="147.32" y="121.92"/>
+<instance part="P+2" gate="G$1" x="137.16" y="149.86"/>
+<instance part="GND4" gate="1" x="160.02" y="91.44"/>
+<instance part="BB1" gate="G$1" x="116.84" y="38.1"/>
+<instance part="R4" gate="G$1" x="193.04" y="129.54" rot="R90"/>
+<instance part="GND5" gate="1" x="193.04" y="101.6"/>
+<instance part="JP3" gate="G$1" x="205.74" y="119.38" rot="R180"/>
 <instance part="U$1" gate="G$1" x="190.5" y="35.56"/>
-<instance part="JP7" gate="G$1" x="30.48" y="27.94"/>
-<instance part="P+1" gate="G$1" x="198.12" y="134.62"/>
+<instance part="JP7" gate="G$1" x="43.18" y="38.1"/>
+<instance part="P+1" gate="G$1" x="193.04" y="137.16"/>
 <instance part="U$2" gate="G$1" x="148.844" y="7.112"/>
-<instance part="JP8" gate="G$1" x="55.88" y="139.7" smashed="yes">
-<attribute name="NAME" x="46.228" y="160.782" size="1.778" layer="95" font="vector"/>
+<instance part="JP8" gate="G$1" x="55.88" y="144.78" smashed="yes">
+<attribute name="NAME" x="46.228" y="165.862" size="1.778" layer="95" font="vector"/>
 </instance>
-<instance part="JP11" gate="G$1" x="12.7" y="124.46"/>
-<instance part="JP1" gate="G$1" x="101.6" y="111.76" rot="R180"/>
-<instance part="S2" gate="G$1" x="198.12" y="109.22" smashed="yes" rot="R90">
-<attribute name="NAME" x="195.58" y="106.68" size="1.778" layer="95" font="vector" rot="R90"/>
+<instance part="JP11" gate="G$1" x="12.7" y="129.54"/>
+<instance part="JP1" gate="G$1" x="101.6" y="116.84" rot="R180"/>
+<instance part="S2" gate="G$1" x="193.04" y="111.76" smashed="yes" rot="R90">
+<attribute name="NAME" x="190.5" y="109.22" size="1.778" layer="95" font="vector" rot="R90"/>
 </instance>
-<instance part="S4" gate="G$1" x="20.32" y="78.74" smashed="yes" rot="R90">
-<attribute name="NAME" x="25.4" y="76.2" size="1.778" layer="95" font="vector" rot="R90"/>
+<instance part="S4" gate="G$1" x="20.32" y="91.44" smashed="yes" rot="R90">
+<attribute name="NAME" x="25.4" y="88.9" size="1.778" layer="95" font="vector" rot="R90"/>
 </instance>
-<instance part="GND8" gate="1" x="40.64" y="109.22"/>
-<instance part="GND9" gate="1" x="86.36" y="101.6"/>
-<instance part="GND10" gate="1" x="96.52" y="66.04"/>
-<instance part="P+5" gate="G$1" x="96.52" y="81.28"/>
-<instance part="SJ1" gate="G$1" x="45.72" y="33.02" smashed="yes">
-<attribute name="NAME" x="48.26" y="33.02" size="1.778" layer="95" font="vector"/>
+<instance part="GND8" gate="1" x="40.64" y="114.3"/>
+<instance part="GND9" gate="1" x="86.36" y="106.68"/>
+<instance part="GND10" gate="1" x="96.52" y="78.74"/>
+<instance part="P+5" gate="G$1" x="96.52" y="93.98"/>
+<instance part="SJ1" gate="G$1" x="58.42" y="43.18" smashed="yes">
+<attribute name="NAME" x="60.96" y="43.18" size="1.778" layer="95" font="vector"/>
 </instance>
-<instance part="SJ2" gate="G$1" x="53.34" y="30.48" smashed="yes">
-<attribute name="NAME" x="55.88" y="30.48" size="1.778" layer="95" font="vector"/>
+<instance part="SJ2" gate="G$1" x="66.04" y="40.64" smashed="yes">
+<attribute name="NAME" x="68.58" y="40.64" size="1.778" layer="95" font="vector"/>
 </instance>
-<instance part="SJ3" gate="G$1" x="43.18" y="27.94" smashed="yes">
-<attribute name="NAME" x="45.72" y="27.94" size="1.778" layer="95" font="vector"/>
+<instance part="SJ3" gate="G$1" x="55.88" y="38.1" smashed="yes">
+<attribute name="NAME" x="58.42" y="38.1" size="1.778" layer="95" font="vector"/>
 </instance>
-<instance part="SJ4" gate="G$1" x="48.26" y="25.4" smashed="yes">
-<attribute name="NAME" x="50.8" y="25.4" size="1.778" layer="95" font="vector"/>
+<instance part="SJ4" gate="G$1" x="60.96" y="35.56" smashed="yes">
+<attribute name="NAME" x="63.5" y="35.56" size="1.778" layer="95" font="vector"/>
 </instance>
-<instance part="LOGO1" gate="G$1" x="233.68" y="73.66"/>
-<instance part="JP2" gate="G$1" x="20.32" y="27.94" rot="MR0"/>
-<instance part="P+3" gate="G$1" x="68.58" y="33.02"/>
-<instance part="GND6" gate="1" x="58.42" y="15.24"/>
-<instance part="GND7" gate="1" x="5.08" y="15.24"/>
-<instance part="P+4" gate="G$1" x="33.02" y="139.7"/>
+<instance part="LOGO1" gate="G$1" x="172.72" y="48.26"/>
+<instance part="JP2" gate="G$1" x="33.02" y="38.1" rot="MR0"/>
+<instance part="P+3" gate="G$1" x="81.28" y="43.18"/>
+<instance part="GND6" gate="1" x="71.12" y="25.4"/>
+<instance part="GND7" gate="1" x="12.7" y="25.4"/>
+<instance part="P+4" gate="G$1" x="33.02" y="144.78"/>
 </instances>
 <busses>
 </busses>
 <nets>
 <net name="GND" class="1">
 <segment>
-<wire x1="238.76" y1="101.6" x2="238.76" y2="104.14" width="0.1524" layer="91"/>
+<wire x1="233.68" y1="104.14" x2="233.68" y2="106.68" width="0.1524" layer="91"/>
 <pinref part="R2" gate="G$1" pin="1"/>
 <pinref part="GND2" gate="1" pin="GND"/>
 </segment>
 <segment>
-<wire x1="226.06" y1="101.6" x2="226.06" y2="104.14" width="0.1524" layer="91"/>
+<wire x1="220.98" y1="104.14" x2="220.98" y2="106.68" width="0.1524" layer="91"/>
 <pinref part="R1" gate="G$1" pin="1"/>
 <pinref part="GND3" gate="1" pin="GND"/>
 </segment>
 <segment>
-<wire x1="91.44" y1="114.3" x2="86.36" y2="114.3" width="0.1524" layer="91"/>
+<wire x1="91.44" y1="119.38" x2="86.36" y2="119.38" width="0.1524" layer="91"/>
 <pinref part="JP1" gate="G$1" pin="7"/>
 <pinref part="GND9" gate="1" pin="GND"/>
-<wire x1="86.36" y1="104.14" x2="86.36" y2="114.3" width="0.1524" layer="91"/>
+<wire x1="86.36" y1="109.22" x2="86.36" y2="119.38" width="0.1524" layer="91"/>
 </segment>
 <segment>
-<wire x1="20.32" y1="73.66" x2="20.32" y2="66.04" width="0.1524" layer="91"/>
+<wire x1="20.32" y1="86.36" x2="20.32" y2="81.28" width="0.1524" layer="91"/>
 <pinref part="GND1" gate="1" pin="GND"/>
 <pinref part="S4" gate="G$1" pin="1"/>
 </segment>
 <segment>
-<wire x1="160.02" y1="132.08" x2="162.56" y2="132.08" width="0.1524" layer="91"/>
-<wire x1="162.56" y1="132.08" x2="162.56" y2="129.54" width="0.1524" layer="91"/>
-<wire x1="162.56" y1="129.54" x2="162.56" y2="127" width="0.1524" layer="91"/>
-<wire x1="162.56" y1="127" x2="162.56" y2="124.46" width="0.1524" layer="91"/>
-<wire x1="162.56" y1="124.46" x2="162.56" y2="121.92" width="0.1524" layer="91"/>
-<wire x1="162.56" y1="121.92" x2="162.56" y2="119.38" width="0.1524" layer="91"/>
-<wire x1="162.56" y1="119.38" x2="162.56" y2="116.84" width="0.1524" layer="91"/>
-<wire x1="162.56" y1="116.84" x2="162.56" y2="114.3" width="0.1524" layer="91"/>
-<wire x1="162.56" y1="114.3" x2="162.56" y2="111.76" width="0.1524" layer="91"/>
-<wire x1="162.56" y1="111.76" x2="162.56" y2="109.22" width="0.1524" layer="91"/>
-<wire x1="162.56" y1="109.22" x2="162.56" y2="106.68" width="0.1524" layer="91"/>
-<wire x1="162.56" y1="106.68" x2="162.56" y2="104.14" width="0.1524" layer="91"/>
-<wire x1="162.56" y1="104.14" x2="162.56" y2="101.6" width="0.1524" layer="91"/>
-<wire x1="162.56" y1="101.6" x2="162.56" y2="99.06" width="0.1524" layer="91"/>
-<wire x1="162.56" y1="99.06" x2="162.56" y2="96.52" width="0.1524" layer="91"/>
-<wire x1="162.56" y1="96.52" x2="162.56" y2="93.98" width="0.1524" layer="91"/>
-<wire x1="162.56" y1="93.98" x2="162.56" y2="88.9" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="93.98" x2="162.56" y2="93.98" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="96.52" x2="162.56" y2="96.52" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="99.06" x2="162.56" y2="99.06" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="101.6" x2="162.56" y2="101.6" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="104.14" x2="162.56" y2="104.14" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="106.68" x2="162.56" y2="106.68" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="109.22" x2="162.56" y2="109.22" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="111.76" x2="162.56" y2="111.76" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="114.3" x2="162.56" y2="114.3" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="116.84" x2="162.56" y2="116.84" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="119.38" x2="162.56" y2="119.38" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="121.92" x2="162.56" y2="121.92" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="124.46" x2="162.56" y2="124.46" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="127" x2="162.56" y2="127" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="129.54" x2="162.56" y2="129.54" width="0.1524" layer="91"/>
-<junction x="162.56" y="93.98"/>
-<junction x="162.56" y="96.52"/>
-<junction x="162.56" y="99.06"/>
-<junction x="162.56" y="101.6"/>
-<junction x="162.56" y="104.14"/>
-<junction x="162.56" y="106.68"/>
-<junction x="162.56" y="109.22"/>
-<junction x="162.56" y="111.76"/>
-<junction x="162.56" y="114.3"/>
-<junction x="162.56" y="116.84"/>
-<junction x="162.56" y="119.38"/>
-<junction x="162.56" y="121.92"/>
-<junction x="162.56" y="124.46"/>
-<junction x="162.56" y="127"/>
-<junction x="162.56" y="129.54"/>
+<wire x1="157.48" y1="137.16" x2="160.02" y2="137.16" width="0.1524" layer="91"/>
+<wire x1="160.02" y1="137.16" x2="160.02" y2="134.62" width="0.1524" layer="91"/>
+<wire x1="160.02" y1="134.62" x2="160.02" y2="132.08" width="0.1524" layer="91"/>
+<wire x1="160.02" y1="132.08" x2="160.02" y2="129.54" width="0.1524" layer="91"/>
+<wire x1="160.02" y1="129.54" x2="160.02" y2="127" width="0.1524" layer="91"/>
+<wire x1="160.02" y1="127" x2="160.02" y2="124.46" width="0.1524" layer="91"/>
+<wire x1="160.02" y1="124.46" x2="160.02" y2="121.92" width="0.1524" layer="91"/>
+<wire x1="160.02" y1="121.92" x2="160.02" y2="119.38" width="0.1524" layer="91"/>
+<wire x1="160.02" y1="119.38" x2="160.02" y2="116.84" width="0.1524" layer="91"/>
+<wire x1="160.02" y1="116.84" x2="160.02" y2="114.3" width="0.1524" layer="91"/>
+<wire x1="160.02" y1="114.3" x2="160.02" y2="111.76" width="0.1524" layer="91"/>
+<wire x1="160.02" y1="111.76" x2="160.02" y2="109.22" width="0.1524" layer="91"/>
+<wire x1="160.02" y1="109.22" x2="160.02" y2="106.68" width="0.1524" layer="91"/>
+<wire x1="160.02" y1="106.68" x2="160.02" y2="104.14" width="0.1524" layer="91"/>
+<wire x1="160.02" y1="104.14" x2="160.02" y2="101.6" width="0.1524" layer="91"/>
+<wire x1="160.02" y1="101.6" x2="160.02" y2="99.06" width="0.1524" layer="91"/>
+<wire x1="160.02" y1="99.06" x2="160.02" y2="93.98" width="0.1524" layer="91"/>
+<wire x1="157.48" y1="99.06" x2="160.02" y2="99.06" width="0.1524" layer="91"/>
+<wire x1="157.48" y1="101.6" x2="160.02" y2="101.6" width="0.1524" layer="91"/>
+<wire x1="157.48" y1="104.14" x2="160.02" y2="104.14" width="0.1524" layer="91"/>
+<wire x1="157.48" y1="106.68" x2="160.02" y2="106.68" width="0.1524" layer="91"/>
+<wire x1="157.48" y1="109.22" x2="160.02" y2="109.22" width="0.1524" layer="91"/>
+<wire x1="157.48" y1="111.76" x2="160.02" y2="111.76" width="0.1524" layer="91"/>
+<wire x1="157.48" y1="114.3" x2="160.02" y2="114.3" width="0.1524" layer="91"/>
+<wire x1="157.48" y1="116.84" x2="160.02" y2="116.84" width="0.1524" layer="91"/>
+<wire x1="157.48" y1="119.38" x2="160.02" y2="119.38" width="0.1524" layer="91"/>
+<wire x1="157.48" y1="121.92" x2="160.02" y2="121.92" width="0.1524" layer="91"/>
+<wire x1="157.48" y1="124.46" x2="160.02" y2="124.46" width="0.1524" layer="91"/>
+<wire x1="157.48" y1="127" x2="160.02" y2="127" width="0.1524" layer="91"/>
+<wire x1="157.48" y1="129.54" x2="160.02" y2="129.54" width="0.1524" layer="91"/>
+<wire x1="157.48" y1="132.08" x2="160.02" y2="132.08" width="0.1524" layer="91"/>
+<wire x1="157.48" y1="134.62" x2="160.02" y2="134.62" width="0.1524" layer="91"/>
+<junction x="160.02" y="99.06"/>
+<junction x="160.02" y="101.6"/>
+<junction x="160.02" y="104.14"/>
+<junction x="160.02" y="106.68"/>
+<junction x="160.02" y="109.22"/>
+<junction x="160.02" y="111.76"/>
+<junction x="160.02" y="114.3"/>
+<junction x="160.02" y="116.84"/>
+<junction x="160.02" y="119.38"/>
+<junction x="160.02" y="121.92"/>
+<junction x="160.02" y="124.46"/>
+<junction x="160.02" y="127"/>
+<junction x="160.02" y="129.54"/>
+<junction x="160.02" y="132.08"/>
+<junction x="160.02" y="134.62"/>
 <pinref part="GND_RAIL" gate="G$1" pin="16"/>
 <pinref part="GND_RAIL" gate="G$1" pin="1"/>
 <pinref part="GND_RAIL" gate="G$1" pin="2"/>
@@ -23025,330 +23025,330 @@ create customizable
 <pinref part="GND_RAIL" gate="G$1" pin="15"/>
 <pinref part="GND4" gate="1" pin="GND"/>
 <pinref part="GND_RAIL" gate="G$1" pin="17"/>
-<wire x1="160.02" y1="134.62" x2="162.56" y2="134.62" width="0.1524" layer="91"/>
-<wire x1="162.56" y1="134.62" x2="162.56" y2="132.08" width="0.1524" layer="91"/>
-<junction x="162.56" y="132.08"/>
+<wire x1="157.48" y1="139.7" x2="160.02" y2="139.7" width="0.1524" layer="91"/>
+<wire x1="160.02" y1="139.7" x2="160.02" y2="137.16" width="0.1524" layer="91"/>
+<junction x="160.02" y="137.16"/>
 <pinref part="GND_RAIL" gate="G$1" pin="18"/>
-<wire x1="160.02" y1="137.16" x2="162.56" y2="137.16" width="0.1524" layer="91"/>
-<wire x1="162.56" y1="137.16" x2="162.56" y2="134.62" width="0.1524" layer="91"/>
-<junction x="162.56" y="134.62"/>
+<wire x1="157.48" y1="142.24" x2="160.02" y2="142.24" width="0.1524" layer="91"/>
+<wire x1="160.02" y1="142.24" x2="160.02" y2="139.7" width="0.1524" layer="91"/>
+<junction x="160.02" y="139.7"/>
 <pinref part="GND_RAIL" gate="G$1" pin="19"/>
-<wire x1="160.02" y1="139.7" x2="162.56" y2="139.7" width="0.1524" layer="91"/>
-<wire x1="162.56" y1="139.7" x2="162.56" y2="137.16" width="0.1524" layer="91"/>
-<junction x="162.56" y="137.16"/>
+<wire x1="157.48" y1="144.78" x2="160.02" y2="144.78" width="0.1524" layer="91"/>
+<wire x1="160.02" y1="144.78" x2="160.02" y2="142.24" width="0.1524" layer="91"/>
+<junction x="160.02" y="142.24"/>
 </segment>
 <segment>
-<wire x1="198.12" y1="104.14" x2="198.12" y2="101.6" width="0.1524" layer="91"/>
+<wire x1="193.04" y1="106.68" x2="193.04" y2="104.14" width="0.1524" layer="91"/>
 <pinref part="GND5" gate="1" pin="GND"/>
 <pinref part="S2" gate="G$1" pin="1"/>
 </segment>
 <segment>
-<wire x1="88.9" y1="71.12" x2="96.52" y2="71.12" width="0.1524" layer="91"/>
+<wire x1="88.9" y1="83.82" x2="96.52" y2="83.82" width="0.1524" layer="91"/>
 <pinref part="ICSP" gate="G$1" pin="6"/>
 <pinref part="GND10" gate="1" pin="GND"/>
-<wire x1="96.52" y1="71.12" x2="96.52" y2="68.58" width="0.1524" layer="91"/>
+<wire x1="96.52" y1="83.82" x2="96.52" y2="81.28" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="JP8" gate="G$1" pin="GND@0"/>
-<wire x1="43.18" y1="116.84" x2="40.64" y2="116.84" width="0.1524" layer="91"/>
-<wire x1="40.64" y1="116.84" x2="40.64" y2="114.3" width="0.1524" layer="91"/>
+<wire x1="43.18" y1="121.92" x2="40.64" y2="121.92" width="0.1524" layer="91"/>
+<wire x1="40.64" y1="121.92" x2="40.64" y2="119.38" width="0.1524" layer="91"/>
 <pinref part="GND8" gate="1" pin="GND"/>
 <pinref part="JP8" gate="G$1" pin="GND@1"/>
-<wire x1="40.64" y1="114.3" x2="40.64" y2="111.76" width="0.1524" layer="91"/>
-<wire x1="43.18" y1="119.38" x2="40.64" y2="119.38" width="0.1524" layer="91"/>
 <wire x1="40.64" y1="119.38" x2="40.64" y2="116.84" width="0.1524" layer="91"/>
-<junction x="40.64" y="116.84"/>
+<wire x1="43.18" y1="124.46" x2="40.64" y2="124.46" width="0.1524" layer="91"/>
+<wire x1="40.64" y1="124.46" x2="40.64" y2="121.92" width="0.1524" layer="91"/>
+<junction x="40.64" y="121.92"/>
 <pinref part="JP11" gate="G$1" pin="3"/>
 <pinref part="JP8" gate="G$1" pin="GND@2"/>
-<wire x1="17.78" y1="121.92" x2="40.64" y2="121.92" width="0.1524" layer="91"/>
-<wire x1="40.64" y1="121.92" x2="43.18" y2="121.92" width="0.1524" layer="91"/>
-<wire x1="40.64" y1="121.92" x2="40.64" y2="119.38" width="0.1524" layer="91"/>
-<junction x="40.64" y="121.92"/>
-<junction x="40.64" y="119.38"/>
+<wire x1="17.78" y1="127" x2="40.64" y2="127" width="0.1524" layer="91"/>
+<wire x1="40.64" y1="127" x2="43.18" y2="127" width="0.1524" layer="91"/>
+<wire x1="40.64" y1="127" x2="40.64" y2="124.46" width="0.1524" layer="91"/>
+<junction x="40.64" y="127"/>
+<junction x="40.64" y="124.46"/>
 <pinref part="JP11" gate="G$1" pin="2"/>
-<wire x1="17.78" y1="119.38" x2="35.56" y2="119.38" width="0.1524" layer="91"/>
-<wire x1="35.56" y1="119.38" x2="35.56" y2="114.3" width="0.1524" layer="91"/>
-<wire x1="35.56" y1="114.3" x2="40.64" y2="114.3" width="0.1524" layer="91"/>
-<junction x="40.64" y="114.3"/>
+<wire x1="17.78" y1="124.46" x2="35.56" y2="124.46" width="0.1524" layer="91"/>
+<wire x1="35.56" y1="124.46" x2="35.56" y2="119.38" width="0.1524" layer="91"/>
+<wire x1="35.56" y1="119.38" x2="40.64" y2="119.38" width="0.1524" layer="91"/>
+<junction x="40.64" y="119.38"/>
 </segment>
 <segment>
 <pinref part="SJ3" gate="G$1" pin="2"/>
-<wire x1="48.26" y1="27.94" x2="58.42" y2="27.94" width="0.1524" layer="91"/>
+<wire x1="60.96" y1="38.1" x2="71.12" y2="38.1" width="0.1524" layer="91"/>
 <pinref part="GND6" gate="1" pin="GND"/>
-<wire x1="58.42" y1="27.94" x2="58.42" y2="17.78" width="0.1524" layer="91"/>
+<wire x1="71.12" y1="38.1" x2="71.12" y2="27.94" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="JP7" gate="G$1" pin="3"/>
 <pinref part="SJ3" gate="G$1" pin="1"/>
-<wire x1="35.56" y1="27.94" x2="38.1" y2="27.94" width="0.1524" layer="91"/>
+<wire x1="48.26" y1="38.1" x2="50.8" y2="38.1" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="JP2" gate="G$1" pin="3"/>
 <pinref part="GND7" gate="1" pin="GND"/>
-<wire x1="15.24" y1="27.94" x2="5.08" y2="27.94" width="0.1524" layer="91"/>
-<wire x1="5.08" y1="27.94" x2="5.08" y2="17.78" width="0.1524" layer="91"/>
+<wire x1="27.94" y1="38.1" x2="12.7" y2="38.1" width="0.1524" layer="91"/>
+<wire x1="12.7" y1="38.1" x2="12.7" y2="27.94" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$6" class="0">
 <segment>
-<wire x1="226.06" y1="116.84" x2="226.06" y2="114.3" width="0.1524" layer="91"/>
+<wire x1="220.98" y1="119.38" x2="220.98" y2="116.84" width="0.1524" layer="91"/>
 <pinref part="R1" gate="G$1" pin="2"/>
 <pinref part="LED1" gate="G$1" pin="C"/>
 </segment>
 </net>
 <net name="N$7" class="0">
 <segment>
-<wire x1="238.76" y1="116.84" x2="238.76" y2="114.3" width="0.1524" layer="91"/>
+<wire x1="233.68" y1="119.38" x2="233.68" y2="116.84" width="0.1524" layer="91"/>
 <pinref part="R2" gate="G$1" pin="2"/>
 <pinref part="LED2" gate="G$1" pin="C"/>
 </segment>
 </net>
 <net name="LED1" class="0">
 <segment>
-<wire x1="226.06" y1="127" x2="226.06" y2="124.46" width="0.1524" layer="91"/>
+<wire x1="220.98" y1="129.54" x2="220.98" y2="127" width="0.1524" layer="91"/>
 <pinref part="LED1" gate="G$1" pin="A"/>
 <pinref part="JP4" gate="G$1" pin="1"/>
 </segment>
 </net>
 <net name="LED2" class="0">
 <segment>
-<wire x1="238.76" y1="127" x2="238.76" y2="124.46" width="0.1524" layer="91"/>
+<wire x1="233.68" y1="129.54" x2="233.68" y2="127" width="0.1524" layer="91"/>
 <pinref part="LED2" gate="G$1" pin="A"/>
 <pinref part="JP9" gate="G$1" pin="1"/>
 </segment>
 </net>
 <net name="RX" class="0">
 <segment>
-<wire x1="91.44" y1="157.48" x2="68.58" y2="157.48" width="0.1524" layer="91"/>
-<label x="88.9" y="157.48" size="1.778" layer="95" font="vector" rot="MR0"/>
+<wire x1="91.44" y1="162.56" x2="68.58" y2="162.56" width="0.1524" layer="91"/>
+<label x="88.9" y="162.56" size="1.778" layer="95" font="vector" rot="MR0"/>
 <pinref part="JP12" gate="G$1" pin="1"/>
 <pinref part="JP8" gate="G$1" pin="RX"/>
 </segment>
 <segment>
 <pinref part="SJ2" gate="G$1" pin="2"/>
-<wire x1="58.42" y1="30.48" x2="60.96" y2="30.48" width="0.1524" layer="91"/>
-<label x="60.96" y="30.48" size="1.27" layer="95" font="vector" xref="yes"/>
+<wire x1="71.12" y1="40.64" x2="73.66" y2="40.64" width="0.1524" layer="91"/>
+<label x="73.66" y="40.64" size="1.27" layer="95" font="vector" xref="yes"/>
 </segment>
 </net>
 <net name="TX" class="0">
 <segment>
-<label x="88.9" y="154.94" size="1.778" layer="95" font="vector" rot="MR0"/>
+<label x="88.9" y="160.02" size="1.778" layer="95" font="vector" rot="MR0"/>
 <pinref part="JP12" gate="G$1" pin="2"/>
 <pinref part="JP8" gate="G$1" pin="TX"/>
-<wire x1="68.58" y1="154.94" x2="91.44" y2="154.94" width="0.1524" layer="91"/>
+<wire x1="68.58" y1="160.02" x2="91.44" y2="160.02" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="SJ1" gate="G$1" pin="2"/>
-<wire x1="50.8" y1="33.02" x2="60.96" y2="33.02" width="0.1524" layer="91"/>
-<label x="60.96" y="33.02" size="1.27" layer="95" font="vector" xref="yes"/>
+<wire x1="63.5" y1="43.18" x2="73.66" y2="43.18" width="0.1524" layer="91"/>
+<label x="73.66" y="43.18" size="1.27" layer="95" font="vector" xref="yes"/>
 </segment>
 </net>
 <net name="D2" class="0">
 <segment>
-<wire x1="91.44" y1="152.4" x2="71.12" y2="152.4" width="0.1524" layer="91"/>
-<label x="88.9" y="152.4" size="1.778" layer="95" font="vector" rot="MR0"/>
+<wire x1="91.44" y1="157.48" x2="71.12" y2="157.48" width="0.1524" layer="91"/>
+<label x="88.9" y="157.48" size="1.778" layer="95" font="vector" rot="MR0"/>
 <pinref part="JP12" gate="G$1" pin="3"/>
 <pinref part="JP8" gate="G$1" pin="D2"/>
-<wire x1="68.58" y1="149.86" x2="71.12" y2="149.86" width="0.1524" layer="91"/>
-<wire x1="71.12" y1="149.86" x2="71.12" y2="152.4" width="0.1524" layer="91"/>
+<wire x1="68.58" y1="154.94" x2="71.12" y2="154.94" width="0.1524" layer="91"/>
+<wire x1="71.12" y1="154.94" x2="71.12" y2="157.48" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="D3" class="0">
 <segment>
-<wire x1="73.66" y1="149.86" x2="91.44" y2="149.86" width="0.1524" layer="91"/>
-<label x="88.9" y="149.86" size="1.778" layer="95" font="vector" rot="MR0"/>
+<wire x1="73.66" y1="154.94" x2="91.44" y2="154.94" width="0.1524" layer="91"/>
+<label x="88.9" y="154.94" size="1.778" layer="95" font="vector" rot="MR0"/>
 <pinref part="JP12" gate="G$1" pin="4"/>
 <pinref part="JP8" gate="G$1" pin="*D3"/>
-<wire x1="68.58" y1="147.32" x2="73.66" y2="147.32" width="0.1524" layer="91"/>
-<wire x1="73.66" y1="147.32" x2="73.66" y2="149.86" width="0.1524" layer="91"/>
+<wire x1="68.58" y1="152.4" x2="73.66" y2="152.4" width="0.1524" layer="91"/>
+<wire x1="73.66" y1="152.4" x2="73.66" y2="154.94" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="D4" class="0">
 <segment>
-<wire x1="91.44" y1="147.32" x2="76.2" y2="147.32" width="0.1524" layer="91"/>
-<label x="88.9" y="147.32" size="1.778" layer="95" font="vector" rot="MR0"/>
+<wire x1="91.44" y1="152.4" x2="76.2" y2="152.4" width="0.1524" layer="91"/>
+<label x="88.9" y="152.4" size="1.778" layer="95" font="vector" rot="MR0"/>
 <pinref part="JP12" gate="G$1" pin="5"/>
 <pinref part="JP8" gate="G$1" pin="D4"/>
-<wire x1="68.58" y1="144.78" x2="76.2" y2="144.78" width="0.1524" layer="91"/>
-<wire x1="76.2" y1="144.78" x2="76.2" y2="147.32" width="0.1524" layer="91"/>
+<wire x1="68.58" y1="149.86" x2="76.2" y2="149.86" width="0.1524" layer="91"/>
+<wire x1="76.2" y1="149.86" x2="76.2" y2="152.4" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="D5" class="0">
 <segment>
-<wire x1="78.74" y1="144.78" x2="91.44" y2="144.78" width="0.1524" layer="91"/>
-<label x="88.9" y="144.78" size="1.778" layer="95" font="vector" rot="MR0"/>
+<wire x1="78.74" y1="149.86" x2="91.44" y2="149.86" width="0.1524" layer="91"/>
+<label x="88.9" y="149.86" size="1.778" layer="95" font="vector" rot="MR0"/>
 <pinref part="JP12" gate="G$1" pin="6"/>
 <pinref part="JP8" gate="G$1" pin="*D5"/>
-<wire x1="68.58" y1="142.24" x2="78.74" y2="142.24" width="0.1524" layer="91"/>
-<wire x1="78.74" y1="142.24" x2="78.74" y2="144.78" width="0.1524" layer="91"/>
+<wire x1="68.58" y1="147.32" x2="78.74" y2="147.32" width="0.1524" layer="91"/>
+<wire x1="78.74" y1="147.32" x2="78.74" y2="149.86" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="D6" class="0">
 <segment>
-<wire x1="91.44" y1="142.24" x2="81.28" y2="142.24" width="0.1524" layer="91"/>
-<label x="88.9" y="142.24" size="1.778" layer="95" font="vector" rot="MR0"/>
+<wire x1="91.44" y1="147.32" x2="81.28" y2="147.32" width="0.1524" layer="91"/>
+<label x="88.9" y="147.32" size="1.778" layer="95" font="vector" rot="MR0"/>
 <pinref part="JP12" gate="G$1" pin="7"/>
 <pinref part="JP8" gate="G$1" pin="*D6"/>
-<wire x1="68.58" y1="139.7" x2="81.28" y2="139.7" width="0.1524" layer="91"/>
-<wire x1="81.28" y1="139.7" x2="81.28" y2="142.24" width="0.1524" layer="91"/>
+<wire x1="68.58" y1="144.78" x2="81.28" y2="144.78" width="0.1524" layer="91"/>
+<wire x1="81.28" y1="144.78" x2="81.28" y2="147.32" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="D7" class="0">
 <segment>
-<wire x1="83.82" y1="139.7" x2="91.44" y2="139.7" width="0.1524" layer="91"/>
-<label x="88.9" y="139.7" size="1.778" layer="95" font="vector" rot="MR0"/>
+<wire x1="83.82" y1="144.78" x2="91.44" y2="144.78" width="0.1524" layer="91"/>
+<label x="88.9" y="144.78" size="1.778" layer="95" font="vector" rot="MR0"/>
 <pinref part="JP12" gate="G$1" pin="8"/>
 <pinref part="JP8" gate="G$1" pin="D7"/>
-<wire x1="68.58" y1="137.16" x2="83.82" y2="137.16" width="0.1524" layer="91"/>
-<wire x1="83.82" y1="137.16" x2="83.82" y2="139.7" width="0.1524" layer="91"/>
+<wire x1="68.58" y1="142.24" x2="83.82" y2="142.24" width="0.1524" layer="91"/>
+<wire x1="83.82" y1="142.24" x2="83.82" y2="144.78" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="D8" class="0">
 <segment>
-<wire x1="91.44" y1="129.54" x2="86.36" y2="129.54" width="0.1524" layer="91"/>
-<label x="81.28" y="134.62" size="1.778" layer="95" font="vector" rot="MR0"/>
-<wire x1="86.36" y1="129.54" x2="86.36" y2="134.62" width="0.1524" layer="91"/>
+<wire x1="91.44" y1="134.62" x2="86.36" y2="134.62" width="0.1524" layer="91"/>
+<label x="81.28" y="139.7" size="1.778" layer="95" font="vector" rot="MR0"/>
+<wire x1="86.36" y1="134.62" x2="86.36" y2="139.7" width="0.1524" layer="91"/>
 <pinref part="JP8" gate="G$1" pin="D8"/>
-<wire x1="86.36" y1="134.62" x2="68.58" y2="134.62" width="0.1524" layer="91"/>
+<wire x1="86.36" y1="139.7" x2="68.58" y2="139.7" width="0.1524" layer="91"/>
 <pinref part="JP1" gate="G$1" pin="1"/>
 </segment>
 </net>
 <net name="D9" class="0">
 <segment>
-<wire x1="83.82" y1="127" x2="91.44" y2="127" width="0.1524" layer="91"/>
-<label x="81.28" y="132.08" size="1.778" layer="95" font="vector" rot="MR0"/>
-<wire x1="83.82" y1="127" x2="83.82" y2="132.08" width="0.1524" layer="91"/>
+<wire x1="83.82" y1="132.08" x2="91.44" y2="132.08" width="0.1524" layer="91"/>
+<label x="81.28" y="137.16" size="1.778" layer="95" font="vector" rot="MR0"/>
+<wire x1="83.82" y1="132.08" x2="83.82" y2="137.16" width="0.1524" layer="91"/>
 <pinref part="JP8" gate="G$1" pin="*D9"/>
-<wire x1="83.82" y1="132.08" x2="68.58" y2="132.08" width="0.1524" layer="91"/>
+<wire x1="83.82" y1="137.16" x2="68.58" y2="137.16" width="0.1524" layer="91"/>
 <pinref part="JP1" gate="G$1" pin="2"/>
 </segment>
 </net>
 <net name="D10" class="0">
 <segment>
-<wire x1="91.44" y1="124.46" x2="81.28" y2="124.46" width="0.1524" layer="91"/>
-<label x="88.9" y="124.46" size="1.778" layer="95" font="vector" rot="MR0"/>
-<wire x1="81.28" y1="124.46" x2="81.28" y2="129.54" width="0.1524" layer="91"/>
+<wire x1="91.44" y1="129.54" x2="81.28" y2="129.54" width="0.1524" layer="91"/>
+<label x="88.9" y="129.54" size="1.778" layer="95" font="vector" rot="MR0"/>
+<wire x1="81.28" y1="129.54" x2="81.28" y2="134.62" width="0.1524" layer="91"/>
 <pinref part="JP8" gate="G$1" pin="*D10"/>
-<wire x1="81.28" y1="129.54" x2="68.58" y2="129.54" width="0.1524" layer="91"/>
+<wire x1="81.28" y1="134.62" x2="68.58" y2="134.62" width="0.1524" layer="91"/>
 <pinref part="JP1" gate="G$1" pin="3"/>
 </segment>
 </net>
 <net name="D11" class="0">
 <segment>
-<wire x1="78.74" y1="121.92" x2="91.44" y2="121.92" width="0.1524" layer="91"/>
-<label x="88.9" y="121.92" size="1.778" layer="95" font="vector" rot="MR0"/>
-<wire x1="78.74" y1="121.92" x2="78.74" y2="127" width="0.1524" layer="91"/>
+<wire x1="78.74" y1="127" x2="91.44" y2="127" width="0.1524" layer="91"/>
+<label x="88.9" y="127" size="1.778" layer="95" font="vector" rot="MR0"/>
+<wire x1="78.74" y1="127" x2="78.74" y2="132.08" width="0.1524" layer="91"/>
 <pinref part="JP8" gate="G$1" pin="*D11"/>
-<wire x1="78.74" y1="127" x2="68.58" y2="127" width="0.1524" layer="91"/>
+<wire x1="78.74" y1="132.08" x2="68.58" y2="132.08" width="0.1524" layer="91"/>
 <pinref part="JP1" gate="G$1" pin="4"/>
 </segment>
 </net>
 <net name="D12" class="0">
 <segment>
-<wire x1="91.44" y1="119.38" x2="76.2" y2="119.38" width="0.1524" layer="91"/>
-<label x="88.9" y="119.38" size="1.778" layer="95" font="vector" rot="MR0"/>
-<wire x1="76.2" y1="119.38" x2="76.2" y2="124.46" width="0.1524" layer="91"/>
+<wire x1="91.44" y1="124.46" x2="76.2" y2="124.46" width="0.1524" layer="91"/>
+<label x="88.9" y="124.46" size="1.778" layer="95" font="vector" rot="MR0"/>
+<wire x1="76.2" y1="124.46" x2="76.2" y2="129.54" width="0.1524" layer="91"/>
 <pinref part="JP8" gate="G$1" pin="D12"/>
-<wire x1="76.2" y1="124.46" x2="68.58" y2="124.46" width="0.1524" layer="91"/>
+<wire x1="76.2" y1="129.54" x2="68.58" y2="129.54" width="0.1524" layer="91"/>
 <pinref part="JP1" gate="G$1" pin="5"/>
 </segment>
 </net>
 <net name="D13" class="0">
 <segment>
-<wire x1="73.66" y1="116.84" x2="91.44" y2="116.84" width="0.1524" layer="91"/>
-<label x="88.9" y="116.84" size="1.778" layer="95" font="vector" rot="MR0"/>
-<wire x1="73.66" y1="116.84" x2="73.66" y2="121.92" width="0.1524" layer="91"/>
+<wire x1="73.66" y1="121.92" x2="91.44" y2="121.92" width="0.1524" layer="91"/>
+<label x="88.9" y="121.92" size="1.778" layer="95" font="vector" rot="MR0"/>
+<wire x1="73.66" y1="121.92" x2="73.66" y2="127" width="0.1524" layer="91"/>
 <pinref part="JP8" gate="G$1" pin="D13"/>
-<wire x1="73.66" y1="121.92" x2="68.58" y2="121.92" width="0.1524" layer="91"/>
+<wire x1="73.66" y1="127" x2="68.58" y2="127" width="0.1524" layer="91"/>
 <pinref part="JP1" gate="G$1" pin="6"/>
 </segment>
 </net>
 <net name="AREF" class="0">
 <segment>
-<wire x1="78.74" y1="111.76" x2="91.44" y2="111.76" width="0.1524" layer="91"/>
+<wire x1="78.74" y1="116.84" x2="91.44" y2="116.84" width="0.1524" layer="91"/>
 <pinref part="JP1" gate="G$1" pin="8"/>
-<label x="78.74" y="111.76" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="78.74" y="116.84" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 <segment>
 <pinref part="JP8" gate="G$1" pin="AREF"/>
-<wire x1="43.18" y1="124.46" x2="40.64" y2="124.46" width="0.1524" layer="91"/>
-<label x="40.64" y="124.46" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<wire x1="43.18" y1="129.54" x2="40.64" y2="129.54" width="0.1524" layer="91"/>
+<label x="40.64" y="129.54" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="RESET" class="0">
 <segment>
-<wire x1="71.12" y1="71.12" x2="63.5" y2="71.12" width="0.1524" layer="91"/>
+<wire x1="71.12" y1="83.82" x2="63.5" y2="83.82" width="0.1524" layer="91"/>
 <pinref part="ICSP" gate="G$1" pin="5"/>
-<label x="63.5" y="71.12" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="63.5" y="83.82" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 <segment>
 <pinref part="JP11" gate="G$1" pin="6"/>
-<wire x1="17.78" y1="129.54" x2="27.94" y2="129.54" width="0.1524" layer="91"/>
-<wire x1="27.94" y1="129.54" x2="27.94" y2="134.62" width="0.1524" layer="91"/>
+<wire x1="17.78" y1="134.62" x2="27.94" y2="134.62" width="0.1524" layer="91"/>
+<wire x1="27.94" y1="134.62" x2="27.94" y2="139.7" width="0.1524" layer="91"/>
 <pinref part="JP8" gate="G$1" pin="RES"/>
-<wire x1="27.94" y1="134.62" x2="43.18" y2="134.62" width="0.1524" layer="91"/>
-<wire x1="27.94" y1="129.54" x2="27.94" y2="91.44" width="0.1524" layer="91"/>
-<junction x="27.94" y="129.54"/>
-<wire x1="20.32" y1="99.06" x2="20.32" y2="91.44" width="0.1524" layer="91"/>
+<wire x1="27.94" y1="139.7" x2="43.18" y2="139.7" width="0.1524" layer="91"/>
+<wire x1="27.94" y1="134.62" x2="27.94" y2="101.6" width="0.1524" layer="91"/>
+<junction x="27.94" y="134.62"/>
+<wire x1="20.32" y1="106.68" x2="20.32" y2="101.6" width="0.1524" layer="91"/>
 <pinref part="S4" gate="G$1" pin="2"/>
-<label x="20.32" y="99.06" size="1.27" layer="95" font="vector" rot="R90" xref="yes"/>
-<wire x1="20.32" y1="91.44" x2="20.32" y2="83.82" width="0.1524" layer="91"/>
-<wire x1="27.94" y1="91.44" x2="20.32" y2="91.44" width="0.1524" layer="91"/>
-<junction x="20.32" y="91.44"/>
+<label x="20.32" y="106.68" size="1.27" layer="95" font="vector" rot="R90" xref="yes"/>
+<wire x1="20.32" y1="101.6" x2="20.32" y2="96.52" width="0.1524" layer="91"/>
+<wire x1="27.94" y1="101.6" x2="20.32" y2="101.6" width="0.1524" layer="91"/>
+<junction x="20.32" y="101.6"/>
 </segment>
 </net>
 <net name="5V" class="1">
 <segment>
-<wire x1="137.16" y1="93.98" x2="139.7" y2="93.98" width="0.1524" layer="91"/>
-<wire x1="139.7" y1="93.98" x2="139.7" y2="96.52" width="0.1524" layer="91"/>
-<wire x1="139.7" y1="96.52" x2="139.7" y2="99.06" width="0.1524" layer="91"/>
-<wire x1="139.7" y1="99.06" x2="139.7" y2="101.6" width="0.1524" layer="91"/>
-<wire x1="139.7" y1="101.6" x2="139.7" y2="104.14" width="0.1524" layer="91"/>
-<wire x1="139.7" y1="104.14" x2="139.7" y2="106.68" width="0.1524" layer="91"/>
-<wire x1="139.7" y1="106.68" x2="139.7" y2="109.22" width="0.1524" layer="91"/>
-<wire x1="139.7" y1="109.22" x2="139.7" y2="111.76" width="0.1524" layer="91"/>
-<wire x1="139.7" y1="111.76" x2="139.7" y2="114.3" width="0.1524" layer="91"/>
-<wire x1="139.7" y1="114.3" x2="139.7" y2="116.84" width="0.1524" layer="91"/>
-<wire x1="139.7" y1="116.84" x2="139.7" y2="119.38" width="0.1524" layer="91"/>
-<wire x1="139.7" y1="119.38" x2="139.7" y2="121.92" width="0.1524" layer="91"/>
-<wire x1="139.7" y1="121.92" x2="139.7" y2="124.46" width="0.1524" layer="91"/>
-<wire x1="139.7" y1="124.46" x2="139.7" y2="127" width="0.1524" layer="91"/>
-<wire x1="139.7" y1="127" x2="139.7" y2="129.54" width="0.1524" layer="91"/>
-<wire x1="139.7" y1="129.54" x2="139.7" y2="132.08" width="0.1524" layer="91"/>
-<wire x1="139.7" y1="132.08" x2="139.7" y2="134.62" width="0.1524" layer="91"/>
-<wire x1="139.7" y1="134.62" x2="139.7" y2="137.16" width="0.1524" layer="91"/>
-<wire x1="139.7" y1="137.16" x2="139.7" y2="139.7" width="0.1524" layer="91"/>
-<wire x1="139.7" y1="139.7" x2="139.7" y2="144.78" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="132.08" x2="139.7" y2="132.08" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="129.54" x2="139.7" y2="129.54" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="127" x2="139.7" y2="127" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="124.46" x2="139.7" y2="124.46" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="121.92" x2="139.7" y2="121.92" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="119.38" x2="139.7" y2="119.38" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="116.84" x2="139.7" y2="116.84" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="114.3" x2="139.7" y2="114.3" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="111.76" x2="139.7" y2="111.76" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="109.22" x2="139.7" y2="109.22" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="106.68" x2="139.7" y2="106.68" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="104.14" x2="139.7" y2="104.14" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="101.6" x2="139.7" y2="101.6" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="99.06" x2="139.7" y2="99.06" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="96.52" x2="139.7" y2="96.52" width="0.1524" layer="91"/>
-<junction x="139.7" y="132.08"/>
-<junction x="139.7" y="129.54"/>
-<junction x="139.7" y="127"/>
-<junction x="139.7" y="124.46"/>
-<junction x="139.7" y="121.92"/>
-<junction x="139.7" y="119.38"/>
-<junction x="139.7" y="116.84"/>
-<junction x="139.7" y="114.3"/>
-<junction x="139.7" y="111.76"/>
-<junction x="139.7" y="109.22"/>
-<junction x="139.7" y="106.68"/>
-<junction x="139.7" y="104.14"/>
-<junction x="139.7" y="101.6"/>
-<junction x="139.7" y="99.06"/>
-<junction x="139.7" y="96.52"/>
+<wire x1="134.62" y1="99.06" x2="137.16" y2="99.06" width="0.1524" layer="91"/>
+<wire x1="137.16" y1="99.06" x2="137.16" y2="101.6" width="0.1524" layer="91"/>
+<wire x1="137.16" y1="101.6" x2="137.16" y2="104.14" width="0.1524" layer="91"/>
+<wire x1="137.16" y1="104.14" x2="137.16" y2="106.68" width="0.1524" layer="91"/>
+<wire x1="137.16" y1="106.68" x2="137.16" y2="109.22" width="0.1524" layer="91"/>
+<wire x1="137.16" y1="109.22" x2="137.16" y2="111.76" width="0.1524" layer="91"/>
+<wire x1="137.16" y1="111.76" x2="137.16" y2="114.3" width="0.1524" layer="91"/>
+<wire x1="137.16" y1="114.3" x2="137.16" y2="116.84" width="0.1524" layer="91"/>
+<wire x1="137.16" y1="116.84" x2="137.16" y2="119.38" width="0.1524" layer="91"/>
+<wire x1="137.16" y1="119.38" x2="137.16" y2="121.92" width="0.1524" layer="91"/>
+<wire x1="137.16" y1="121.92" x2="137.16" y2="124.46" width="0.1524" layer="91"/>
+<wire x1="137.16" y1="124.46" x2="137.16" y2="127" width="0.1524" layer="91"/>
+<wire x1="137.16" y1="127" x2="137.16" y2="129.54" width="0.1524" layer="91"/>
+<wire x1="137.16" y1="129.54" x2="137.16" y2="132.08" width="0.1524" layer="91"/>
+<wire x1="137.16" y1="132.08" x2="137.16" y2="134.62" width="0.1524" layer="91"/>
+<wire x1="137.16" y1="134.62" x2="137.16" y2="137.16" width="0.1524" layer="91"/>
+<wire x1="137.16" y1="137.16" x2="137.16" y2="139.7" width="0.1524" layer="91"/>
+<wire x1="137.16" y1="139.7" x2="137.16" y2="142.24" width="0.1524" layer="91"/>
+<wire x1="137.16" y1="142.24" x2="137.16" y2="144.78" width="0.1524" layer="91"/>
+<wire x1="137.16" y1="144.78" x2="137.16" y2="149.86" width="0.1524" layer="91"/>
+<wire x1="134.62" y1="137.16" x2="137.16" y2="137.16" width="0.1524" layer="91"/>
+<wire x1="134.62" y1="134.62" x2="137.16" y2="134.62" width="0.1524" layer="91"/>
+<wire x1="134.62" y1="132.08" x2="137.16" y2="132.08" width="0.1524" layer="91"/>
+<wire x1="134.62" y1="129.54" x2="137.16" y2="129.54" width="0.1524" layer="91"/>
+<wire x1="134.62" y1="127" x2="137.16" y2="127" width="0.1524" layer="91"/>
+<wire x1="134.62" y1="124.46" x2="137.16" y2="124.46" width="0.1524" layer="91"/>
+<wire x1="134.62" y1="121.92" x2="137.16" y2="121.92" width="0.1524" layer="91"/>
+<wire x1="134.62" y1="119.38" x2="137.16" y2="119.38" width="0.1524" layer="91"/>
+<wire x1="134.62" y1="116.84" x2="137.16" y2="116.84" width="0.1524" layer="91"/>
+<wire x1="134.62" y1="114.3" x2="137.16" y2="114.3" width="0.1524" layer="91"/>
+<wire x1="134.62" y1="111.76" x2="137.16" y2="111.76" width="0.1524" layer="91"/>
+<wire x1="134.62" y1="109.22" x2="137.16" y2="109.22" width="0.1524" layer="91"/>
+<wire x1="134.62" y1="106.68" x2="137.16" y2="106.68" width="0.1524" layer="91"/>
+<wire x1="134.62" y1="104.14" x2="137.16" y2="104.14" width="0.1524" layer="91"/>
+<wire x1="134.62" y1="101.6" x2="137.16" y2="101.6" width="0.1524" layer="91"/>
+<junction x="137.16" y="137.16"/>
+<junction x="137.16" y="134.62"/>
+<junction x="137.16" y="132.08"/>
+<junction x="137.16" y="129.54"/>
+<junction x="137.16" y="127"/>
+<junction x="137.16" y="124.46"/>
+<junction x="137.16" y="121.92"/>
+<junction x="137.16" y="119.38"/>
+<junction x="137.16" y="116.84"/>
+<junction x="137.16" y="114.3"/>
+<junction x="137.16" y="111.76"/>
+<junction x="137.16" y="109.22"/>
+<junction x="137.16" y="106.68"/>
+<junction x="137.16" y="104.14"/>
+<junction x="137.16" y="101.6"/>
 <pinref part="5V_RAIL" gate="G$1" pin="1"/>
 <pinref part="5V_RAIL" gate="G$1" pin="16"/>
 <pinref part="5V_RAIL" gate="G$1" pin="15"/>
@@ -23367,266 +23367,266 @@ create customizable
 <pinref part="5V_RAIL" gate="G$1" pin="2"/>
 <pinref part="P+2" gate="G$1" pin="5V"/>
 <pinref part="5V_RAIL" gate="G$1" pin="17"/>
-<wire x1="137.16" y1="134.62" x2="139.7" y2="134.62" width="0.1524" layer="91"/>
-<junction x="139.7" y="134.62"/>
+<wire x1="134.62" y1="139.7" x2="137.16" y2="139.7" width="0.1524" layer="91"/>
+<junction x="137.16" y="139.7"/>
 <pinref part="5V_RAIL" gate="G$1" pin="18"/>
-<wire x1="137.16" y1="137.16" x2="139.7" y2="137.16" width="0.1524" layer="91"/>
-<junction x="139.7" y="137.16"/>
+<wire x1="134.62" y1="142.24" x2="137.16" y2="142.24" width="0.1524" layer="91"/>
+<junction x="137.16" y="142.24"/>
 <pinref part="5V_RAIL" gate="G$1" pin="19"/>
-<wire x1="137.16" y1="139.7" x2="139.7" y2="139.7" width="0.1524" layer="91"/>
-<junction x="139.7" y="139.7"/>
+<wire x1="134.62" y1="144.78" x2="137.16" y2="144.78" width="0.1524" layer="91"/>
+<junction x="137.16" y="144.78"/>
 </segment>
 <segment>
-<wire x1="88.9" y1="76.2" x2="96.52" y2="76.2" width="0.1524" layer="91"/>
+<wire x1="88.9" y1="88.9" x2="96.52" y2="88.9" width="0.1524" layer="91"/>
 <pinref part="ICSP" gate="G$1" pin="2"/>
 <pinref part="P+5" gate="G$1" pin="5V"/>
-<wire x1="96.52" y1="76.2" x2="96.52" y2="81.28" width="0.1524" layer="91"/>
+<wire x1="96.52" y1="88.9" x2="96.52" y2="93.98" width="0.1524" layer="91"/>
 </segment>
 <segment>
-<wire x1="198.12" y1="134.62" x2="198.12" y2="132.08" width="0.1524" layer="91"/>
+<wire x1="193.04" y1="137.16" x2="193.04" y2="134.62" width="0.1524" layer="91"/>
 <pinref part="R4" gate="G$1" pin="2"/>
 <pinref part="P+1" gate="G$1" pin="5V"/>
 </segment>
 <segment>
 <pinref part="JP11" gate="G$1" pin="4"/>
-<wire x1="17.78" y1="124.46" x2="33.02" y2="124.46" width="0.1524" layer="91"/>
-<wire x1="33.02" y1="124.46" x2="33.02" y2="129.54" width="0.1524" layer="91"/>
+<wire x1="17.78" y1="129.54" x2="33.02" y2="129.54" width="0.1524" layer="91"/>
+<wire x1="33.02" y1="129.54" x2="33.02" y2="134.62" width="0.1524" layer="91"/>
 <pinref part="JP8" gate="G$1" pin="5V"/>
-<wire x1="33.02" y1="129.54" x2="43.18" y2="129.54" width="0.1524" layer="91"/>
+<wire x1="33.02" y1="134.62" x2="43.18" y2="134.62" width="0.1524" layer="91"/>
 <pinref part="P+4" gate="G$1" pin="5V"/>
-<wire x1="33.02" y1="139.7" x2="33.02" y2="129.54" width="0.1524" layer="91"/>
-<junction x="33.02" y="129.54"/>
+<wire x1="33.02" y1="144.78" x2="33.02" y2="134.62" width="0.1524" layer="91"/>
+<junction x="33.02" y="134.62"/>
 </segment>
 <segment>
 <pinref part="SJ4" gate="G$1" pin="2"/>
-<wire x1="53.34" y1="25.4" x2="68.58" y2="25.4" width="0.1524" layer="91"/>
-<wire x1="68.58" y1="25.4" x2="68.58" y2="33.02" width="0.1524" layer="91"/>
+<wire x1="66.04" y1="35.56" x2="81.28" y2="35.56" width="0.1524" layer="91"/>
+<wire x1="81.28" y1="35.56" x2="81.28" y2="43.18" width="0.1524" layer="91"/>
 <pinref part="P+3" gate="G$1" pin="5V"/>
 </segment>
 </net>
 <net name="BUTTON" class="0">
 <segment>
-<wire x1="198.12" y1="114.3" x2="198.12" y2="116.84" width="0.1524" layer="91"/>
-<label x="185.42" y="116.84" size="1.778" layer="95" font="vector"/>
+<wire x1="193.04" y1="116.84" x2="193.04" y2="119.38" width="0.1524" layer="91"/>
+<label x="180.34" y="119.38" size="1.778" layer="95" font="vector"/>
 <pinref part="R4" gate="G$1" pin="1"/>
 <pinref part="S2" gate="G$1" pin="2"/>
 <pinref part="JP3" gate="G$1" pin="1"/>
-<wire x1="198.12" y1="116.84" x2="198.12" y2="121.92" width="0.1524" layer="91"/>
-<wire x1="203.2" y1="116.84" x2="198.12" y2="116.84" width="0.1524" layer="91"/>
-<junction x="198.12" y="116.84"/>
+<wire x1="193.04" y1="119.38" x2="193.04" y2="124.46" width="0.1524" layer="91"/>
+<wire x1="198.12" y1="119.38" x2="193.04" y2="119.38" width="0.1524" layer="91"/>
+<junction x="193.04" y="119.38"/>
 </segment>
 </net>
 <net name="MOSI_NC" class="0">
 <segment>
-<wire x1="88.9" y1="73.66" x2="96.52" y2="73.66" width="0.1524" layer="91"/>
+<wire x1="88.9" y1="86.36" x2="96.52" y2="86.36" width="0.1524" layer="91"/>
 <pinref part="ICSP" gate="G$1" pin="4"/>
-<label x="96.52" y="73.66" size="1.27" layer="95" font="vector" xref="yes"/>
+<label x="96.52" y="86.36" size="1.27" layer="95" font="vector" xref="yes"/>
 </segment>
 </net>
 <net name="MISO_NC" class="0">
 <segment>
-<wire x1="71.12" y1="76.2" x2="63.5" y2="76.2" width="0.1524" layer="91"/>
+<wire x1="71.12" y1="88.9" x2="63.5" y2="88.9" width="0.1524" layer="91"/>
 <pinref part="ICSP" gate="G$1" pin="1"/>
-<label x="63.5" y="76.2" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="63.5" y="88.9" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="SCK_NC" class="0">
 <segment>
-<wire x1="71.12" y1="73.66" x2="63.5" y2="73.66" width="0.1524" layer="91"/>
+<wire x1="71.12" y1="86.36" x2="63.5" y2="86.36" width="0.1524" layer="91"/>
 <pinref part="ICSP" gate="G$1" pin="3"/>
-<label x="63.5" y="73.66" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="63.5" y="86.36" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="NC1" class="0">
 <segment>
-<wire x1="35.56" y1="22.86" x2="40.64" y2="22.86" width="0.1524" layer="91"/>
+<wire x1="48.26" y1="33.02" x2="53.34" y2="33.02" width="0.1524" layer="91"/>
 <pinref part="JP7" gate="G$1" pin="1"/>
-<label x="40.64" y="22.86" size="1.27" layer="95" font="vector" xref="yes"/>
+<label x="53.34" y="33.02" size="1.27" layer="95" font="vector" xref="yes"/>
 </segment>
 <segment>
 <pinref part="JP2" gate="G$1" pin="1"/>
-<wire x1="15.24" y1="22.86" x2="12.7" y2="22.86" width="0.1524" layer="91"/>
-<label x="12.7" y="22.86" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<wire x1="27.94" y1="33.02" x2="22.86" y2="33.02" width="0.1524" layer="91"/>
+<label x="22.86" y="33.02" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="NC2" class="0">
 <segment>
-<wire x1="35.56" y1="35.56" x2="38.1" y2="35.56" width="0.1524" layer="91"/>
+<wire x1="48.26" y1="45.72" x2="50.8" y2="45.72" width="0.1524" layer="91"/>
 <pinref part="JP7" gate="G$1" pin="6"/>
-<label x="38.1" y="35.56" size="1.27" layer="95" font="vector" xref="yes"/>
+<label x="50.8" y="45.72" size="1.27" layer="95" font="vector" xref="yes"/>
 </segment>
 <segment>
 <pinref part="JP2" gate="G$1" pin="6"/>
-<wire x1="15.24" y1="35.56" x2="12.7" y2="35.56" width="0.1524" layer="91"/>
-<label x="12.7" y="35.56" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<wire x1="27.94" y1="45.72" x2="22.86" y2="45.72" width="0.1524" layer="91"/>
+<label x="22.86" y="45.72" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="N$1" class="0">
 <segment>
 <pinref part="JP11" gate="G$1" pin="7"/>
-<wire x1="17.78" y1="132.08" x2="25.4" y2="132.08" width="0.1524" layer="91"/>
-<wire x1="25.4" y1="132.08" x2="25.4" y2="137.16" width="0.1524" layer="91"/>
+<wire x1="17.78" y1="137.16" x2="25.4" y2="137.16" width="0.1524" layer="91"/>
+<wire x1="25.4" y1="137.16" x2="25.4" y2="142.24" width="0.1524" layer="91"/>
 <pinref part="JP8" gate="G$1" pin="IOREF"/>
-<wire x1="25.4" y1="137.16" x2="43.18" y2="137.16" width="0.1524" layer="91"/>
+<wire x1="25.4" y1="142.24" x2="43.18" y2="142.24" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="3.3" class="0">
 <segment>
 <pinref part="JP11" gate="G$1" pin="5"/>
 <pinref part="JP8" gate="G$1" pin="3.3V"/>
-<wire x1="17.78" y1="127" x2="43.18" y2="127" width="0.1524" layer="91"/>
+<wire x1="17.78" y1="132.08" x2="43.18" y2="132.08" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="SDA" class="0">
 <segment>
 <pinref part="JP1" gate="G$1" pin="9"/>
-<wire x1="91.44" y1="109.22" x2="71.12" y2="109.22" width="0.1524" layer="91"/>
-<wire x1="71.12" y1="109.22" x2="71.12" y2="119.38" width="0.1524" layer="91"/>
+<wire x1="91.44" y1="114.3" x2="71.12" y2="114.3" width="0.1524" layer="91"/>
+<wire x1="71.12" y1="114.3" x2="71.12" y2="124.46" width="0.1524" layer="91"/>
 <pinref part="JP8" gate="G$1" pin="SDA"/>
-<wire x1="71.12" y1="119.38" x2="68.58" y2="119.38" width="0.1524" layer="91"/>
-<label x="78.74" y="109.22" size="1.778" layer="95" font="vector"/>
+<wire x1="71.12" y1="124.46" x2="68.58" y2="124.46" width="0.1524" layer="91"/>
+<label x="78.74" y="114.3" size="1.778" layer="95" font="vector"/>
 </segment>
 </net>
 <net name="SCL" class="0">
 <segment>
 <pinref part="JP8" gate="G$1" pin="SCL"/>
-<wire x1="68.58" y1="116.84" x2="68.58" y2="106.68" width="0.1524" layer="91"/>
+<wire x1="68.58" y1="121.92" x2="68.58" y2="111.76" width="0.1524" layer="91"/>
 <pinref part="JP1" gate="G$1" pin="10"/>
-<wire x1="68.58" y1="106.68" x2="91.44" y2="106.68" width="0.1524" layer="91"/>
-<label x="78.74" y="106.68" size="1.778" layer="95" font="vector"/>
+<wire x1="68.58" y1="111.76" x2="91.44" y2="111.76" width="0.1524" layer="91"/>
+<label x="78.74" y="111.76" size="1.778" layer="95" font="vector"/>
 </segment>
 </net>
 <net name="VIN" class="0">
 <segment>
 <pinref part="JP11" gate="G$1" pin="1"/>
-<wire x1="17.78" y1="116.84" x2="30.48" y2="116.84" width="0.1524" layer="91"/>
-<wire x1="30.48" y1="116.84" x2="30.48" y2="132.08" width="0.1524" layer="91"/>
+<wire x1="17.78" y1="121.92" x2="30.48" y2="121.92" width="0.1524" layer="91"/>
+<wire x1="30.48" y1="121.92" x2="30.48" y2="137.16" width="0.1524" layer="91"/>
 <pinref part="JP8" gate="G$1" pin="VIN"/>
-<wire x1="30.48" y1="132.08" x2="43.18" y2="132.08" width="0.1524" layer="91"/>
+<wire x1="30.48" y1="137.16" x2="43.18" y2="137.16" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="NC3" class="0">
 <segment>
 <pinref part="JP11" gate="G$1" pin="8"/>
-<wire x1="17.78" y1="134.62" x2="20.32" y2="134.62" width="0.1524" layer="91"/>
-<wire x1="20.32" y1="134.62" x2="20.32" y2="139.7" width="0.1524" layer="91"/>
-<wire x1="20.32" y1="139.7" x2="22.86" y2="139.7" width="0.1524" layer="91"/>
-<label x="22.86" y="139.7" size="1.27" layer="95" font="vector" xref="yes"/>
+<wire x1="17.78" y1="139.7" x2="20.32" y2="139.7" width="0.1524" layer="91"/>
+<wire x1="20.32" y1="139.7" x2="20.32" y2="144.78" width="0.1524" layer="91"/>
+<wire x1="20.32" y1="144.78" x2="22.86" y2="144.78" width="0.1524" layer="91"/>
+<label x="22.86" y="144.78" size="1.27" layer="95" font="vector" xref="yes"/>
 </segment>
 </net>
 <net name="RX-I" class="0">
 <segment>
 <pinref part="JP7" gate="G$1" pin="5"/>
 <pinref part="SJ1" gate="G$1" pin="1"/>
-<wire x1="40.64" y1="33.02" x2="35.56" y2="33.02" width="0.1524" layer="91"/>
+<wire x1="53.34" y1="43.18" x2="48.26" y2="43.18" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="JP2" gate="G$1" pin="5"/>
-<wire x1="15.24" y1="33.02" x2="12.7" y2="33.02" width="0.1524" layer="91"/>
-<label x="12.7" y="33.02" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<wire x1="27.94" y1="43.18" x2="22.86" y2="43.18" width="0.1524" layer="91"/>
+<label x="22.86" y="43.18" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="TX-O" class="0">
 <segment>
 <pinref part="JP7" gate="G$1" pin="4"/>
 <pinref part="SJ2" gate="G$1" pin="1"/>
-<wire x1="35.56" y1="30.48" x2="48.26" y2="30.48" width="0.1524" layer="91"/>
+<wire x1="48.26" y1="40.64" x2="60.96" y2="40.64" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="JP2" gate="G$1" pin="4"/>
-<wire x1="15.24" y1="30.48" x2="12.7" y2="30.48" width="0.1524" layer="91"/>
-<label x="12.7" y="30.48" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<wire x1="27.94" y1="40.64" x2="22.86" y2="40.64" width="0.1524" layer="91"/>
+<label x="22.86" y="40.64" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="VCC" class="0">
 <segment>
 <pinref part="JP2" gate="G$1" pin="2"/>
-<wire x1="15.24" y1="25.4" x2="12.7" y2="25.4" width="0.1524" layer="91"/>
-<label x="12.7" y="25.4" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<wire x1="27.94" y1="35.56" x2="22.86" y2="35.56" width="0.1524" layer="91"/>
+<label x="22.86" y="35.56" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 <segment>
 <pinref part="JP7" gate="G$1" pin="2"/>
 <pinref part="SJ4" gate="G$1" pin="1"/>
-<wire x1="35.56" y1="25.4" x2="43.18" y2="25.4" width="0.1524" layer="91"/>
+<wire x1="48.26" y1="35.56" x2="55.88" y2="35.56" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="A0" class="0">
 <segment>
 <pinref part="JP10" gate="G$1" pin="6"/>
 <pinref part="JP8" gate="G$1" pin="A0"/>
-<wire x1="27.94" y1="165.1" x2="43.18" y2="165.1" width="0.1524" layer="91"/>
-<wire x1="43.18" y1="165.1" x2="43.18" y2="157.48" width="0.1524" layer="91"/>
+<wire x1="27.94" y1="170.18" x2="43.18" y2="170.18" width="0.1524" layer="91"/>
+<wire x1="43.18" y1="170.18" x2="43.18" y2="162.56" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="A1" class="0">
 <segment>
 <pinref part="JP8" gate="G$1" pin="A1"/>
-<wire x1="43.18" y1="154.94" x2="40.64" y2="154.94" width="0.1524" layer="91"/>
-<wire x1="40.64" y1="154.94" x2="40.64" y2="162.56" width="0.1524" layer="91"/>
+<wire x1="43.18" y1="160.02" x2="40.64" y2="160.02" width="0.1524" layer="91"/>
+<wire x1="40.64" y1="160.02" x2="40.64" y2="167.64" width="0.1524" layer="91"/>
 <pinref part="JP10" gate="G$1" pin="5"/>
-<wire x1="40.64" y1="162.56" x2="27.94" y2="162.56" width="0.1524" layer="91"/>
+<wire x1="40.64" y1="167.64" x2="27.94" y2="167.64" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="A2" class="0">
 <segment>
 <pinref part="JP10" gate="G$1" pin="4"/>
-<wire x1="27.94" y1="160.02" x2="38.1" y2="160.02" width="0.1524" layer="91"/>
-<wire x1="38.1" y1="160.02" x2="38.1" y2="152.4" width="0.1524" layer="91"/>
+<wire x1="27.94" y1="165.1" x2="38.1" y2="165.1" width="0.1524" layer="91"/>
+<wire x1="38.1" y1="165.1" x2="38.1" y2="157.48" width="0.1524" layer="91"/>
 <pinref part="JP8" gate="G$1" pin="A2"/>
-<wire x1="38.1" y1="152.4" x2="43.18" y2="152.4" width="0.1524" layer="91"/>
+<wire x1="38.1" y1="157.48" x2="43.18" y2="157.48" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="A3" class="0">
 <segment>
 <pinref part="JP10" gate="G$1" pin="3"/>
-<wire x1="27.94" y1="157.48" x2="35.56" y2="157.48" width="0.1524" layer="91"/>
-<wire x1="35.56" y1="157.48" x2="35.56" y2="149.86" width="0.1524" layer="91"/>
+<wire x1="27.94" y1="162.56" x2="35.56" y2="162.56" width="0.1524" layer="91"/>
+<wire x1="35.56" y1="162.56" x2="35.56" y2="154.94" width="0.1524" layer="91"/>
 <pinref part="JP8" gate="G$1" pin="A3"/>
-<wire x1="35.56" y1="149.86" x2="43.18" y2="149.86" width="0.1524" layer="91"/>
+<wire x1="35.56" y1="154.94" x2="43.18" y2="154.94" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="A4" class="0">
 <segment>
 <pinref part="JP8" gate="G$1" pin="A4"/>
-<wire x1="43.18" y1="147.32" x2="33.02" y2="147.32" width="0.1524" layer="91"/>
-<wire x1="33.02" y1="147.32" x2="33.02" y2="154.94" width="0.1524" layer="91"/>
+<wire x1="43.18" y1="152.4" x2="33.02" y2="152.4" width="0.1524" layer="91"/>
+<wire x1="33.02" y1="152.4" x2="33.02" y2="160.02" width="0.1524" layer="91"/>
 <pinref part="JP10" gate="G$1" pin="2"/>
-<wire x1="33.02" y1="154.94" x2="27.94" y2="154.94" width="0.1524" layer="91"/>
+<wire x1="33.02" y1="160.02" x2="27.94" y2="160.02" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="A5" class="0">
 <segment>
 <pinref part="JP8" gate="G$1" pin="A5"/>
-<wire x1="30.48" y1="144.78" x2="43.18" y2="144.78" width="0.1524" layer="91"/>
-<wire x1="30.48" y1="144.78" x2="30.48" y2="152.4" width="0.1524" layer="91"/>
+<wire x1="30.48" y1="149.86" x2="43.18" y2="149.86" width="0.1524" layer="91"/>
+<wire x1="30.48" y1="149.86" x2="30.48" y2="157.48" width="0.1524" layer="91"/>
 <pinref part="JP10" gate="G$1" pin="1"/>
-<wire x1="30.48" y1="152.4" x2="27.94" y2="152.4" width="0.1524" layer="91"/>
+<wire x1="30.48" y1="157.48" x2="27.94" y2="157.48" width="0.1524" layer="91"/>
 </segment>
 </net>
 </nets>
 </sheet>
 </sheets>
 <errors>
-<approved hash="106,1,71.12,76.2,MISO_NC,,,,,"/>
-<approved hash="106,1,88.9,73.66,MOSI_NC,,,,,"/>
-<approved hash="106,1,17.78,134.62,NC3,,,,,"/>
-<approved hash="106,1,71.12,73.66,SCK_NC,,,,,"/>
-<approved hash="113,1,224.1,120.65,LED1,,,,,"/>
-<approved hash="113,1,236.8,120.65,LED2,,,,,"/>
-<approved hash="113,1,227.398,130.217,JP4,,,,,"/>
-<approved hash="113,1,240.098,130.217,JP9,,,,,"/>
-<approved hash="113,1,94.6573,147.252,JP12,,,,,"/>
-<approved hash="113,1,24.7227,160.088,JP10,,,,,"/>
-<approved hash="113,1,133.943,118.178,5V_RAIL,,,,,"/>
-<approved hash="113,1,156.803,118.178,GND_RAIL,,,,,"/>
-<approved hash="113,1,206.417,115.502,JP3,,,,,"/>
-<approved hash="113,1,32.3427,30.5477,JP7,,,,,"/>
-<approved hash="113,1,14.5627,127.068,JP11,,,,,"/>
-<approved hash="113,1,94.6573,116.772,JP1,,,,,"/>
-<approved hash="115,1,36.83,27.94,GND,,,,,"/>
-<approved hash="115,1,39.37,25.4,VCC,,,,,"/>
-<approved hash="115,1,38.1,33.02,RX-I,,,,,"/>
-<approved hash="115,1,41.91,30.48,TX-O,,,,,"/>
+<approved hash="106,1,71.12,88.9,MISO_NC,,,,,"/>
+<approved hash="106,1,88.9,86.36,MOSI_NC,,,,,"/>
+<approved hash="106,1,17.78,139.7,NC3,,,,,"/>
+<approved hash="106,1,71.12,86.36,SCK_NC,,,,,"/>
+<approved hash="113,1,219.02,123.19,LED1,,,,,"/>
+<approved hash="113,1,231.72,123.19,LED2,,,,,"/>
+<approved hash="113,1,222.318,132.757,JP4,,,,,"/>
+<approved hash="113,1,235.018,132.757,JP9,,,,,"/>
+<approved hash="113,1,94.6573,152.332,JP12,,,,,"/>
+<approved hash="113,1,24.7227,165.168,JP10,,,,,"/>
+<approved hash="113,1,131.403,123.258,5V_RAIL,,,,,"/>
+<approved hash="113,1,154.263,123.258,GND_RAIL,,,,,"/>
+<approved hash="113,1,201.337,118.042,JP3,,,,,"/>
+<approved hash="113,1,45.0427,40.7077,JP7,,,,,"/>
+<approved hash="113,1,14.5627,132.148,JP11,,,,,"/>
+<approved hash="113,1,94.6573,121.852,JP1,,,,,"/>
+<approved hash="115,1,50.8,43.18,RX-I,,,,,"/>
+<approved hash="115,1,49.53,38.1,GND,,,,,"/>
+<approved hash="115,1,54.61,40.64,TX-O,,,,,"/>
+<approved hash="115,1,52.07,35.56,VCC,,,,,"/>
 </errors>
 </schematic>
 </drawing>


### PR DESCRIPTION
**Board**

* Change wire boundary to bRestrict layer to prevent ground pour from creating a thermal around GND jumper pads.

**Schematic**

* Move OSHW logo next to SparkFun logo
* Move schematic components around to make use of the empty space