### PR TITLE
Revision 32: Update Proto2

### DIFF
--- a/Hardware/SparkFun_ProtoShield_Kit_rev32.brd
+++ b/Hardware/SparkFun_ProtoShield_Kit_rev32.brd
@@ -6,7 +6,7 @@
 <setting alwaysvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.01" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.005" altunitdist="inch" altunit="inch"/>
+<grid distance="0.05" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.005" altunitdist="inch" altunit="inch"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="2" name="Route2" color="1" fill="3" visible="no" active="no"/>
@@ -28,14 +28,14 @@
 <layer number="18" name="Vias" color="2" fill="1" visible="yes" active="yes"/>
 <layer number="19" name="Unrouted" color="6" fill="1" visible="yes" active="yes"/>
 <layer number="20" name="Dimension" color="15" fill="1" visible="yes" active="yes"/>
-<layer number="21" name="tPlace" color="14" fill="1" visible="yes" active="yes"/>
-<layer number="22" name="bPlace" color="16" fill="1" visible="yes" active="yes"/>
+<layer number="21" name="tPlace" color="16" fill="1" visible="yes" active="yes"/>
+<layer number="22" name="bPlace" color="14" fill="1" visible="yes" active="yes"/>
 <layer number="23" name="tOrigins" color="15" fill="1" visible="yes" active="yes"/>
-<layer number="24" name="bOrigins" color="15" fill="1" visible="yes" active="yes"/>
+<layer number="24" name="bOrigins" color="15" fill="1" visible="no" active="yes"/>
 <layer number="25" name="tNames" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="26" name="bNames" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="27" name="tValues" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="28" name="bValues" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="26" name="bNames" color="7" fill="1" visible="no" active="yes"/>
+<layer number="27" name="tValues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="28" name="bValues" color="7" fill="1" visible="no" active="yes"/>
 <layer number="29" name="tStop" color="7" fill="6" visible="no" active="yes"/>
 <layer number="30" name="bStop" color="7" fill="3" visible="no" active="yes"/>
 <layer number="31" name="tCream" color="7" fill="5" visible="no" active="yes"/>
@@ -47,18 +47,18 @@
 <layer number="37" name="tTest" color="7" fill="1" visible="no" active="yes"/>
 <layer number="38" name="bTest" color="7" fill="1" visible="no" active="yes"/>
 <layer number="39" name="tKeepout" color="4" fill="11" visible="no" active="yes"/>
-<layer number="40" name="bKeepout" color="1" fill="11" visible="yes" active="yes"/>
+<layer number="40" name="bKeepout" color="1" fill="11" visible="no" active="yes"/>
 <layer number="41" name="tRestrict" color="4" fill="10" visible="yes" active="yes"/>
 <layer number="42" name="bRestrict" color="1" fill="10" visible="yes" active="yes"/>
 <layer number="43" name="vRestrict" color="2" fill="10" visible="no" active="yes"/>
 <layer number="44" name="Drills" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="45" name="Holes" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="46" name="Milling" color="3" fill="1" visible="no" active="yes"/>
-<layer number="47" name="Measures" color="7" fill="1" visible="no" active="yes"/>
+<layer number="47" name="Measures" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="48" name="Document" color="7" fill="1" visible="no" active="yes"/>
 <layer number="49" name="Reference" color="7" fill="1" visible="no" active="yes"/>
 <layer number="50" name="dxf" color="7" fill="1" visible="no" active="yes"/>
-<layer number="51" name="tDocu" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="51" name="tDocu" color="6" fill="1" visible="yes" active="yes"/>
 <layer number="52" name="bDocu" color="6" fill="1" visible="no" active="yes"/>
 <layer number="53" name="tGND_GNDA" color="7" fill="9" visible="no" active="no"/>
 <layer number="54" name="bGND_GNDA" color="1" fill="9" visible="no" active="no"/>
@@ -145,8 +145,8 @@
 <layer number="229" name="229bmp" color="7" fill="1" visible="no" active="yes"/>
 <layer number="230" name="230bmp" color="7" fill="1" visible="no" active="yes"/>
 <layer number="231" name="231bmp" color="7" fill="1" visible="no" active="yes"/>
-<layer number="232" name="Eagle3D_PG2" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="233" name="Eagle3D_PG3" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="232" name="Eagle3D_PG2" color="7" fill="1" visible="no" active="yes"/>
+<layer number="233" name="Eagle3D_PG3" color="7" fill="1" visible="no" active="yes"/>
 <layer number="248" name="Housing" color="7" fill="1" visible="no" active="yes"/>
 <layer number="249" name="Edge" color="7" fill="1" visible="no" active="yes"/>
 <layer number="250" name="Descript" color="3" fill="1" visible="no" active="no"/>
@@ -159,17 +159,15 @@
 <text x="4.064" y="31.369" size="0.8128" layer="21" ratio="15">GND</text>
 <text x="44.5412" y="25.8716" size="1.4" layer="25" font="fixed" rot="R270">Digital</text>
 <text x="32.131" y="11.049" size="1.4" layer="21" font="vector" ratio="15">1</text>
-<text x="32.1634" y="2.1314" size="1.4" layer="25" font="fixed">1</text>
-<text x="28.575" y="58.928" size="1.27" layer="21" font="vector" ratio="15">  Arduino 
-ProtoShield</text>
+<text x="31.115" y="61.468" size="1.143" layer="21" font="vector" ratio="15">Arduino ProtoShield</text>
 <text x="4.191" y="36.449" size="0.8128" layer="21" font="vector" ratio="15">5V</text>
 <text x="4.191" y="38.989" size="0.8128" layer="21" font="vector" ratio="15">3.3</text>
 <text x="4.064" y="28.702" size="0.8128" layer="21" font="vector" ratio="15">RAW</text>
 <text x="4.064" y="41.529" size="0.8128" layer="21" font="vector" ratio="15">RST</text>
 <text x="4.064" y="33.909" size="0.8128" layer="21" font="vector" ratio="15">GND</text>
-<text x="3.048" y="58.039" size="1.016" layer="21" font="vector" ratio="15">Reset</text>
-<text x="47.244" y="50.673" size="0.8128" layer="21" font="vector" ratio="15">REF</text>
-<text x="47.244" y="48.133" size="0.8128" layer="21" font="vector" ratio="15">GND</text>
+<text x="3.048" y="60.325" size="1.016" layer="21" font="vector" ratio="15">Reset</text>
+<text x="47.244" y="50.927" size="0.8128" layer="21" font="vector" ratio="15">REF</text>
+<text x="47.244" y="48.387" size="0.8128" layer="21" font="vector" ratio="15">GND</text>
 <text x="4.191" y="23.622" size="1.143" layer="21" font="vector" ratio="15">A0</text>
 <text x="4.191" y="21.082" size="1.143" layer="21" font="vector" ratio="15">A1</text>
 <text x="4.191" y="18.542" size="1.143" layer="21" font="vector" ratio="15">A2</text>
@@ -182,21 +180,21 @@ ProtoShield</text>
 <text x="47.371" y="16.002" size="1.143" layer="21" font="vector" ratio="15">D2</text>
 <text x="47.371" y="13.462" size="1.143" layer="21" font="vector" ratio="15">D1</text>
 <text x="47.371" y="10.922" size="1.143" layer="21" font="vector" ratio="15">D0</text>
-<text x="47.244" y="40.513" size="0.8128" layer="21" font="vector" ratio="15">D11</text>
-<text x="47.244" y="37.973" size="0.8128" layer="21" font="vector" ratio="15">D10</text>
-<text x="47.371" y="35.306" size="1.143" layer="21" font="vector" ratio="15">D9</text>
-<text x="47.371" y="32.639" size="1.143" layer="21" font="vector" ratio="15">D8</text>
+<text x="47.244" y="40.767" size="0.8128" layer="21" font="vector" ratio="15">D11</text>
+<text x="47.244" y="38.227" size="0.8128" layer="21" font="vector" ratio="15">D10</text>
+<text x="47.371" y="35.56" size="1.143" layer="21" font="vector" ratio="15">D9</text>
+<text x="47.371" y="33.147" size="1.143" layer="21" font="vector" ratio="15">D8</text>
 <text x="47.371" y="28.702" size="1.143" layer="21" font="vector" ratio="15">D7</text>
 <text x="47.371" y="26.162" size="1.143" layer="21" font="vector" ratio="15">D6</text>
-<text x="47.244" y="43.053" size="0.8128" layer="21" font="vector" ratio="15">D12</text>
-<text x="47.244" y="45.593" size="0.8128" layer="21" font="vector" ratio="15">D13</text>
-<text x="18.415" y="59.944" size="0.8128" layer="21" font="vector" ratio="15">D1</text>
-<text x="20.955" y="59.944" size="0.8128" layer="21" font="vector" ratio="15">D0</text>
-<text x="26.035" y="59.944" size="0.8128" layer="21" font="vector" ratio="15">5V</text>
-<text x="23.114" y="59.944" size="0.8128" layer="21" font="vector" ratio="15">GND</text>
-<text x="17.145" y="2.8575" size="0.8128" layer="21" font="vector" ratio="15">LED1</text>
-<text x="21.082" y="2.8575" size="0.8128" layer="21" font="vector" ratio="15">SW2</text>
-<text x="13.335" y="2.8575" size="0.8128" layer="21" font="vector" ratio="15">LED2</text>
+<text x="47.244" y="43.307" size="0.8128" layer="21" font="vector" ratio="15">D12</text>
+<text x="47.244" y="45.847" size="0.8128" layer="21" font="vector" ratio="15">D13</text>
+<text x="17.653" y="59.69" size="0.8128" layer="21" font="vector" ratio="15">D11</text>
+<text x="20.447" y="59.69" size="0.8128" layer="21" font="vector" ratio="15">D10</text>
+<text x="26.035" y="59.69" size="0.8128" layer="21" font="vector" ratio="15">5V</text>
+<text x="23.114" y="59.69" size="0.8128" layer="21" font="vector" ratio="15">GND</text>
+<text x="22.479" y="3.1115" size="0.8128" layer="21" font="vector" ratio="15">L1</text>
+<text x="32.4612" y="3.1115" size="0.8128" layer="21" font="vector" ratio="15">SW2</text>
+<text x="25.019" y="3.1115" size="0.8128" layer="21" font="vector" ratio="15">L2</text>
 <text x="53.0225" y="2.8575" size="0.8128" layer="21" font="vector" ratio="15" rot="R90">SW2</text>
 <hole x="5.08" y="6.35" drill="0.381"/>
 <hole x="5.715" y="6.35" drill="0.381"/>
@@ -209,16 +207,14 @@ ProtoShield</text>
 <hole x="51.435" y="8.89" drill="0.381"/>
 <text x="4.064" y="44.069" size="0.8128" layer="21" font="vector" ratio="15">IOR</text>
 <text x="4.064" y="46.609" size="0.8128" layer="21" font="vector" ratio="15">NC</text>
-<text x="47.244" y="53.213" size="0.8128" layer="21" font="vector" ratio="15">SDA</text>
-<text x="47.244" y="55.753" size="0.8128" layer="21" font="vector" ratio="15">SCL</text>
+<text x="47.244" y="53.467" size="0.8128" layer="21" font="vector" ratio="15">SDA</text>
+<text x="47.244" y="56.007" size="0.8128" layer="21" font="vector" ratio="15">SCL</text>
 <text x="26.035" y="64.262" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">BlueSMiRF</text>
-<text x="36.703" y="3.556" size="0.8128" layer="21" font="vector" ratio="15">LED1</text>
-<text x="5.6515" y="2.8575" size="0.8128" layer="21" font="vector" ratio="15">LED2</text>
-<text x="4.445" y="61.595" size="1.27" layer="16" font="vector" ratio="15" rot="MR180">v31</text>
-<text x="12.827" y="12.192" size="1.27" layer="21" font="vector" ratio="15" rot="R180">5V</text>
-<text x="43.815" y="12.192" size="1.27" layer="21" font="vector" ratio="15" rot="R180">GND</text>
-<text x="43.688" y="59.055" size="1.27" layer="21" font="vector" ratio="15">GND</text>
-<text x="10.033" y="60.325" size="1.27" layer="21" font="fixed" ratio="15" rot="R180">5V</text>
+<text x="4.826" y="2.667" size="0.8128" layer="21" font="vector" ratio="15">L1</text>
+<text x="17.2085" y="1.4605" size="0.8128" layer="21" font="vector" ratio="15" rot="R180">L2</text>
+<text x="45.593" y="62.611" size="1.27" layer="16" font="vector" ratio="15" rot="MR180">v32</text>
+<text x="30.099" y="3.1115" size="0.8128" layer="21" font="vector" ratio="15">5V</text>
+<text x="27.305" y="3.1115" size="0.8128" layer="21" font="vector" ratio="15">GND</text>
 <dimension x1="0" y1="0" x2="0" y2="59.69" x3="-1.905" y3="29.845" textsize="1.27" textratio="15" layer="47" unit="inch"/>
 <dimension x1="0" y1="1.27" x2="53.34" y2="1.27" x3="26.67" y3="-2.54" textsize="1.27" textratio="15" layer="47" unit="inch"/>
 <dimension x1="2.54" y1="62.23" x2="0" y2="59.69" x3="-6.667503125" y3="68.897503125" textsize="1.27" textratio="15" layer="47" unit="inch"/>
@@ -237,37 +233,31 @@ ProtoShield</text>
 <dimension x1="53.34" y1="0" x2="53.34" y2="60.96" x3="57.15" y3="30.48" textsize="1.27" textratio="15" layer="47" unit="inch"/>
 <dimension x1="53.34" y1="0" x2="53.34" y2="7.62" x3="60.96" y3="3.81" textsize="1.27" textratio="15" layer="47" unit="inch"/>
 <dimension x1="0" y1="0" x2="0" y2="5.08" x3="-3.81" y3="2.54" textsize="1.27" textratio="15" layer="47" unit="inch"/>
-<text x="36.576" y="61.849" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">TX</text>
-<text x="36.576" y="59.182" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">RX</text>
+<text x="35.306" y="61.087" size="0.8128" layer="22" font="vector" ratio="15" rot="MR90">D11</text>
+<text x="35.306" y="58.293" size="0.8128" layer="22" font="vector" ratio="15" rot="MR90">D10</text>
 <text x="25.273" y="59.182" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">GND</text>
 <text x="16.764" y="59.182" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">5V</text>
-<text x="4.699" y="3.429" size="0.8128" layer="21" font="vector" ratio="15">-</text>
-<text x="39.751" y="2.54" size="0.8128" layer="21" font="vector" ratio="15">+</text>
-<text x="16.129" y="2.8575" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">LED2</text>
-<text x="19.939" y="2.8575" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">LED1</text>
-<text x="23.241" y="2.8575" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">SW2</text>
-<text x="46.863" y="59.055" size="1.27" layer="22" font="vector" ratio="15" rot="MR0">GND</text>
-<text x="40.005" y="12.192" size="1.27" layer="22" font="vector" ratio="15" rot="MR180">GND</text>
-<text x="10.287" y="12.192" size="1.27" layer="22" font="vector" ratio="15" rot="MR180">5V</text>
-<text x="7.493" y="60.325" size="1.27" layer="22" font="fixed" ratio="15" rot="MR180">5V</text>
-<text x="49.276" y="50.673" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">REF</text>
-<text x="49.276" y="48.133" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">GND</text>
+<text x="20.828" y="0.508" size="0.8128" layer="21" font="vector" ratio="15">-</text>
+<text x="4.191" y="4.064" size="0.8128" layer="21" font="vector" ratio="15">-</text>
+<text x="34.417" y="3.1115" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">SW2</text>
+<text x="49.276" y="50.927" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">REF</text>
+<text x="49.276" y="48.387" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">GND</text>
 <text x="49.149" y="23.622" size="1.143" layer="22" font="vector" ratio="15" rot="MR0">D5</text>
 <text x="49.149" y="21.082" size="1.143" layer="22" font="vector" ratio="15" rot="MR0">D4</text>
 <text x="49.149" y="18.542" size="1.143" layer="22" font="vector" ratio="15" rot="MR0">D3</text>
 <text x="49.149" y="16.002" size="1.143" layer="22" font="vector" ratio="15" rot="MR0">D2</text>
 <text x="49.149" y="13.462" size="1.143" layer="22" font="vector" ratio="15" rot="MR0">D1</text>
 <text x="49.149" y="10.922" size="1.143" layer="22" font="vector" ratio="15" rot="MR0">D0</text>
-<text x="49.276" y="40.513" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">D11</text>
-<text x="49.276" y="37.973" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">D10</text>
-<text x="49.149" y="35.306" size="1.143" layer="22" font="vector" ratio="15" rot="MR0">D9</text>
-<text x="49.149" y="32.639" size="1.143" layer="22" font="vector" ratio="15" rot="MR0">D8</text>
+<text x="49.276" y="40.767" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">D11</text>
+<text x="49.276" y="38.227" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">D10</text>
+<text x="49.149" y="35.56" size="1.143" layer="22" font="vector" ratio="15" rot="MR0">D9</text>
+<text x="49.149" y="33.147" size="1.143" layer="22" font="vector" ratio="15" rot="MR0">D8</text>
 <text x="49.149" y="28.702" size="1.143" layer="22" font="vector" ratio="15" rot="MR0">D7</text>
 <text x="49.149" y="26.162" size="1.143" layer="22" font="vector" ratio="15" rot="MR0">D6</text>
-<text x="49.276" y="43.053" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">D12</text>
-<text x="49.276" y="45.593" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">D13</text>
-<text x="49.276" y="53.213" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">SDA</text>
-<text x="49.276" y="55.753" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">SCL</text>
+<text x="49.276" y="43.307" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">D12</text>
+<text x="49.276" y="45.847" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">D13</text>
+<text x="49.276" y="53.467" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">SDA</text>
+<text x="49.276" y="56.007" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">SCL</text>
 <text x="6.096" y="31.369" size="0.8128" layer="22" ratio="15" rot="MR0">GND</text>
 <text x="5.969" y="36.449" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">5V</text>
 <text x="5.969" y="38.989" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">3.3</text>
@@ -358,23 +348,17 @@ ProtoShield</text>
 <wire x1="15.24" y1="66.04" x2="15.24" y2="67.31" width="0.2032" layer="22"/>
 <wire x1="15.24" y1="67.31" x2="15.875" y2="67.945" width="0.2032" layer="22"/>
 <wire x1="15.875" y1="67.945" x2="17.145" y2="67.945" width="0.2032" layer="22"/>
-<wire x1="1.905" y1="48.26" x2="3.175" y2="48.26" width="0.254" layer="22"/>
-<wire x1="3.175" y1="48.26" x2="3.81" y2="47.625" width="0.254" layer="22"/>
 <wire x1="3.81" y1="47.625" x2="3.81" y2="46.355" width="0.254" layer="22"/>
 <wire x1="3.81" y1="46.355" x2="3.175" y2="45.72" width="0.254" layer="22"/>
 <wire x1="3.175" y1="45.72" x2="3.81" y2="45.085" width="0.254" layer="22"/>
-<wire x1="3.81" y1="45.085" x2="3.81" y2="43.815" width="0.254" layer="22"/>
 <wire x1="3.81" y1="43.815" x2="3.175" y2="43.18" width="0.254" layer="22"/>
 <wire x1="3.175" y1="43.18" x2="3.81" y2="42.545" width="0.254" layer="22"/>
 <wire x1="3.81" y1="42.545" x2="3.81" y2="41.275" width="0.254" layer="22"/>
 <wire x1="3.81" y1="41.275" x2="3.175" y2="40.64" width="0.254" layer="22"/>
 <wire x1="3.175" y1="40.64" x2="3.81" y2="40.005" width="0.254" layer="22"/>
 <wire x1="3.81" y1="40.005" x2="3.81" y2="38.735" width="0.254" layer="22"/>
-<wire x1="3.81" y1="38.735" x2="3.175" y2="38.1" width="0.254" layer="22"/>
-<wire x1="3.175" y1="38.1" x2="3.81" y2="37.465" width="0.254" layer="22"/>
 <wire x1="3.81" y1="37.465" x2="3.81" y2="36.195" width="0.254" layer="22"/>
 <wire x1="3.81" y1="36.195" x2="3.175" y2="35.56" width="0.254" layer="22"/>
-<wire x1="3.175" y1="35.56" x2="3.81" y2="34.925" width="0.254" layer="22"/>
 <wire x1="3.81" y1="34.925" x2="3.81" y2="33.655" width="0.254" layer="22"/>
 <wire x1="3.81" y1="33.655" x2="3.175" y2="33.02" width="0.254" layer="22"/>
 <wire x1="3.175" y1="33.02" x2="3.81" y2="32.385" width="0.254" layer="22"/>
@@ -382,14 +366,9 @@ ProtoShield</text>
 <wire x1="3.81" y1="31.115" x2="3.175" y2="30.48" width="0.254" layer="22"/>
 <wire x1="3.175" y1="30.48" x2="3.81" y2="29.845" width="0.254" layer="22"/>
 <wire x1="3.81" y1="29.845" x2="3.81" y2="28.575" width="0.254" layer="22"/>
-<wire x1="3.81" y1="28.575" x2="3.175" y2="27.94" width="0.254" layer="22"/>
-<wire x1="3.175" y1="27.94" x2="1.905" y2="27.94" width="0.254" layer="22"/>
-<wire x1="1.905" y1="27.94" x2="1.27" y2="28.575" width="0.254" layer="22"/>
 <wire x1="1.27" y1="28.575" x2="1.27" y2="29.845" width="0.254" layer="22"/>
 <wire x1="1.27" y1="29.845" x2="1.905" y2="30.48" width="0.254" layer="22"/>
-<wire x1="1.905" y1="30.48" x2="1.27" y2="31.115" width="0.254" layer="22"/>
 <wire x1="1.27" y1="31.115" x2="1.27" y2="32.385" width="0.254" layer="22"/>
-<wire x1="1.27" y1="32.385" x2="1.905" y2="33.02" width="0.254" layer="22"/>
 <wire x1="1.905" y1="33.02" x2="1.27" y2="33.655" width="0.254" layer="22"/>
 <wire x1="1.27" y1="33.655" x2="1.27" y2="34.925" width="0.254" layer="22"/>
 <wire x1="1.27" y1="34.925" x2="1.905" y2="35.56" width="0.254" layer="22"/>
@@ -399,7 +378,6 @@ ProtoShield</text>
 <wire x1="1.905" y1="38.1" x2="1.27" y2="38.735" width="0.254" layer="22"/>
 <wire x1="1.27" y1="38.735" x2="1.27" y2="40.005" width="0.254" layer="22"/>
 <wire x1="1.27" y1="40.005" x2="1.905" y2="40.64" width="0.254" layer="22"/>
-<wire x1="1.905" y1="40.64" x2="1.27" y2="41.275" width="0.254" layer="22"/>
 <wire x1="1.27" y1="41.275" x2="1.27" y2="42.545" width="0.254" layer="22"/>
 <wire x1="1.27" y1="42.545" x2="1.905" y2="43.18" width="0.254" layer="22"/>
 <wire x1="1.905" y1="43.18" x2="1.27" y2="43.815" width="0.254" layer="22"/>
@@ -410,28 +388,20 @@ ProtoShield</text>
 <wire x1="1.27" y1="47.625" x2="1.905" y2="48.26" width="0.254" layer="22"/>
 <wire x1="6.985" y1="48.26" x2="8.255" y2="48.26" width="0.254" layer="22"/>
 <wire x1="8.255" y1="48.26" x2="8.89" y2="47.625" width="0.254" layer="22"/>
-<wire x1="8.89" y1="47.625" x2="8.89" y2="46.355" width="0.254" layer="22"/>
 <wire x1="8.89" y1="46.355" x2="8.255" y2="45.72" width="0.254" layer="22"/>
 <wire x1="8.255" y1="45.72" x2="8.89" y2="45.085" width="0.254" layer="22"/>
-<wire x1="8.89" y1="45.085" x2="8.89" y2="43.815" width="0.254" layer="22"/>
 <wire x1="8.89" y1="43.815" x2="8.255" y2="43.18" width="0.254" layer="22"/>
 <wire x1="8.255" y1="43.18" x2="8.89" y2="42.545" width="0.254" layer="22"/>
-<wire x1="8.89" y1="42.545" x2="8.89" y2="41.275" width="0.254" layer="22"/>
 <wire x1="8.89" y1="41.275" x2="8.255" y2="40.64" width="0.254" layer="22"/>
 <wire x1="8.255" y1="40.64" x2="8.89" y2="40.005" width="0.254" layer="22"/>
-<wire x1="8.89" y1="40.005" x2="8.89" y2="38.735" width="0.254" layer="22"/>
 <wire x1="8.89" y1="38.735" x2="8.255" y2="38.1" width="0.254" layer="22"/>
 <wire x1="8.255" y1="38.1" x2="8.89" y2="37.465" width="0.254" layer="22"/>
-<wire x1="8.89" y1="37.465" x2="8.89" y2="36.195" width="0.254" layer="22"/>
 <wire x1="8.89" y1="36.195" x2="8.255" y2="35.56" width="0.254" layer="22"/>
 <wire x1="8.255" y1="35.56" x2="8.89" y2="34.925" width="0.254" layer="22"/>
-<wire x1="8.89" y1="34.925" x2="8.89" y2="33.655" width="0.254" layer="22"/>
 <wire x1="8.89" y1="33.655" x2="8.255" y2="33.02" width="0.254" layer="22"/>
 <wire x1="8.255" y1="33.02" x2="8.89" y2="32.385" width="0.254" layer="22"/>
-<wire x1="8.89" y1="32.385" x2="8.89" y2="31.115" width="0.254" layer="22"/>
 <wire x1="8.89" y1="31.115" x2="8.255" y2="30.48" width="0.254" layer="22"/>
 <wire x1="8.255" y1="30.48" x2="8.89" y2="29.845" width="0.254" layer="22"/>
-<wire x1="8.89" y1="29.845" x2="8.89" y2="28.575" width="0.254" layer="22"/>
 <wire x1="8.89" y1="28.575" x2="8.255" y2="27.94" width="0.254" layer="22"/>
 <wire x1="8.255" y1="27.94" x2="6.985" y2="27.94" width="0.254" layer="22"/>
 <wire x1="6.985" y1="27.94" x2="6.35" y2="28.575" width="0.254" layer="22"/>
@@ -458,59 +428,41 @@ ProtoShield</text>
 <wire x1="6.985" y1="45.72" x2="6.35" y2="46.355" width="0.254" layer="22"/>
 <wire x1="6.35" y1="46.355" x2="6.35" y2="47.625" width="0.254" layer="22"/>
 <wire x1="6.35" y1="47.625" x2="6.985" y2="48.26" width="0.254" layer="22"/>
-<wire x1="1.905" y1="25.4" x2="3.175" y2="25.4" width="0.254" layer="22"/>
-<wire x1="3.175" y1="25.4" x2="3.81" y2="24.765" width="0.254" layer="22"/>
 <wire x1="3.81" y1="24.765" x2="3.81" y2="23.495" width="0.254" layer="22"/>
-<wire x1="3.81" y1="23.495" x2="3.175" y2="22.86" width="0.254" layer="22"/>
 <wire x1="3.175" y1="22.86" x2="3.81" y2="22.225" width="0.254" layer="22"/>
 <wire x1="3.81" y1="22.225" x2="3.81" y2="20.955" width="0.254" layer="22"/>
 <wire x1="3.81" y1="20.955" x2="3.175" y2="20.32" width="0.254" layer="22"/>
 <wire x1="3.175" y1="20.32" x2="3.81" y2="19.685" width="0.254" layer="22"/>
 <wire x1="3.81" y1="19.685" x2="3.81" y2="18.415" width="0.254" layer="22"/>
-<wire x1="3.81" y1="18.415" x2="3.175" y2="17.78" width="0.254" layer="22"/>
 <wire x1="3.175" y1="17.78" x2="3.81" y2="17.145" width="0.254" layer="22"/>
 <wire x1="3.81" y1="17.145" x2="3.81" y2="15.875" width="0.254" layer="22"/>
 <wire x1="3.81" y1="15.875" x2="3.175" y2="15.24" width="0.254" layer="22"/>
 <wire x1="3.175" y1="15.24" x2="3.81" y2="14.605" width="0.254" layer="22"/>
 <wire x1="3.81" y1="14.605" x2="3.81" y2="13.335" width="0.254" layer="22"/>
-<wire x1="3.81" y1="13.335" x2="3.175" y2="12.7" width="0.254" layer="22"/>
-<wire x1="3.175" y1="12.7" x2="3.81" y2="12.065" width="0.254" layer="22"/>
 <wire x1="3.81" y1="12.065" x2="3.81" y2="10.795" width="0.254" layer="22"/>
-<wire x1="3.81" y1="10.795" x2="3.175" y2="10.16" width="0.254" layer="22"/>
 <wire x1="3.175" y1="10.16" x2="1.905" y2="10.16" width="0.254" layer="22"/>
 <wire x1="1.905" y1="10.16" x2="1.27" y2="10.795" width="0.254" layer="22"/>
 <wire x1="1.27" y1="10.795" x2="1.27" y2="12.065" width="0.254" layer="22"/>
-<wire x1="1.27" y1="12.065" x2="1.905" y2="12.7" width="0.254" layer="22"/>
 <wire x1="1.905" y1="12.7" x2="1.27" y2="13.335" width="0.254" layer="22"/>
 <wire x1="1.27" y1="13.335" x2="1.27" y2="14.605" width="0.254" layer="22"/>
-<wire x1="1.27" y1="14.605" x2="1.905" y2="15.24" width="0.254" layer="22"/>
 <wire x1="1.905" y1="15.24" x2="1.27" y2="15.875" width="0.254" layer="22"/>
 <wire x1="1.27" y1="15.875" x2="1.27" y2="17.145" width="0.254" layer="22"/>
 <wire x1="1.27" y1="17.145" x2="1.905" y2="17.78" width="0.254" layer="22"/>
-<wire x1="1.905" y1="17.78" x2="1.27" y2="18.415" width="0.254" layer="22"/>
 <wire x1="1.27" y1="18.415" x2="1.27" y2="19.685" width="0.254" layer="22"/>
-<wire x1="1.27" y1="19.685" x2="1.905" y2="20.32" width="0.254" layer="22"/>
 <wire x1="1.905" y1="20.32" x2="1.27" y2="20.955" width="0.254" layer="22"/>
 <wire x1="1.27" y1="20.955" x2="1.27" y2="22.225" width="0.254" layer="22"/>
 <wire x1="1.27" y1="22.225" x2="1.905" y2="22.86" width="0.254" layer="22"/>
-<wire x1="1.905" y1="22.86" x2="1.27" y2="23.495" width="0.254" layer="22"/>
 <wire x1="1.27" y1="23.495" x2="1.27" y2="24.765" width="0.254" layer="22"/>
-<wire x1="1.27" y1="24.765" x2="1.905" y2="25.4" width="0.254" layer="22"/>
 <wire x1="6.985" y1="25.4" x2="8.255" y2="25.4" width="0.254" layer="22"/>
 <wire x1="8.255" y1="25.4" x2="8.89" y2="24.765" width="0.254" layer="22"/>
-<wire x1="8.89" y1="24.765" x2="8.89" y2="23.495" width="0.254" layer="22"/>
 <wire x1="8.89" y1="23.495" x2="8.255" y2="22.86" width="0.254" layer="22"/>
 <wire x1="8.255" y1="22.86" x2="8.89" y2="22.225" width="0.254" layer="22"/>
-<wire x1="8.89" y1="22.225" x2="8.89" y2="20.955" width="0.254" layer="22"/>
 <wire x1="8.89" y1="20.955" x2="8.255" y2="20.32" width="0.254" layer="22"/>
 <wire x1="8.255" y1="20.32" x2="8.89" y2="19.685" width="0.254" layer="22"/>
-<wire x1="8.89" y1="19.685" x2="8.89" y2="18.415" width="0.254" layer="22"/>
 <wire x1="8.89" y1="18.415" x2="8.255" y2="17.78" width="0.254" layer="22"/>
 <wire x1="8.255" y1="17.78" x2="8.89" y2="17.145" width="0.254" layer="22"/>
-<wire x1="8.89" y1="17.145" x2="8.89" y2="15.875" width="0.254" layer="22"/>
 <wire x1="8.89" y1="15.875" x2="8.255" y2="15.24" width="0.254" layer="22"/>
 <wire x1="8.255" y1="15.24" x2="8.89" y2="14.605" width="0.254" layer="22"/>
-<wire x1="8.89" y1="14.605" x2="8.89" y2="13.335" width="0.254" layer="22"/>
 <wire x1="8.89" y1="13.335" x2="8.255" y2="12.7" width="0.254" layer="22"/>
 <wire x1="8.255" y1="12.7" x2="8.89" y2="12.065" width="0.254" layer="22"/>
 <wire x1="8.89" y1="12.065" x2="8.89" y2="10.795" width="0.254" layer="22"/>
@@ -585,9 +537,7 @@ ProtoShield</text>
 <wire x1="44.45" y1="28.575" x2="44.45" y2="29.845" width="0.254" layer="22"/>
 <wire x1="44.45" y1="29.845" x2="45.085" y2="30.48" width="0.254" layer="22"/>
 <wire x1="50.165" y1="30.48" x2="51.435" y2="30.48" width="0.254" layer="22"/>
-<wire x1="51.435" y1="30.48" x2="52.07" y2="29.845" width="0.254" layer="22"/>
 <wire x1="52.07" y1="29.845" x2="52.07" y2="28.575" width="0.254" layer="22"/>
-<wire x1="52.07" y1="28.575" x2="51.435" y2="27.94" width="0.254" layer="22"/>
 <wire x1="51.435" y1="27.94" x2="52.07" y2="27.305" width="0.254" layer="22"/>
 <wire x1="52.07" y1="27.305" x2="52.07" y2="26.035" width="0.254" layer="22"/>
 <wire x1="52.07" y1="26.035" x2="51.435" y2="25.4" width="0.254" layer="22"/>
@@ -608,7 +558,6 @@ ProtoShield</text>
 <wire x1="52.07" y1="13.335" x2="51.435" y2="12.7" width="0.254" layer="22"/>
 <wire x1="51.435" y1="12.7" x2="52.07" y2="12.065" width="0.254" layer="22"/>
 <wire x1="52.07" y1="12.065" x2="52.07" y2="10.795" width="0.254" layer="22"/>
-<wire x1="52.07" y1="10.795" x2="51.435" y2="10.16" width="0.254" layer="22"/>
 <wire x1="51.435" y1="10.16" x2="50.165" y2="10.16" width="0.254" layer="22"/>
 <wire x1="50.165" y1="10.16" x2="49.53" y2="10.795" width="0.254" layer="22"/>
 <wire x1="49.53" y1="10.795" x2="49.53" y2="12.065" width="0.254" layer="22"/>
@@ -625,7 +574,6 @@ ProtoShield</text>
 <wire x1="50.165" y1="20.32" x2="49.53" y2="20.955" width="0.254" layer="22"/>
 <wire x1="49.53" y1="20.955" x2="49.53" y2="22.225" width="0.254" layer="22"/>
 <wire x1="49.53" y1="22.225" x2="50.165" y2="22.86" width="0.254" layer="22"/>
-<wire x1="50.165" y1="22.86" x2="49.53" y2="23.495" width="0.254" layer="22"/>
 <wire x1="49.53" y1="23.495" x2="49.53" y2="24.765" width="0.254" layer="22"/>
 <wire x1="49.53" y1="24.765" x2="50.165" y2="25.4" width="0.254" layer="22"/>
 <wire x1="50.165" y1="25.4" x2="49.53" y2="26.035" width="0.254" layer="22"/>
@@ -634,78 +582,74 @@ ProtoShield</text>
 <wire x1="50.165" y1="27.94" x2="49.53" y2="28.575" width="0.254" layer="22"/>
 <wire x1="49.53" y1="28.575" x2="49.53" y2="29.845" width="0.254" layer="22"/>
 <wire x1="49.53" y1="29.845" x2="50.165" y2="30.48" width="0.254" layer="22"/>
-<wire x1="46.355" y1="57.15" x2="46.99" y2="56.515" width="0.254" layer="22"/>
-<wire x1="46.99" y1="56.515" x2="46.99" y2="55.245" width="0.254" layer="22"/>
-<wire x1="46.99" y1="55.245" x2="46.355" y2="54.61" width="0.254" layer="22"/>
-<wire x1="46.355" y1="54.61" x2="46.99" y2="53.975" width="0.254" layer="22"/>
-<wire x1="46.99" y1="53.975" x2="46.99" y2="52.705" width="0.254" layer="22"/>
-<wire x1="46.99" y1="52.705" x2="46.355" y2="52.07" width="0.254" layer="22"/>
-<wire x1="46.355" y1="52.07" x2="46.99" y2="51.435" width="0.254" layer="22"/>
-<wire x1="46.99" y1="51.435" x2="46.99" y2="50.165" width="0.254" layer="22"/>
-<wire x1="46.99" y1="50.165" x2="46.355" y2="49.53" width="0.254" layer="22"/>
-<wire x1="46.355" y1="49.53" x2="46.99" y2="48.895" width="0.254" layer="22"/>
-<wire x1="46.99" y1="48.895" x2="46.99" y2="47.625" width="0.254" layer="22"/>
-<wire x1="46.99" y1="47.625" x2="46.355" y2="46.99" width="0.254" layer="22"/>
-<wire x1="46.355" y1="46.99" x2="46.99" y2="46.355" width="0.254" layer="22"/>
-<wire x1="46.99" y1="46.355" x2="46.99" y2="45.085" width="0.254" layer="22"/>
-<wire x1="46.99" y1="45.085" x2="46.355" y2="44.45" width="0.254" layer="22"/>
-<wire x1="46.355" y1="44.45" x2="46.99" y2="43.815" width="0.254" layer="22"/>
-<wire x1="46.99" y1="43.815" x2="46.99" y2="42.545" width="0.254" layer="22"/>
-<wire x1="46.99" y1="42.545" x2="46.355" y2="41.91" width="0.254" layer="22"/>
-<wire x1="46.355" y1="41.91" x2="46.99" y2="41.275" width="0.254" layer="22"/>
-<wire x1="46.99" y1="41.275" x2="46.99" y2="40.005" width="0.254" layer="22"/>
-<wire x1="46.99" y1="40.005" x2="46.355" y2="39.37" width="0.254" layer="22"/>
-<wire x1="46.355" y1="39.37" x2="46.99" y2="38.735" width="0.254" layer="22"/>
-<wire x1="46.99" y1="38.735" x2="46.99" y2="37.465" width="0.254" layer="22"/>
-<wire x1="46.99" y1="37.465" x2="46.355" y2="36.83" width="0.254" layer="22"/>
-<wire x1="46.355" y1="36.83" x2="46.99" y2="36.195" width="0.254" layer="22"/>
-<wire x1="46.99" y1="36.195" x2="46.99" y2="34.925" width="0.254" layer="22"/>
-<wire x1="46.99" y1="34.925" x2="46.355" y2="34.29" width="0.254" layer="22"/>
-<wire x1="46.355" y1="34.29" x2="46.99" y2="33.655" width="0.254" layer="22"/>
-<wire x1="46.99" y1="33.655" x2="46.99" y2="32.385" width="0.254" layer="22"/>
-<wire x1="46.99" y1="32.385" x2="46.355" y2="31.75" width="0.254" layer="22"/>
-<wire x1="45.085" y1="31.75" x2="44.45" y2="32.385" width="0.254" layer="22"/>
-<wire x1="44.45" y1="32.385" x2="44.45" y2="33.655" width="0.254" layer="22"/>
-<wire x1="44.45" y1="33.655" x2="45.085" y2="34.29" width="0.254" layer="22"/>
-<wire x1="45.085" y1="34.29" x2="44.45" y2="34.925" width="0.254" layer="22"/>
-<wire x1="44.45" y1="34.925" x2="44.45" y2="36.195" width="0.254" layer="22"/>
-<wire x1="44.45" y1="36.195" x2="45.085" y2="36.83" width="0.254" layer="22"/>
-<wire x1="45.085" y1="36.83" x2="44.45" y2="37.465" width="0.254" layer="22"/>
-<wire x1="44.45" y1="37.465" x2="44.45" y2="38.735" width="0.254" layer="22"/>
-<wire x1="44.45" y1="38.735" x2="45.085" y2="39.37" width="0.254" layer="22"/>
-<wire x1="45.085" y1="39.37" x2="44.45" y2="40.005" width="0.254" layer="22"/>
-<wire x1="44.45" y1="40.005" x2="44.45" y2="41.275" width="0.254" layer="22"/>
-<wire x1="44.45" y1="41.275" x2="45.085" y2="41.91" width="0.254" layer="22"/>
-<wire x1="45.085" y1="41.91" x2="44.45" y2="42.545" width="0.254" layer="22"/>
-<wire x1="44.45" y1="42.545" x2="44.45" y2="43.815" width="0.254" layer="22"/>
-<wire x1="44.45" y1="43.815" x2="45.085" y2="44.45" width="0.254" layer="22"/>
-<wire x1="45.085" y1="44.45" x2="44.45" y2="45.085" width="0.254" layer="22"/>
-<wire x1="44.45" y1="45.085" x2="44.45" y2="46.355" width="0.254" layer="22"/>
-<wire x1="44.45" y1="46.355" x2="45.085" y2="46.99" width="0.254" layer="22"/>
-<wire x1="45.085" y1="46.99" x2="44.45" y2="47.625" width="0.254" layer="22"/>
-<wire x1="44.45" y1="47.625" x2="44.45" y2="48.895" width="0.254" layer="22"/>
-<wire x1="44.45" y1="48.895" x2="45.085" y2="49.53" width="0.254" layer="22"/>
-<wire x1="45.085" y1="49.53" x2="44.45" y2="50.165" width="0.254" layer="22"/>
-<wire x1="44.45" y1="50.165" x2="44.45" y2="51.435" width="0.254" layer="22"/>
-<wire x1="44.45" y1="51.435" x2="45.085" y2="52.07" width="0.254" layer="22"/>
-<wire x1="45.085" y1="52.07" x2="44.45" y2="52.705" width="0.254" layer="22"/>
-<wire x1="44.45" y1="52.705" x2="44.45" y2="53.975" width="0.254" layer="22"/>
-<wire x1="44.45" y1="53.975" x2="45.085" y2="54.61" width="0.254" layer="22"/>
-<wire x1="45.085" y1="54.61" x2="44.45" y2="55.245" width="0.254" layer="22"/>
-<wire x1="44.45" y1="55.245" x2="44.45" y2="56.515" width="0.254" layer="22"/>
-<wire x1="44.45" y1="56.515" x2="45.085" y2="57.15" width="0.254" layer="22"/>
-<wire x1="51.435" y1="57.15" x2="52.07" y2="56.515" width="0.254" layer="22"/>
+<wire x1="46.355" y1="58.42" x2="46.99" y2="57.785" width="0.254" layer="22"/>
+<wire x1="46.99" y1="57.785" x2="46.99" y2="56.515" width="0.254" layer="22"/>
+<wire x1="46.99" y1="56.515" x2="46.355" y2="55.88" width="0.254" layer="22"/>
+<wire x1="46.355" y1="55.88" x2="46.99" y2="55.245" width="0.254" layer="22"/>
+<wire x1="46.99" y1="55.245" x2="46.99" y2="53.975" width="0.254" layer="22"/>
+<wire x1="46.99" y1="53.975" x2="46.355" y2="53.34" width="0.254" layer="22"/>
+<wire x1="46.355" y1="53.34" x2="46.99" y2="52.705" width="0.254" layer="22"/>
+<wire x1="46.99" y1="52.705" x2="46.99" y2="51.435" width="0.254" layer="22"/>
+<wire x1="46.99" y1="51.435" x2="46.355" y2="50.8" width="0.254" layer="22"/>
+<wire x1="46.355" y1="50.8" x2="46.99" y2="50.165" width="0.254" layer="22"/>
+<wire x1="46.99" y1="50.165" x2="46.99" y2="48.895" width="0.254" layer="22"/>
+<wire x1="46.99" y1="48.895" x2="46.355" y2="48.26" width="0.254" layer="22"/>
+<wire x1="46.355" y1="48.26" x2="46.99" y2="47.625" width="0.254" layer="22"/>
+<wire x1="46.99" y1="47.625" x2="46.99" y2="46.355" width="0.254" layer="22"/>
+<wire x1="46.99" y1="46.355" x2="46.355" y2="45.72" width="0.254" layer="22"/>
+<wire x1="46.355" y1="45.72" x2="46.99" y2="45.085" width="0.254" layer="22"/>
+<wire x1="46.99" y1="45.085" x2="46.99" y2="43.815" width="0.254" layer="22"/>
+<wire x1="46.99" y1="43.815" x2="46.355" y2="43.18" width="0.254" layer="22"/>
+<wire x1="46.355" y1="43.18" x2="46.99" y2="42.545" width="0.254" layer="22"/>
+<wire x1="46.99" y1="42.545" x2="46.99" y2="41.275" width="0.254" layer="22"/>
+<wire x1="46.99" y1="41.275" x2="46.355" y2="40.64" width="0.254" layer="22"/>
+<wire x1="46.355" y1="40.64" x2="46.99" y2="40.005" width="0.254" layer="22"/>
+<wire x1="46.99" y1="40.005" x2="46.99" y2="38.735" width="0.254" layer="22"/>
+<wire x1="46.99" y1="38.735" x2="46.355" y2="38.1" width="0.254" layer="22"/>
+<wire x1="46.355" y1="38.1" x2="46.99" y2="37.465" width="0.254" layer="22"/>
+<wire x1="46.99" y1="37.465" x2="46.99" y2="36.195" width="0.254" layer="22"/>
+<wire x1="46.99" y1="36.195" x2="46.355" y2="35.56" width="0.254" layer="22"/>
+<wire x1="46.355" y1="35.56" x2="46.99" y2="34.925" width="0.254" layer="22"/>
+<wire x1="46.99" y1="34.925" x2="46.99" y2="33.655" width="0.254" layer="22"/>
+<wire x1="46.99" y1="33.655" x2="46.355" y2="33.02" width="0.254" layer="22"/>
+<wire x1="45.085" y1="33.02" x2="44.45" y2="33.655" width="0.254" layer="22"/>
+<wire x1="44.45" y1="33.655" x2="44.45" y2="34.925" width="0.254" layer="22"/>
+<wire x1="44.45" y1="34.925" x2="45.085" y2="35.56" width="0.254" layer="22"/>
+<wire x1="45.085" y1="35.56" x2="44.45" y2="36.195" width="0.254" layer="22"/>
+<wire x1="44.45" y1="36.195" x2="44.45" y2="37.465" width="0.254" layer="22"/>
+<wire x1="44.45" y1="37.465" x2="45.085" y2="38.1" width="0.254" layer="22"/>
+<wire x1="45.085" y1="38.1" x2="44.45" y2="38.735" width="0.254" layer="22"/>
+<wire x1="44.45" y1="38.735" x2="44.45" y2="40.005" width="0.254" layer="22"/>
+<wire x1="44.45" y1="40.005" x2="45.085" y2="40.64" width="0.254" layer="22"/>
+<wire x1="45.085" y1="40.64" x2="44.45" y2="41.275" width="0.254" layer="22"/>
+<wire x1="44.45" y1="41.275" x2="44.45" y2="42.545" width="0.254" layer="22"/>
+<wire x1="44.45" y1="42.545" x2="45.085" y2="43.18" width="0.254" layer="22"/>
+<wire x1="45.085" y1="43.18" x2="44.45" y2="43.815" width="0.254" layer="22"/>
+<wire x1="44.45" y1="43.815" x2="44.45" y2="45.085" width="0.254" layer="22"/>
+<wire x1="44.45" y1="45.085" x2="45.085" y2="45.72" width="0.254" layer="22"/>
+<wire x1="45.085" y1="45.72" x2="44.45" y2="46.355" width="0.254" layer="22"/>
+<wire x1="44.45" y1="46.355" x2="44.45" y2="47.625" width="0.254" layer="22"/>
+<wire x1="44.45" y1="47.625" x2="45.085" y2="48.26" width="0.254" layer="22"/>
+<wire x1="45.085" y1="48.26" x2="44.45" y2="48.895" width="0.254" layer="22"/>
+<wire x1="44.45" y1="48.895" x2="44.45" y2="50.165" width="0.254" layer="22"/>
+<wire x1="44.45" y1="50.165" x2="45.085" y2="50.8" width="0.254" layer="22"/>
+<wire x1="45.085" y1="50.8" x2="44.45" y2="51.435" width="0.254" layer="22"/>
+<wire x1="44.45" y1="51.435" x2="44.45" y2="52.705" width="0.254" layer="22"/>
+<wire x1="44.45" y1="52.705" x2="45.085" y2="53.34" width="0.254" layer="22"/>
+<wire x1="45.085" y1="53.34" x2="44.45" y2="53.975" width="0.254" layer="22"/>
+<wire x1="44.45" y1="53.975" x2="44.45" y2="55.245" width="0.254" layer="22"/>
+<wire x1="44.45" y1="55.245" x2="45.085" y2="55.88" width="0.254" layer="22"/>
+<wire x1="45.085" y1="55.88" x2="44.45" y2="56.515" width="0.254" layer="22"/>
+<wire x1="44.45" y1="56.515" x2="44.45" y2="57.785" width="0.254" layer="22"/>
+<wire x1="44.45" y1="57.785" x2="45.085" y2="58.42" width="0.254" layer="22"/>
 <wire x1="52.07" y1="56.515" x2="52.07" y2="55.245" width="0.254" layer="22"/>
 <wire x1="52.07" y1="55.245" x2="51.435" y2="54.61" width="0.254" layer="22"/>
 <wire x1="51.435" y1="54.61" x2="52.07" y2="53.975" width="0.254" layer="22"/>
 <wire x1="52.07" y1="53.975" x2="52.07" y2="52.705" width="0.254" layer="22"/>
 <wire x1="52.07" y1="52.705" x2="51.435" y2="52.07" width="0.254" layer="22"/>
 <wire x1="51.435" y1="52.07" x2="52.07" y2="51.435" width="0.254" layer="22"/>
-<wire x1="52.07" y1="51.435" x2="52.07" y2="50.165" width="0.254" layer="22"/>
-<wire x1="52.07" y1="50.165" x2="51.435" y2="49.53" width="0.254" layer="22"/>
 <wire x1="51.435" y1="49.53" x2="52.07" y2="48.895" width="0.254" layer="22"/>
 <wire x1="52.07" y1="48.895" x2="52.07" y2="47.625" width="0.254" layer="22"/>
-<wire x1="52.07" y1="47.625" x2="51.435" y2="46.99" width="0.254" layer="22"/>
 <wire x1="51.435" y1="46.99" x2="52.07" y2="46.355" width="0.254" layer="22"/>
 <wire x1="52.07" y1="46.355" x2="52.07" y2="45.085" width="0.254" layer="22"/>
 <wire x1="52.07" y1="45.085" x2="51.435" y2="44.45" width="0.254" layer="22"/>
@@ -726,20 +670,13 @@ ProtoShield</text>
 <wire x1="52.07" y1="32.385" x2="51.435" y2="31.75" width="0.254" layer="22"/>
 <wire x1="50.165" y1="31.75" x2="49.53" y2="32.385" width="0.254" layer="22"/>
 <wire x1="49.53" y1="32.385" x2="49.53" y2="33.655" width="0.254" layer="22"/>
-<wire x1="49.53" y1="33.655" x2="50.165" y2="34.29" width="0.254" layer="22"/>
-<wire x1="50.165" y1="34.29" x2="49.53" y2="34.925" width="0.254" layer="22"/>
 <wire x1="49.53" y1="34.925" x2="49.53" y2="36.195" width="0.254" layer="22"/>
 <wire x1="49.53" y1="36.195" x2="50.165" y2="36.83" width="0.254" layer="22"/>
-<wire x1="50.165" y1="36.83" x2="49.53" y2="37.465" width="0.254" layer="22"/>
-<wire x1="49.53" y1="37.465" x2="49.53" y2="38.735" width="0.254" layer="22"/>
-<wire x1="49.53" y1="38.735" x2="50.165" y2="39.37" width="0.254" layer="22"/>
-<wire x1="50.165" y1="39.37" x2="49.53" y2="40.005" width="0.254" layer="22"/>
 <wire x1="49.53" y1="40.005" x2="49.53" y2="41.275" width="0.254" layer="22"/>
 <wire x1="49.53" y1="41.275" x2="50.165" y2="41.91" width="0.254" layer="22"/>
 <wire x1="50.165" y1="41.91" x2="49.53" y2="42.545" width="0.254" layer="22"/>
 <wire x1="49.53" y1="42.545" x2="49.53" y2="43.815" width="0.254" layer="22"/>
 <wire x1="49.53" y1="43.815" x2="50.165" y2="44.45" width="0.254" layer="22"/>
-<wire x1="50.165" y1="44.45" x2="49.53" y2="45.085" width="0.254" layer="22"/>
 <wire x1="49.53" y1="45.085" x2="49.53" y2="46.355" width="0.254" layer="22"/>
 <wire x1="49.53" y1="46.355" x2="50.165" y2="46.99" width="0.254" layer="22"/>
 <wire x1="50.165" y1="46.99" x2="49.53" y2="47.625" width="0.254" layer="22"/>
@@ -753,11 +690,8 @@ ProtoShield</text>
 <wire x1="49.53" y1="53.975" x2="50.165" y2="54.61" width="0.254" layer="22"/>
 <wire x1="50.165" y1="54.61" x2="49.53" y2="55.245" width="0.254" layer="22"/>
 <wire x1="49.53" y1="55.245" x2="49.53" y2="56.515" width="0.254" layer="22"/>
-<wire x1="49.53" y1="56.515" x2="50.165" y2="57.15" width="0.254" layer="22"/>
-<wire x1="45.085" y1="57.15" x2="46.355" y2="57.15" width="0.254" layer="22"/>
-<wire x1="50.165" y1="57.15" x2="51.435" y2="57.15" width="0.254" layer="22"/>
-<wire x1="45.085" y1="31.75" x2="46.355" y2="31.75" width="0.254" layer="22"/>
-<wire x1="50.165" y1="31.75" x2="51.435" y2="31.75" width="0.254" layer="22"/>
+<wire x1="45.085" y1="58.42" x2="46.355" y2="58.42" width="0.254" layer="22"/>
+<wire x1="45.085" y1="33.02" x2="46.355" y2="33.02" width="0.254" layer="22"/>
 <text x="18.034" y="64.262" size="0.8128" layer="21" font="vector" ratio="15">RXI</text>
 <text x="20.574" y="64.262" size="0.8128" layer="21" font="vector" ratio="15">TXO</text>
 <text x="23.241" y="64.262" size="0.8128" layer="21" font="vector" ratio="15">GND</text>
@@ -768,263 +702,9 @@ ProtoShield</text>
 <wire x1="31.75" y1="66.04" x2="29.718" y2="64.008" width="0.254" layer="22"/>
 <wire x1="29.718" y1="64.008" x2="16.002" y2="64.008" width="0.254" layer="22"/>
 <wire x1="16.002" y1="64.008" x2="13.97" y2="66.04" width="0.254" layer="22"/>
-<text x="8.509" y="0.889" size="0.8128" layer="21" font="vector" ratio="15">330</text>
-<text x="36.449" y="0.889" size="0.8128" layer="21" font="vector" ratio="15">330</text>
-<text x="26.67" y="0.889" size="0.8128" layer="21" font="vector" ratio="15">10k</text>
-<wire x1="41.275" y1="60.96" x2="42.545" y2="60.96" width="0.254" layer="22"/>
-<wire x1="42.545" y1="60.96" x2="43.18" y2="60.325" width="0.254" layer="22"/>
-<wire x1="43.18" y1="60.325" x2="43.18" y2="59.055" width="0.254" layer="22"/>
-<wire x1="43.18" y1="59.055" x2="42.545" y2="58.42" width="0.254" layer="22"/>
-<wire x1="42.545" y1="58.42" x2="43.18" y2="57.785" width="0.254" layer="22"/>
-<wire x1="43.18" y1="57.785" x2="43.18" y2="56.515" width="0.254" layer="22"/>
-<wire x1="43.18" y1="56.515" x2="42.545" y2="55.88" width="0.254" layer="22"/>
-<wire x1="42.545" y1="55.88" x2="43.18" y2="55.245" width="0.254" layer="22"/>
-<wire x1="43.18" y1="55.245" x2="43.18" y2="53.975" width="0.254" layer="22"/>
-<wire x1="43.18" y1="53.975" x2="42.545" y2="53.34" width="0.254" layer="22"/>
-<wire x1="42.545" y1="53.34" x2="43.18" y2="52.705" width="0.254" layer="22"/>
-<wire x1="43.18" y1="52.705" x2="43.18" y2="51.435" width="0.254" layer="22"/>
-<wire x1="43.18" y1="51.435" x2="42.545" y2="50.8" width="0.254" layer="22"/>
-<wire x1="42.545" y1="50.8" x2="43.18" y2="50.165" width="0.254" layer="22"/>
-<wire x1="43.18" y1="50.165" x2="43.18" y2="48.895" width="0.254" layer="22"/>
-<wire x1="43.18" y1="48.895" x2="42.545" y2="48.26" width="0.254" layer="22"/>
-<wire x1="42.545" y1="48.26" x2="43.18" y2="47.625" width="0.254" layer="22"/>
-<wire x1="43.18" y1="47.625" x2="43.18" y2="46.355" width="0.254" layer="22"/>
-<wire x1="43.18" y1="46.355" x2="42.545" y2="45.72" width="0.254" layer="22"/>
-<wire x1="42.545" y1="45.72" x2="43.18" y2="45.085" width="0.254" layer="22"/>
-<wire x1="43.18" y1="45.085" x2="43.18" y2="43.815" width="0.254" layer="22"/>
-<wire x1="43.18" y1="43.815" x2="42.545" y2="43.18" width="0.254" layer="22"/>
-<wire x1="42.545" y1="43.18" x2="43.18" y2="42.545" width="0.254" layer="22"/>
-<wire x1="43.18" y1="42.545" x2="43.18" y2="41.275" width="0.254" layer="22"/>
-<wire x1="43.18" y1="41.275" x2="42.545" y2="40.64" width="0.254" layer="22"/>
-<wire x1="42.545" y1="40.64" x2="43.18" y2="40.005" width="0.254" layer="22"/>
-<wire x1="43.18" y1="40.005" x2="43.18" y2="38.735" width="0.254" layer="22"/>
-<wire x1="43.18" y1="38.735" x2="42.545" y2="38.1" width="0.254" layer="22"/>
-<wire x1="42.545" y1="38.1" x2="43.18" y2="37.465" width="0.254" layer="22"/>
-<wire x1="43.18" y1="37.465" x2="43.18" y2="36.195" width="0.254" layer="22"/>
-<wire x1="43.18" y1="36.195" x2="42.545" y2="35.56" width="0.254" layer="22"/>
-<wire x1="42.545" y1="35.56" x2="43.18" y2="34.925" width="0.254" layer="22"/>
-<wire x1="43.18" y1="34.925" x2="43.18" y2="33.655" width="0.254" layer="22"/>
-<wire x1="43.18" y1="33.655" x2="42.545" y2="33.02" width="0.254" layer="22"/>
-<wire x1="42.545" y1="33.02" x2="43.18" y2="32.385" width="0.254" layer="22"/>
-<wire x1="43.18" y1="32.385" x2="43.18" y2="31.115" width="0.254" layer="22"/>
-<wire x1="43.18" y1="31.115" x2="42.545" y2="30.48" width="0.254" layer="22"/>
-<wire x1="42.545" y1="30.48" x2="43.18" y2="29.845" width="0.254" layer="22"/>
-<wire x1="43.18" y1="29.845" x2="43.18" y2="28.575" width="0.254" layer="22"/>
-<wire x1="43.18" y1="28.575" x2="42.545" y2="27.94" width="0.254" layer="22"/>
-<wire x1="42.545" y1="27.94" x2="43.18" y2="27.305" width="0.254" layer="22"/>
-<wire x1="43.18" y1="27.305" x2="43.18" y2="26.035" width="0.254" layer="22"/>
-<wire x1="43.18" y1="26.035" x2="42.545" y2="25.4" width="0.254" layer="22"/>
-<wire x1="42.545" y1="25.4" x2="43.18" y2="24.765" width="0.254" layer="22"/>
-<wire x1="43.18" y1="24.765" x2="43.18" y2="23.495" width="0.254" layer="22"/>
-<wire x1="43.18" y1="23.495" x2="42.545" y2="22.86" width="0.254" layer="22"/>
-<wire x1="42.545" y1="22.86" x2="43.18" y2="22.225" width="0.254" layer="22"/>
-<wire x1="43.18" y1="22.225" x2="43.18" y2="20.955" width="0.254" layer="22"/>
-<wire x1="43.18" y1="20.955" x2="42.545" y2="20.32" width="0.254" layer="22"/>
-<wire x1="42.545" y1="20.32" x2="43.18" y2="19.685" width="0.254" layer="22"/>
-<wire x1="43.18" y1="19.685" x2="43.18" y2="18.415" width="0.254" layer="22"/>
-<wire x1="43.18" y1="18.415" x2="42.545" y2="17.78" width="0.254" layer="22"/>
-<wire x1="42.545" y1="17.78" x2="43.18" y2="17.145" width="0.254" layer="22"/>
-<wire x1="43.18" y1="17.145" x2="43.18" y2="15.875" width="0.254" layer="22"/>
-<wire x1="43.18" y1="15.875" x2="42.545" y2="15.24" width="0.254" layer="22"/>
-<wire x1="42.545" y1="15.24" x2="43.18" y2="14.605" width="0.254" layer="22"/>
-<wire x1="43.18" y1="14.605" x2="43.18" y2="13.335" width="0.254" layer="22"/>
-<wire x1="43.18" y1="13.335" x2="42.545" y2="12.7" width="0.254" layer="22"/>
-<wire x1="12.065" y1="12.7" x2="10.795" y2="12.7" width="0.254" layer="22"/>
-<wire x1="10.795" y1="12.7" x2="10.16" y2="13.335" width="0.254" layer="22"/>
-<wire x1="10.16" y1="13.335" x2="10.16" y2="14.605" width="0.254" layer="22"/>
-<wire x1="10.16" y1="14.605" x2="10.795" y2="15.24" width="0.254" layer="22"/>
-<wire x1="10.795" y1="15.24" x2="10.16" y2="15.875" width="0.254" layer="22"/>
-<wire x1="10.16" y1="15.875" x2="10.16" y2="17.145" width="0.254" layer="22"/>
-<wire x1="10.16" y1="17.145" x2="10.795" y2="17.78" width="0.254" layer="22"/>
-<wire x1="10.795" y1="17.78" x2="10.16" y2="18.415" width="0.254" layer="22"/>
-<wire x1="10.16" y1="18.415" x2="10.16" y2="19.685" width="0.254" layer="22"/>
-<wire x1="10.16" y1="19.685" x2="10.795" y2="20.32" width="0.254" layer="22"/>
-<wire x1="10.795" y1="20.32" x2="10.16" y2="20.955" width="0.254" layer="22"/>
-<wire x1="10.16" y1="20.955" x2="10.16" y2="22.225" width="0.254" layer="22"/>
-<wire x1="10.16" y1="22.225" x2="10.795" y2="22.86" width="0.254" layer="22"/>
-<wire x1="10.795" y1="22.86" x2="10.16" y2="23.495" width="0.254" layer="22"/>
-<wire x1="10.16" y1="23.495" x2="10.16" y2="24.765" width="0.254" layer="22"/>
-<wire x1="10.16" y1="24.765" x2="10.795" y2="25.4" width="0.254" layer="22"/>
-<wire x1="10.795" y1="25.4" x2="10.16" y2="26.035" width="0.254" layer="22"/>
-<wire x1="10.16" y1="26.035" x2="10.16" y2="27.305" width="0.254" layer="22"/>
-<wire x1="10.16" y1="27.305" x2="10.795" y2="27.94" width="0.254" layer="22"/>
-<wire x1="10.795" y1="27.94" x2="10.16" y2="28.575" width="0.254" layer="22"/>
-<wire x1="10.16" y1="28.575" x2="10.16" y2="29.845" width="0.254" layer="22"/>
-<wire x1="10.16" y1="29.845" x2="10.795" y2="30.48" width="0.254" layer="22"/>
-<wire x1="10.795" y1="30.48" x2="10.16" y2="31.115" width="0.254" layer="22"/>
-<wire x1="10.16" y1="31.115" x2="10.16" y2="32.385" width="0.254" layer="22"/>
-<wire x1="10.16" y1="32.385" x2="10.795" y2="33.02" width="0.254" layer="22"/>
-<wire x1="10.795" y1="33.02" x2="10.16" y2="33.655" width="0.254" layer="22"/>
-<wire x1="10.16" y1="33.655" x2="10.16" y2="34.925" width="0.254" layer="22"/>
-<wire x1="10.16" y1="34.925" x2="10.795" y2="35.56" width="0.254" layer="22"/>
-<wire x1="10.795" y1="35.56" x2="10.16" y2="36.195" width="0.254" layer="22"/>
-<wire x1="10.16" y1="36.195" x2="10.16" y2="37.465" width="0.254" layer="22"/>
-<wire x1="10.16" y1="37.465" x2="10.795" y2="38.1" width="0.254" layer="22"/>
-<wire x1="10.795" y1="38.1" x2="10.16" y2="38.735" width="0.254" layer="22"/>
-<wire x1="10.16" y1="38.735" x2="10.16" y2="40.005" width="0.254" layer="22"/>
-<wire x1="10.16" y1="40.005" x2="10.795" y2="40.64" width="0.254" layer="22"/>
-<wire x1="10.795" y1="40.64" x2="10.16" y2="41.275" width="0.254" layer="22"/>
-<wire x1="10.16" y1="41.275" x2="10.16" y2="42.545" width="0.254" layer="22"/>
-<wire x1="10.16" y1="42.545" x2="10.795" y2="43.18" width="0.254" layer="22"/>
-<wire x1="10.795" y1="43.18" x2="10.16" y2="43.815" width="0.254" layer="22"/>
-<wire x1="10.16" y1="43.815" x2="10.16" y2="45.085" width="0.254" layer="22"/>
-<wire x1="10.16" y1="45.085" x2="10.795" y2="45.72" width="0.254" layer="22"/>
-<wire x1="10.795" y1="45.72" x2="10.16" y2="46.355" width="0.254" layer="22"/>
-<wire x1="10.16" y1="46.355" x2="10.16" y2="47.625" width="0.254" layer="22"/>
-<wire x1="10.16" y1="47.625" x2="10.795" y2="48.26" width="0.254" layer="22"/>
-<wire x1="10.795" y1="48.26" x2="10.16" y2="48.895" width="0.254" layer="22"/>
-<wire x1="10.16" y1="48.895" x2="10.16" y2="50.165" width="0.254" layer="22"/>
-<wire x1="10.16" y1="50.165" x2="10.795" y2="50.8" width="0.254" layer="22"/>
-<wire x1="10.795" y1="50.8" x2="10.16" y2="51.435" width="0.254" layer="22"/>
-<wire x1="10.16" y1="51.435" x2="10.16" y2="52.705" width="0.254" layer="22"/>
-<wire x1="10.16" y1="52.705" x2="10.795" y2="53.34" width="0.254" layer="22"/>
-<wire x1="10.795" y1="53.34" x2="10.16" y2="53.975" width="0.254" layer="22"/>
-<wire x1="10.16" y1="53.975" x2="10.16" y2="55.245" width="0.254" layer="22"/>
-<wire x1="10.16" y1="55.245" x2="10.795" y2="55.88" width="0.254" layer="22"/>
-<wire x1="10.795" y1="55.88" x2="10.16" y2="56.515" width="0.254" layer="22"/>
-<wire x1="10.16" y1="56.515" x2="10.16" y2="57.785" width="0.254" layer="22"/>
-<wire x1="10.16" y1="57.785" x2="10.795" y2="58.42" width="0.254" layer="22"/>
-<wire x1="10.795" y1="58.42" x2="10.16" y2="59.055" width="0.254" layer="22"/>
-<wire x1="10.16" y1="59.055" x2="10.16" y2="60.325" width="0.254" layer="22"/>
-<wire x1="10.16" y1="60.325" x2="10.795" y2="60.96" width="0.254" layer="22"/>
-<wire x1="10.795" y1="60.96" x2="12.065" y2="60.96" width="0.254" layer="22"/>
-<wire x1="12.065" y1="60.96" x2="12.7" y2="60.325" width="0.254" layer="22"/>
-<wire x1="12.7" y1="60.325" x2="12.7" y2="59.055" width="0.254" layer="22"/>
-<wire x1="12.7" y1="59.055" x2="12.065" y2="58.42" width="0.254" layer="22"/>
-<wire x1="12.065" y1="58.42" x2="12.7" y2="57.785" width="0.254" layer="22"/>
-<wire x1="12.7" y1="57.785" x2="12.7" y2="56.515" width="0.254" layer="22"/>
-<wire x1="12.7" y1="56.515" x2="12.065" y2="55.88" width="0.254" layer="22"/>
-<wire x1="12.065" y1="55.88" x2="12.7" y2="55.245" width="0.254" layer="22"/>
-<wire x1="12.7" y1="55.245" x2="12.7" y2="53.975" width="0.254" layer="22"/>
-<wire x1="12.7" y1="53.975" x2="12.065" y2="53.34" width="0.254" layer="22"/>
-<wire x1="12.065" y1="53.34" x2="12.7" y2="52.705" width="0.254" layer="22"/>
-<wire x1="12.7" y1="52.705" x2="12.7" y2="51.435" width="0.254" layer="22"/>
-<wire x1="12.7" y1="51.435" x2="12.065" y2="50.8" width="0.254" layer="22"/>
-<wire x1="12.065" y1="50.8" x2="12.7" y2="50.165" width="0.254" layer="22"/>
-<wire x1="12.7" y1="50.165" x2="12.7" y2="48.895" width="0.254" layer="22"/>
-<wire x1="12.7" y1="48.895" x2="12.065" y2="48.26" width="0.254" layer="22"/>
-<wire x1="12.065" y1="48.26" x2="12.7" y2="47.625" width="0.254" layer="22"/>
-<wire x1="12.7" y1="47.625" x2="12.7" y2="46.355" width="0.254" layer="22"/>
-<wire x1="12.7" y1="46.355" x2="12.065" y2="45.72" width="0.254" layer="22"/>
-<wire x1="12.065" y1="45.72" x2="12.7" y2="45.085" width="0.254" layer="22"/>
-<wire x1="12.7" y1="45.085" x2="12.7" y2="43.815" width="0.254" layer="22"/>
-<wire x1="12.7" y1="43.815" x2="12.065" y2="43.18" width="0.254" layer="22"/>
-<wire x1="12.065" y1="43.18" x2="12.7" y2="42.545" width="0.254" layer="22"/>
-<wire x1="12.7" y1="42.545" x2="12.7" y2="41.275" width="0.254" layer="22"/>
-<wire x1="12.7" y1="41.275" x2="12.065" y2="40.64" width="0.254" layer="22"/>
-<wire x1="12.065" y1="40.64" x2="12.7" y2="40.005" width="0.254" layer="22"/>
-<wire x1="12.7" y1="40.005" x2="12.7" y2="38.735" width="0.254" layer="22"/>
-<wire x1="12.7" y1="38.735" x2="12.065" y2="38.1" width="0.254" layer="22"/>
-<wire x1="12.065" y1="38.1" x2="12.7" y2="37.465" width="0.254" layer="22"/>
-<wire x1="12.7" y1="37.465" x2="12.7" y2="36.195" width="0.254" layer="22"/>
-<wire x1="12.7" y1="36.195" x2="12.065" y2="35.56" width="0.254" layer="22"/>
-<wire x1="12.065" y1="35.56" x2="12.7" y2="34.925" width="0.254" layer="22"/>
-<wire x1="12.7" y1="34.925" x2="12.7" y2="33.655" width="0.254" layer="22"/>
-<wire x1="12.7" y1="33.655" x2="12.065" y2="33.02" width="0.254" layer="22"/>
-<wire x1="12.065" y1="33.02" x2="12.7" y2="32.385" width="0.254" layer="22"/>
-<wire x1="12.7" y1="32.385" x2="12.7" y2="31.115" width="0.254" layer="22"/>
-<wire x1="12.7" y1="31.115" x2="12.065" y2="30.48" width="0.254" layer="22"/>
-<wire x1="12.065" y1="30.48" x2="12.7" y2="29.845" width="0.254" layer="22"/>
-<wire x1="12.7" y1="29.845" x2="12.7" y2="28.575" width="0.254" layer="22"/>
-<wire x1="12.7" y1="28.575" x2="12.065" y2="27.94" width="0.254" layer="22"/>
-<wire x1="12.065" y1="27.94" x2="12.7" y2="27.305" width="0.254" layer="22"/>
-<wire x1="12.7" y1="27.305" x2="12.7" y2="26.035" width="0.254" layer="22"/>
-<wire x1="12.7" y1="26.035" x2="12.065" y2="25.4" width="0.254" layer="22"/>
-<wire x1="12.065" y1="25.4" x2="12.7" y2="24.765" width="0.254" layer="22"/>
-<wire x1="12.7" y1="24.765" x2="12.7" y2="23.495" width="0.254" layer="22"/>
-<wire x1="12.7" y1="23.495" x2="12.065" y2="22.86" width="0.254" layer="22"/>
-<wire x1="12.065" y1="22.86" x2="12.7" y2="22.225" width="0.254" layer="22"/>
-<wire x1="12.7" y1="22.225" x2="12.7" y2="20.955" width="0.254" layer="22"/>
-<wire x1="12.7" y1="20.955" x2="12.065" y2="20.32" width="0.254" layer="22"/>
-<wire x1="12.065" y1="20.32" x2="12.7" y2="19.685" width="0.254" layer="22"/>
-<wire x1="12.7" y1="19.685" x2="12.7" y2="18.415" width="0.254" layer="22"/>
-<wire x1="12.7" y1="18.415" x2="12.065" y2="17.78" width="0.254" layer="22"/>
-<wire x1="12.065" y1="17.78" x2="12.7" y2="17.145" width="0.254" layer="22"/>
-<wire x1="12.7" y1="17.145" x2="12.7" y2="15.875" width="0.254" layer="22"/>
-<wire x1="12.7" y1="15.875" x2="12.065" y2="15.24" width="0.254" layer="22"/>
-<wire x1="12.065" y1="15.24" x2="12.7" y2="14.605" width="0.254" layer="22"/>
-<wire x1="12.7" y1="14.605" x2="12.7" y2="13.335" width="0.254" layer="22"/>
-<wire x1="12.7" y1="13.335" x2="12.065" y2="12.7" width="0.254" layer="22"/>
-<wire x1="42.545" y1="12.7" x2="41.275" y2="12.7" width="0.254" layer="22"/>
-<wire x1="41.275" y1="12.7" x2="40.64" y2="13.335" width="0.254" layer="22"/>
-<wire x1="40.64" y1="13.335" x2="40.64" y2="14.605" width="0.254" layer="22"/>
-<wire x1="40.64" y1="14.605" x2="41.275" y2="15.24" width="0.254" layer="22"/>
-<wire x1="41.275" y1="15.24" x2="40.64" y2="15.875" width="0.254" layer="22"/>
-<wire x1="40.64" y1="15.875" x2="40.64" y2="17.145" width="0.254" layer="22"/>
-<wire x1="40.64" y1="17.145" x2="41.275" y2="17.78" width="0.254" layer="22"/>
-<wire x1="41.275" y1="17.78" x2="40.64" y2="18.415" width="0.254" layer="22"/>
-<wire x1="40.64" y1="18.415" x2="40.64" y2="19.685" width="0.254" layer="22"/>
-<wire x1="40.64" y1="19.685" x2="41.275" y2="20.32" width="0.254" layer="22"/>
-<wire x1="41.275" y1="20.32" x2="40.64" y2="20.955" width="0.254" layer="22"/>
-<wire x1="40.64" y1="20.955" x2="40.64" y2="22.225" width="0.254" layer="22"/>
-<wire x1="40.64" y1="22.225" x2="41.275" y2="22.86" width="0.254" layer="22"/>
-<wire x1="41.275" y1="22.86" x2="40.64" y2="23.495" width="0.254" layer="22"/>
-<wire x1="40.64" y1="23.495" x2="40.64" y2="24.765" width="0.254" layer="22"/>
-<wire x1="40.64" y1="24.765" x2="41.275" y2="25.4" width="0.254" layer="22"/>
-<wire x1="41.275" y1="25.4" x2="40.64" y2="26.035" width="0.254" layer="22"/>
-<wire x1="40.64" y1="26.035" x2="40.64" y2="27.305" width="0.254" layer="22"/>
-<wire x1="40.64" y1="27.305" x2="41.275" y2="27.94" width="0.254" layer="22"/>
-<wire x1="41.275" y1="27.94" x2="40.64" y2="28.575" width="0.254" layer="22"/>
-<wire x1="40.64" y1="28.575" x2="40.64" y2="29.845" width="0.254" layer="22"/>
-<wire x1="40.64" y1="29.845" x2="41.275" y2="30.48" width="0.254" layer="22"/>
-<wire x1="41.275" y1="30.48" x2="40.64" y2="31.115" width="0.254" layer="22"/>
-<wire x1="40.64" y1="31.115" x2="40.64" y2="32.385" width="0.254" layer="22"/>
-<wire x1="40.64" y1="32.385" x2="41.275" y2="33.02" width="0.254" layer="22"/>
-<wire x1="41.275" y1="33.02" x2="40.64" y2="33.655" width="0.254" layer="22"/>
-<wire x1="40.64" y1="33.655" x2="40.64" y2="34.925" width="0.254" layer="22"/>
-<wire x1="40.64" y1="34.925" x2="41.275" y2="35.56" width="0.254" layer="22"/>
-<wire x1="41.275" y1="35.56" x2="40.64" y2="36.195" width="0.254" layer="22"/>
-<wire x1="40.64" y1="36.195" x2="40.64" y2="37.465" width="0.254" layer="22"/>
-<wire x1="40.64" y1="37.465" x2="41.275" y2="38.1" width="0.254" layer="22"/>
-<wire x1="41.275" y1="38.1" x2="40.64" y2="38.735" width="0.254" layer="22"/>
-<wire x1="40.64" y1="38.735" x2="40.64" y2="40.005" width="0.254" layer="22"/>
-<wire x1="40.64" y1="40.005" x2="41.275" y2="40.64" width="0.254" layer="22"/>
-<wire x1="41.275" y1="40.64" x2="40.64" y2="41.275" width="0.254" layer="22"/>
-<wire x1="40.64" y1="41.275" x2="40.64" y2="42.545" width="0.254" layer="22"/>
-<wire x1="40.64" y1="42.545" x2="41.275" y2="43.18" width="0.254" layer="22"/>
-<wire x1="41.275" y1="43.18" x2="40.64" y2="43.815" width="0.254" layer="22"/>
-<wire x1="40.64" y1="43.815" x2="40.64" y2="45.085" width="0.254" layer="22"/>
-<wire x1="40.64" y1="45.085" x2="41.275" y2="45.72" width="0.254" layer="22"/>
-<wire x1="41.275" y1="45.72" x2="40.64" y2="46.355" width="0.254" layer="22"/>
-<wire x1="40.64" y1="46.355" x2="40.64" y2="47.625" width="0.254" layer="22"/>
-<wire x1="40.64" y1="47.625" x2="41.275" y2="48.26" width="0.254" layer="22"/>
-<wire x1="41.275" y1="48.26" x2="40.64" y2="48.895" width="0.254" layer="22"/>
-<wire x1="40.64" y1="48.895" x2="40.64" y2="50.165" width="0.254" layer="22"/>
-<wire x1="40.64" y1="50.165" x2="41.275" y2="50.8" width="0.254" layer="22"/>
-<wire x1="41.275" y1="50.8" x2="40.64" y2="51.435" width="0.254" layer="22"/>
-<wire x1="40.64" y1="51.435" x2="40.64" y2="52.705" width="0.254" layer="22"/>
-<wire x1="40.64" y1="52.705" x2="41.275" y2="53.34" width="0.254" layer="22"/>
-<wire x1="41.275" y1="53.34" x2="40.64" y2="53.975" width="0.254" layer="22"/>
-<wire x1="40.64" y1="53.975" x2="40.64" y2="55.245" width="0.254" layer="22"/>
-<wire x1="40.64" y1="55.245" x2="41.275" y2="55.88" width="0.254" layer="22"/>
-<wire x1="41.275" y1="55.88" x2="40.64" y2="56.515" width="0.254" layer="22"/>
-<wire x1="40.64" y1="56.515" x2="40.64" y2="57.785" width="0.254" layer="22"/>
-<wire x1="40.64" y1="57.785" x2="41.275" y2="58.42" width="0.254" layer="22"/>
-<wire x1="41.275" y1="58.42" x2="40.64" y2="59.055" width="0.254" layer="22"/>
-<wire x1="40.64" y1="59.055" x2="40.64" y2="60.325" width="0.254" layer="22"/>
-<wire x1="40.64" y1="60.325" x2="41.275" y2="60.96" width="0.254" layer="22"/>
-<wire x1="22.4282" y1="1.9304" x2="22.4282" y2="0.6604" width="0.254" layer="22"/>
-<wire x1="22.4282" y1="0.6604" x2="21.7932" y2="0.0254" width="0.254" layer="22"/>
-<wire x1="21.7932" y1="0.0254" x2="20.5232" y2="0.0254" width="0.254" layer="22"/>
-<wire x1="20.5232" y1="0.0254" x2="19.8882" y2="0.6604" width="0.254" layer="22"/>
-<wire x1="19.8882" y1="0.6604" x2="19.2532" y2="0.0254" width="0.254" layer="22"/>
-<wire x1="19.2532" y1="0.0254" x2="17.9832" y2="0.0254" width="0.254" layer="22"/>
-<wire x1="17.9832" y1="0.0254" x2="17.3482" y2="0.6604" width="0.254" layer="22"/>
-<wire x1="17.3482" y1="0.6604" x2="16.7132" y2="0.0254" width="0.254" layer="22"/>
-<wire x1="16.7132" y1="0.0254" x2="15.4432" y2="0.0254" width="0.254" layer="22"/>
-<wire x1="15.4432" y1="0.0254" x2="14.8082" y2="0.6604" width="0.254" layer="22"/>
-<wire x1="14.8082" y1="0.6604" x2="14.8082" y2="1.9304" width="0.254" layer="22"/>
-<wire x1="14.8082" y1="1.9304" x2="15.4432" y2="2.5654" width="0.254" layer="22"/>
-<wire x1="15.4432" y1="2.5654" x2="16.7132" y2="2.5654" width="0.254" layer="22"/>
-<wire x1="16.7132" y1="2.5654" x2="17.3482" y2="1.9304" width="0.254" layer="22"/>
-<wire x1="17.3482" y1="1.9304" x2="17.9832" y2="2.5654" width="0.254" layer="22"/>
-<wire x1="17.9832" y1="2.5654" x2="19.2532" y2="2.5654" width="0.254" layer="22"/>
-<wire x1="19.2532" y1="2.5654" x2="19.8882" y2="1.9304" width="0.254" layer="22"/>
-<wire x1="19.8882" y1="1.9304" x2="20.5232" y2="2.5654" width="0.254" layer="22"/>
-<wire x1="20.5232" y1="2.5654" x2="21.7932" y2="2.5654" width="0.254" layer="22"/>
-<wire x1="21.7932" y1="2.5654" x2="22.4282" y2="1.9304" width="0.254" layer="22"/>
-<wire x1="17.3482" y1="1.9558" x2="17.3482" y2="0.6604" width="0.254" layer="22"/>
-<wire x1="19.8882" y1="1.9558" x2="19.8882" y2="0.6096" width="0.254" layer="22"/>
+<text x="9.017" y="0.889" size="0.8128" layer="21" font="vector" ratio="15">330</text>
+<text x="10.541" y="3.175" size="0.8128" layer="21" font="vector" ratio="15">330</text>
+<text x="38.7604" y="3.4036" size="0.8128" layer="21" font="vector" ratio="15">10k</text>
 <wire x1="24.765" y1="12.7" x2="31.115" y2="12.7" width="0.254" layer="22"/>
 <wire x1="31.115" y1="12.7" x2="31.75" y2="12.065" width="0.254" layer="22"/>
 <wire x1="31.75" y1="12.065" x2="31.75" y2="8.255" width="0.254" layer="22"/>
@@ -1051,6 +731,1255 @@ ProtoShield</text>
 <wire x1="22.606" y1="60.579" x2="23.114" y2="61.087" width="0.254" layer="42"/>
 <wire x1="20.447" y1="60.579" x2="20.447" y2="60.198" width="0.254" layer="42"/>
 <wire x1="20.447" y1="58.801" x2="20.447" y2="59.182" width="0.254" layer="42"/>
+<text x="17.78" y="9.144" size="0.8128" layer="21" font="vector" ratio="15">VDD</text>
+<text x="9.906" y="11.684" size="0.8128" layer="21" font="vector" ratio="15">5V</text>
+<text x="34.544" y="11.684" size="0.8128" layer="21" font="vector" ratio="15">GND</text>
+<wire x1="26.924" y1="14.986" x2="26.924" y2="12.954" width="0.254" layer="21"/>
+<wire x1="26.924" y1="12.954" x2="29.464" y2="12.954" width="0.254" layer="21"/>
+<wire x1="26.924" y1="14.986" x2="44.196" y2="14.986" width="0.254" layer="21"/>
+<wire x1="44.196" y1="14.986" x2="44.196" y2="10.414" width="0.254" layer="21"/>
+<wire x1="44.196" y1="10.414" x2="37.084" y2="10.414" width="0.254" layer="21"/>
+<wire x1="37.084" y1="10.414" x2="37.084" y2="12.954" width="0.254" layer="21"/>
+<wire x1="37.084" y1="12.954" x2="31.496" y2="12.954" width="0.254" layer="21"/>
+<text x="23.749" y="3.1115" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">L1</text>
+<text x="26.289" y="3.1115" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">L2</text>
+<text x="29.337" y="3.1115" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">GND</text>
+<text x="31.369" y="3.1115" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">5V</text>
+<text x="31.115" y="58.293" size="0.8128" layer="22" font="vector" ratio="15" rot="MR90">TXO</text>
+<text x="31.115" y="61.214" size="0.8128" layer="22" font="vector" ratio="15" rot="MR90">RXI</text>
+<wire x1="8.89" y1="13.335" x2="8.89" y2="14.605" width="0.254" layer="22"/>
+<wire x1="8.89" y1="17.145" x2="8.89" y2="15.875" width="0.254" layer="22"/>
+<wire x1="8.89" y1="18.415" x2="8.89" y2="19.685" width="0.254" layer="22"/>
+<wire x1="8.89" y1="20.955" x2="8.89" y2="22.225" width="0.254" layer="22"/>
+<wire x1="8.89" y1="23.495" x2="8.89" y2="24.765" width="0.254" layer="22"/>
+<wire x1="8.89" y1="28.575" x2="8.89" y2="29.845" width="0.254" layer="22"/>
+<wire x1="8.89" y1="32.385" x2="8.89" y2="31.115" width="0.254" layer="22"/>
+<wire x1="8.89" y1="33.655" x2="8.89" y2="34.925" width="0.254" layer="22"/>
+<wire x1="8.89" y1="36.195" x2="8.89" y2="37.465" width="0.254" layer="22"/>
+<wire x1="8.89" y1="38.735" x2="8.89" y2="40.005" width="0.254" layer="22"/>
+<wire x1="8.89" y1="41.402" x2="8.89" y2="42.545" width="0.254" layer="22"/>
+<wire x1="8.89" y1="43.815" x2="8.89" y2="45.085" width="0.254" layer="22"/>
+<wire x1="8.89" y1="46.355" x2="8.89" y2="47.498" width="0.254" layer="22"/>
+<wire x1="15.24" y1="37.846" x2="22.86" y2="37.846" width="0.254" layer="21" style="shortdash"/>
+<wire x1="22.86" y1="37.846" x2="23.876" y2="36.83" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="23.876" y1="36.83" x2="22.86" y2="35.814" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="22.86" y1="35.814" x2="15.24" y2="35.814" width="0.254" layer="21" style="shortdash"/>
+<wire x1="15.24" y1="35.814" x2="14.224" y2="36.83" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="14.224" y1="36.83" x2="15.24" y2="37.846" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="15.24" y1="35.306" x2="22.86" y2="35.306" width="0.254" layer="21" style="shortdash"/>
+<wire x1="22.86" y1="35.306" x2="23.876" y2="34.29" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="23.876" y1="34.29" x2="22.86" y2="33.274" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="22.86" y1="33.274" x2="15.24" y2="33.274" width="0.254" layer="21" style="shortdash"/>
+<wire x1="15.24" y1="33.274" x2="14.224" y2="34.29" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="14.224" y1="34.29" x2="15.24" y2="35.306" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="15.24" y1="32.766" x2="22.86" y2="32.766" width="0.254" layer="21" style="shortdash"/>
+<wire x1="22.86" y1="32.766" x2="23.876" y2="31.75" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="23.876" y1="31.75" x2="22.86" y2="30.734" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="22.86" y1="30.734" x2="15.24" y2="30.734" width="0.254" layer="21" style="shortdash"/>
+<wire x1="15.24" y1="30.734" x2="14.224" y2="31.75" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="14.224" y1="31.75" x2="15.24" y2="32.766" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="15.24" y1="30.226" x2="22.86" y2="30.226" width="0.254" layer="21" style="shortdash"/>
+<wire x1="22.86" y1="30.226" x2="23.876" y2="29.21" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="23.876" y1="29.21" x2="22.86" y2="28.194" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="22.86" y1="28.194" x2="15.24" y2="28.194" width="0.254" layer="21" style="shortdash"/>
+<wire x1="15.24" y1="28.194" x2="14.224" y2="29.21" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="14.224" y1="29.21" x2="15.24" y2="30.226" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="15.24" y1="27.686" x2="22.86" y2="27.686" width="0.254" layer="21" style="shortdash"/>
+<wire x1="22.86" y1="27.686" x2="23.876" y2="26.67" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="23.876" y1="26.67" x2="22.86" y2="25.654" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="22.86" y1="25.654" x2="15.24" y2="25.654" width="0.254" layer="21" style="shortdash"/>
+<wire x1="15.24" y1="25.654" x2="14.224" y2="26.67" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="14.224" y1="26.67" x2="15.24" y2="27.686" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="15.24" y1="25.146" x2="22.86" y2="25.146" width="0.254" layer="21" style="shortdash"/>
+<wire x1="22.86" y1="25.146" x2="23.876" y2="24.13" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="23.876" y1="24.13" x2="22.86" y2="23.114" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="22.86" y1="23.114" x2="15.24" y2="23.114" width="0.254" layer="21" style="shortdash"/>
+<wire x1="15.24" y1="23.114" x2="14.224" y2="24.13" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="14.224" y1="24.13" x2="15.24" y2="25.146" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="15.24" y1="22.606" x2="22.86" y2="22.606" width="0.254" layer="21" style="shortdash"/>
+<wire x1="22.86" y1="22.606" x2="23.876" y2="21.59" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="23.876" y1="21.59" x2="22.86" y2="20.574" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="22.86" y1="20.574" x2="15.24" y2="20.574" width="0.254" layer="21" style="shortdash"/>
+<wire x1="15.24" y1="20.574" x2="14.224" y2="21.59" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="14.224" y1="21.59" x2="15.24" y2="22.606" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="15.24" y1="20.066" x2="22.86" y2="20.066" width="0.254" layer="21" style="shortdash"/>
+<wire x1="22.86" y1="20.066" x2="23.876" y2="19.05" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="23.876" y1="19.05" x2="22.86" y2="18.034" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="22.86" y1="18.034" x2="15.24" y2="18.034" width="0.254" layer="21" style="shortdash"/>
+<wire x1="15.24" y1="18.034" x2="14.224" y2="19.05" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="14.224" y1="19.05" x2="15.24" y2="20.066" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="15.24" y1="17.526" x2="22.86" y2="17.526" width="0.254" layer="21" style="shortdash"/>
+<wire x1="22.86" y1="17.526" x2="23.876" y2="16.51" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="23.876" y1="16.51" x2="22.86" y2="15.494" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="22.86" y1="15.494" x2="15.24" y2="15.494" width="0.254" layer="21" style="shortdash"/>
+<wire x1="15.24" y1="15.494" x2="14.224" y2="16.51" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="14.224" y1="16.51" x2="15.24" y2="17.526" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="22.86" y1="37.846" x2="15.24" y2="37.846" width="0.254" layer="22" style="shortdash"/>
+<wire x1="15.24" y1="37.846" x2="14.224" y2="36.83" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="14.224" y1="36.83" x2="15.24" y2="35.814" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="15.24" y1="35.814" x2="22.86" y2="35.814" width="0.254" layer="22" style="shortdash"/>
+<wire x1="22.86" y1="35.814" x2="23.876" y2="36.83" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="23.876" y1="36.83" x2="22.86" y2="37.846" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="22.86" y1="35.306" x2="15.24" y2="35.306" width="0.254" layer="22" style="shortdash"/>
+<wire x1="15.24" y1="35.306" x2="14.224" y2="34.29" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="14.224" y1="34.29" x2="15.24" y2="33.274" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="15.24" y1="33.274" x2="22.86" y2="33.274" width="0.254" layer="22" style="shortdash"/>
+<wire x1="22.86" y1="33.274" x2="23.876" y2="34.29" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="23.876" y1="34.29" x2="22.86" y2="35.306" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="22.86" y1="32.766" x2="15.24" y2="32.766" width="0.254" layer="22" style="shortdash"/>
+<wire x1="15.24" y1="32.766" x2="14.224" y2="31.75" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="14.224" y1="31.75" x2="15.24" y2="30.734" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="15.24" y1="30.734" x2="22.86" y2="30.734" width="0.254" layer="22" style="shortdash"/>
+<wire x1="22.86" y1="30.734" x2="23.876" y2="31.75" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="23.876" y1="31.75" x2="22.86" y2="32.766" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="22.86" y1="30.226" x2="15.24" y2="30.226" width="0.254" layer="22" style="shortdash"/>
+<wire x1="15.24" y1="30.226" x2="14.224" y2="29.21" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="14.224" y1="29.21" x2="15.24" y2="28.194" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="15.24" y1="28.194" x2="22.86" y2="28.194" width="0.254" layer="22" style="shortdash"/>
+<wire x1="22.86" y1="28.194" x2="23.876" y2="29.21" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="23.876" y1="29.21" x2="22.86" y2="30.226" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="22.86" y1="27.686" x2="15.24" y2="27.686" width="0.254" layer="22" style="shortdash"/>
+<wire x1="15.24" y1="27.686" x2="14.224" y2="26.67" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="14.224" y1="26.67" x2="15.24" y2="25.654" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="15.24" y1="25.654" x2="22.86" y2="25.654" width="0.254" layer="22" style="shortdash"/>
+<wire x1="22.86" y1="25.654" x2="23.876" y2="26.67" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="23.876" y1="26.67" x2="22.86" y2="27.686" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="22.86" y1="25.146" x2="15.24" y2="25.146" width="0.254" layer="22" style="shortdash"/>
+<wire x1="15.24" y1="25.146" x2="14.224" y2="24.13" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="14.224" y1="24.13" x2="15.24" y2="23.114" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="15.24" y1="23.114" x2="22.86" y2="23.114" width="0.254" layer="22" style="shortdash"/>
+<wire x1="22.86" y1="23.114" x2="23.876" y2="24.13" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="23.876" y1="24.13" x2="22.86" y2="25.146" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="22.86" y1="22.606" x2="15.24" y2="22.606" width="0.254" layer="22" style="shortdash"/>
+<wire x1="15.24" y1="22.606" x2="14.224" y2="21.59" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="14.224" y1="21.59" x2="15.24" y2="20.574" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="15.24" y1="20.574" x2="22.86" y2="20.574" width="0.254" layer="22" style="shortdash"/>
+<wire x1="22.86" y1="20.574" x2="23.876" y2="21.59" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="23.876" y1="21.59" x2="22.86" y2="22.606" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="22.86" y1="20.066" x2="15.24" y2="20.066" width="0.254" layer="22" style="shortdash"/>
+<wire x1="15.24" y1="20.066" x2="14.224" y2="19.05" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="14.224" y1="19.05" x2="15.24" y2="18.034" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="15.24" y1="18.034" x2="22.86" y2="18.034" width="0.254" layer="22" style="shortdash"/>
+<wire x1="22.86" y1="18.034" x2="23.876" y2="19.05" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="23.876" y1="19.05" x2="22.86" y2="20.066" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="30.48" y1="37.846" x2="38.1" y2="37.846" width="0.254" layer="21" style="shortdash"/>
+<wire x1="38.1" y1="37.846" x2="39.116" y2="36.83" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="39.116" y1="36.83" x2="38.1" y2="35.814" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="38.1" y1="35.814" x2="30.48" y2="35.814" width="0.254" layer="21" style="shortdash"/>
+<wire x1="30.48" y1="35.814" x2="29.464" y2="36.83" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="29.464" y1="36.83" x2="30.48" y2="37.846" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="30.48" y1="35.306" x2="38.1" y2="35.306" width="0.254" layer="21" style="shortdash"/>
+<wire x1="38.1" y1="35.306" x2="39.116" y2="34.29" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="39.116" y1="34.29" x2="38.1" y2="33.274" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="38.1" y1="33.274" x2="30.48" y2="33.274" width="0.254" layer="21" style="shortdash"/>
+<wire x1="30.48" y1="33.274" x2="29.464" y2="34.29" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="29.464" y1="34.29" x2="30.48" y2="35.306" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="30.48" y1="32.766" x2="38.1" y2="32.766" width="0.254" layer="21" style="shortdash"/>
+<wire x1="38.1" y1="32.766" x2="39.116" y2="31.75" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="39.116" y1="31.75" x2="38.1" y2="30.734" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="38.1" y1="30.734" x2="30.48" y2="30.734" width="0.254" layer="21" style="shortdash"/>
+<wire x1="30.48" y1="30.734" x2="29.464" y2="31.75" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="29.464" y1="31.75" x2="30.48" y2="32.766" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="30.48" y1="30.226" x2="38.1" y2="30.226" width="0.254" layer="21" style="shortdash"/>
+<wire x1="38.1" y1="30.226" x2="39.116" y2="29.21" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="39.116" y1="29.21" x2="38.1" y2="28.194" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="38.1" y1="28.194" x2="30.48" y2="28.194" width="0.254" layer="21" style="shortdash"/>
+<wire x1="30.48" y1="28.194" x2="29.464" y2="29.21" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="29.464" y1="29.21" x2="30.48" y2="30.226" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="30.48" y1="27.686" x2="38.1" y2="27.686" width="0.254" layer="21" style="shortdash"/>
+<wire x1="38.1" y1="27.686" x2="39.116" y2="26.67" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="39.116" y1="26.67" x2="38.1" y2="25.654" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="38.1" y1="25.654" x2="30.48" y2="25.654" width="0.254" layer="21" style="shortdash"/>
+<wire x1="30.48" y1="25.654" x2="29.464" y2="26.67" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="29.464" y1="26.67" x2="30.48" y2="27.686" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="30.48" y1="25.146" x2="38.1" y2="25.146" width="0.254" layer="21" style="shortdash"/>
+<wire x1="38.1" y1="25.146" x2="39.116" y2="24.13" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="39.116" y1="24.13" x2="38.1" y2="23.114" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="38.1" y1="23.114" x2="30.48" y2="23.114" width="0.254" layer="21" style="shortdash"/>
+<wire x1="30.48" y1="23.114" x2="29.464" y2="24.13" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="29.464" y1="24.13" x2="30.48" y2="25.146" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="30.48" y1="22.606" x2="38.1" y2="22.606" width="0.254" layer="21" style="shortdash"/>
+<wire x1="38.1" y1="22.606" x2="39.116" y2="21.59" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="39.116" y1="21.59" x2="38.1" y2="20.574" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="38.1" y1="20.574" x2="30.48" y2="20.574" width="0.254" layer="21" style="shortdash"/>
+<wire x1="30.48" y1="20.574" x2="29.464" y2="21.59" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="29.464" y1="21.59" x2="30.48" y2="22.606" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="30.48" y1="20.066" x2="38.1" y2="20.066" width="0.254" layer="21" style="shortdash"/>
+<wire x1="38.1" y1="20.066" x2="39.116" y2="19.05" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="39.116" y1="19.05" x2="38.1" y2="18.034" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="38.1" y1="18.034" x2="30.48" y2="18.034" width="0.254" layer="21" style="shortdash"/>
+<wire x1="30.48" y1="18.034" x2="29.464" y2="19.05" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="29.464" y1="19.05" x2="30.48" y2="20.066" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="30.48" y1="17.526" x2="38.1" y2="17.526" width="0.254" layer="21" style="shortdash"/>
+<wire x1="38.1" y1="17.526" x2="39.116" y2="16.51" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="39.116" y1="16.51" x2="38.1" y2="15.494" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="38.1" y1="15.494" x2="30.48" y2="15.494" width="0.254" layer="21" style="shortdash"/>
+<wire x1="30.48" y1="15.494" x2="29.464" y2="16.51" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="29.464" y1="16.51" x2="30.48" y2="17.526" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="26.416" y1="39.37" x2="26.416" y2="16.51" width="0.254" layer="21" style="shortdash"/>
+<wire x1="26.416" y1="16.51" x2="25.4" y2="15.494" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="25.4" y1="15.494" x2="24.384" y2="16.51" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="24.384" y1="16.51" x2="24.384" y2="39.37" width="0.254" layer="21" style="shortdash"/>
+<wire x1="24.384" y1="39.37" x2="25.4" y2="40.386" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="25.4" y1="40.386" x2="26.416" y2="39.37" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="28.956" y1="16.51" x2="27.94" y2="15.494" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="27.94" y1="15.494" x2="26.924" y2="16.51" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="26.924" y1="16.51" x2="26.924" y2="39.37" width="0.254" layer="21" style="shortdash"/>
+<wire x1="26.924" y1="39.37" x2="27.94" y2="40.386" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="27.94" y1="40.386" x2="28.956" y2="39.37" width="0.254" layer="21" style="shortdash" curve="-90"/>
+<wire x1="28.956" y1="39.37" x2="28.956" y2="16.51" width="0.254" layer="21" style="shortdash"/>
+<wire x1="38.1" y1="37.846" x2="30.48" y2="37.846" width="0.254" layer="22" style="shortdash"/>
+<wire x1="30.48" y1="37.846" x2="29.464" y2="36.83" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="29.464" y1="36.83" x2="30.48" y2="35.814" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="30.48" y1="35.814" x2="38.1" y2="35.814" width="0.254" layer="22" style="shortdash"/>
+<wire x1="38.1" y1="35.814" x2="39.116" y2="36.83" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="39.116" y1="36.83" x2="38.1" y2="37.846" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="38.1" y1="35.306" x2="30.48" y2="35.306" width="0.254" layer="22" style="shortdash"/>
+<wire x1="30.48" y1="35.306" x2="29.464" y2="34.29" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="29.464" y1="34.29" x2="30.48" y2="33.274" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="30.48" y1="33.274" x2="38.1" y2="33.274" width="0.254" layer="22" style="shortdash"/>
+<wire x1="38.1" y1="33.274" x2="39.116" y2="34.29" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="39.116" y1="34.29" x2="38.1" y2="35.306" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="38.1" y1="32.766" x2="30.48" y2="32.766" width="0.254" layer="22" style="shortdash"/>
+<wire x1="30.48" y1="32.766" x2="29.464" y2="31.75" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="29.464" y1="31.75" x2="30.48" y2="30.734" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="30.48" y1="30.734" x2="38.1" y2="30.734" width="0.254" layer="22" style="shortdash"/>
+<wire x1="38.1" y1="30.734" x2="39.116" y2="31.75" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="39.116" y1="31.75" x2="38.1" y2="32.766" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="38.1" y1="30.226" x2="30.48" y2="30.226" width="0.254" layer="22" style="shortdash"/>
+<wire x1="30.48" y1="30.226" x2="29.464" y2="29.21" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="29.464" y1="29.21" x2="30.48" y2="28.194" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="30.48" y1="28.194" x2="38.1" y2="28.194" width="0.254" layer="22" style="shortdash"/>
+<wire x1="38.1" y1="28.194" x2="39.116" y2="29.21" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="39.116" y1="29.21" x2="38.1" y2="30.226" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="38.1" y1="27.686" x2="30.48" y2="27.686" width="0.254" layer="22" style="shortdash"/>
+<wire x1="30.48" y1="27.686" x2="29.464" y2="26.67" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="29.464" y1="26.67" x2="30.48" y2="25.654" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="30.48" y1="25.654" x2="38.1" y2="25.654" width="0.254" layer="22" style="shortdash"/>
+<wire x1="38.1" y1="25.654" x2="39.116" y2="26.67" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="39.116" y1="26.67" x2="38.1" y2="27.686" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="38.1" y1="25.146" x2="30.48" y2="25.146" width="0.254" layer="22" style="shortdash"/>
+<wire x1="30.48" y1="25.146" x2="29.464" y2="24.13" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="29.464" y1="24.13" x2="30.48" y2="23.114" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="30.48" y1="23.114" x2="38.1" y2="23.114" width="0.254" layer="22" style="shortdash"/>
+<wire x1="38.1" y1="23.114" x2="39.116" y2="24.13" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="39.116" y1="24.13" x2="38.1" y2="25.146" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="38.1" y1="22.606" x2="30.48" y2="22.606" width="0.254" layer="22" style="shortdash"/>
+<wire x1="30.48" y1="22.606" x2="29.464" y2="21.59" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="29.464" y1="21.59" x2="30.48" y2="20.574" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="30.48" y1="20.574" x2="38.1" y2="20.574" width="0.254" layer="22" style="shortdash"/>
+<wire x1="38.1" y1="20.574" x2="39.116" y2="21.59" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="39.116" y1="21.59" x2="38.1" y2="22.606" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="38.1" y1="20.066" x2="30.48" y2="20.066" width="0.254" layer="22" style="shortdash"/>
+<wire x1="30.48" y1="20.066" x2="29.464" y2="19.05" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="29.464" y1="19.05" x2="30.48" y2="18.034" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="30.48" y1="18.034" x2="38.1" y2="18.034" width="0.254" layer="22" style="shortdash"/>
+<wire x1="38.1" y1="18.034" x2="39.116" y2="19.05" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="39.116" y1="19.05" x2="38.1" y2="20.066" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="30.48" y1="15.494" x2="38.1" y2="15.494" width="0.254" layer="22" style="shortdash"/>
+<wire x1="38.1" y1="15.494" x2="39.116" y2="16.51" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="39.116" y1="16.51" x2="38.1" y2="17.526" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="38.1" y1="17.526" x2="30.48" y2="17.526" width="0.254" layer="22" style="shortdash"/>
+<wire x1="30.48" y1="17.526" x2="29.464" y2="16.51" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="29.464" y1="16.51" x2="30.48" y2="15.494" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="15.24" y1="15.494" x2="22.86" y2="15.494" width="0.254" layer="22" style="shortdash"/>
+<wire x1="22.86" y1="15.494" x2="23.876" y2="16.51" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="23.876" y1="16.51" x2="22.86" y2="17.526" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="22.86" y1="17.526" x2="15.24" y2="17.526" width="0.254" layer="22" style="shortdash"/>
+<wire x1="15.24" y1="17.526" x2="14.224" y2="16.51" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="14.224" y1="16.51" x2="15.24" y2="15.494" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="25.4" y1="15.494" x2="26.416" y2="16.51" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="26.416" y1="16.51" x2="26.416" y2="39.37" width="0.254" layer="22" style="shortdash"/>
+<wire x1="26.416" y1="39.37" x2="25.4" y2="40.386" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="25.4" y1="40.386" x2="24.384" y2="39.37" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="24.384" y1="39.37" x2="24.384" y2="16.51" width="0.254" layer="22" style="shortdash"/>
+<wire x1="24.384" y1="16.51" x2="25.4" y2="15.494" width="0.254" layer="22" style="shortdash" curve="90"/>
+<wire x1="27.94" y1="15.494" x2="26.924" y2="16.51" width="0.254" layer="22" style="shortdash" curve="-90"/>
+<wire x1="26.924" y1="16.51" x2="26.924" y2="39.37" width="0.254" layer="22" style="shortdash"/>
+<wire x1="26.924" y1="39.37" x2="27.94" y2="40.386" width="0.254" layer="22" style="shortdash" curve="-90"/>
+<wire x1="27.94" y1="40.386" x2="28.956" y2="39.37" width="0.254" layer="22" style="shortdash" curve="-90"/>
+<wire x1="28.956" y1="39.37" x2="28.956" y2="16.51" width="0.254" layer="22" style="shortdash"/>
+<wire x1="28.956" y1="16.51" x2="27.94" y2="15.494" width="0.254" layer="22" style="shortdash" curve="-90"/>
+<wire x1="44.196" y1="14.986" x2="26.924" y2="14.986" width="0.254" layer="22"/>
+<wire x1="26.924" y1="14.986" x2="26.924" y2="12.954" width="0.254" layer="22"/>
+<wire x1="26.924" y1="12.954" x2="29.464" y2="12.954" width="0.254" layer="22"/>
+<wire x1="31.496" y1="12.954" x2="37.084" y2="12.954" width="0.254" layer="22"/>
+<wire x1="37.084" y1="12.954" x2="37.084" y2="10.414" width="0.254" layer="22"/>
+<wire x1="37.084" y1="10.414" x2="44.196" y2="10.414" width="0.254" layer="22"/>
+<wire x1="44.196" y1="10.414" x2="44.196" y2="14.986" width="0.254" layer="22"/>
+<wire x1="10.16" y1="14.986" x2="25.4" y2="14.986" width="0.254" layer="21"/>
+<wire x1="25.4" y1="14.986" x2="26.416" y2="13.97" width="0.254" layer="21" curve="-90"/>
+<wire x1="26.416" y1="13.97" x2="25.4" y2="12.954" width="0.254" layer="21" curve="-90"/>
+<wire x1="25.4" y1="12.954" x2="10.16" y2="12.954" width="0.254" layer="21"/>
+<wire x1="10.16" y1="12.954" x2="9.144" y2="13.97" width="0.254" layer="21" curve="-90"/>
+<wire x1="9.144" y1="13.97" x2="10.16" y2="14.986" width="0.254" layer="21" curve="-90"/>
+<wire x1="15.24" y1="12.446" x2="22.86" y2="12.446" width="0.254" layer="21"/>
+<wire x1="22.86" y1="12.446" x2="23.876" y2="11.43" width="0.254" layer="21" curve="-90"/>
+<wire x1="23.876" y1="11.43" x2="22.86" y2="10.414" width="0.254" layer="21" curve="-90"/>
+<wire x1="22.86" y1="10.414" x2="15.24" y2="10.414" width="0.254" layer="21"/>
+<wire x1="15.24" y1="10.414" x2="14.224" y2="11.43" width="0.254" layer="21" curve="-90"/>
+<wire x1="14.224" y1="11.43" x2="15.24" y2="12.446" width="0.254" layer="21" curve="-90"/>
+<text x="36.576" y="11.684" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">GND</text>
+<text x="19.812" y="9.144" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">VDD</text>
+<text x="11.176" y="11.684" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">5V</text>
+<wire x1="51.435" y1="10.16" x2="52.07" y2="10.795" width="0.254" layer="22"/>
+<wire x1="49.53" y1="23.495" x2="50.165" y2="22.86" width="0.254" layer="22"/>
+<wire x1="51.435" y1="27.94" x2="52.07" y2="28.575" width="0.254" layer="22"/>
+<wire x1="52.07" y1="29.845" x2="51.435" y2="30.48" width="0.254" layer="22"/>
+<wire x1="50.165" y1="31.75" x2="51.435" y2="31.75" width="0.254" layer="22"/>
+<wire x1="49.53" y1="33.655" x2="50.165" y2="34.29" width="0.254" layer="22"/>
+<wire x1="50.165" y1="34.29" x2="49.53" y2="34.925" width="0.254" layer="22"/>
+<wire x1="50.165" y1="36.83" x2="49.53" y2="37.465" width="0.254" layer="22"/>
+<wire x1="49.53" y1="37.465" x2="49.53" y2="38.735" width="0.254" layer="22"/>
+<wire x1="49.53" y1="38.735" x2="50.165" y2="39.37" width="0.254" layer="22"/>
+<wire x1="50.165" y1="39.37" x2="49.53" y2="40.005" width="0.254" layer="22"/>
+<wire x1="49.53" y1="45.085" x2="50.165" y2="44.45" width="0.254" layer="22"/>
+<wire x1="51.435" y1="46.99" x2="52.07" y2="47.625" width="0.254" layer="22"/>
+<wire x1="51.435" y1="49.53" x2="52.07" y2="50.165" width="0.254" layer="22"/>
+<wire x1="52.07" y1="50.165" x2="52.07" y2="51.435" width="0.254" layer="22"/>
+<wire x1="49.53" y1="56.515" x2="50.165" y2="57.15" width="0.254" layer="22"/>
+<wire x1="50.165" y1="57.15" x2="51.435" y2="57.15" width="0.254" layer="22"/>
+<wire x1="51.435" y1="57.15" x2="52.07" y2="56.515" width="0.254" layer="22"/>
+<wire x1="1.905" y1="48.26" x2="3.175" y2="48.26" width="0.254" layer="22"/>
+<wire x1="3.175" y1="48.26" x2="3.81" y2="47.625" width="0.254" layer="22"/>
+<wire x1="3.81" y1="45.085" x2="3.81" y2="43.815" width="0.254" layer="22"/>
+<wire x1="1.27" y1="41.275" x2="1.905" y2="40.64" width="0.254" layer="22"/>
+<wire x1="3.81" y1="38.735" x2="3.175" y2="38.1" width="0.254" layer="22"/>
+<wire x1="3.81" y1="37.465" x2="3.175" y2="38.1" width="0.254" layer="22"/>
+<wire x1="3.175" y1="35.56" x2="3.81" y2="34.925" width="0.254" layer="22"/>
+<wire x1="1.27" y1="32.385" x2="1.905" y2="33.02" width="0.254" layer="22"/>
+<wire x1="1.27" y1="31.115" x2="1.905" y2="30.48" width="0.254" layer="22"/>
+<wire x1="1.27" y1="28.575" x2="1.905" y2="27.94" width="0.254" layer="22"/>
+<wire x1="1.905" y1="27.94" x2="3.175" y2="27.94" width="0.254" layer="22"/>
+<wire x1="3.175" y1="27.94" x2="3.81" y2="28.575" width="0.254" layer="22"/>
+<wire x1="1.27" y1="23.495" x2="1.905" y2="22.86" width="0.254" layer="22"/>
+<wire x1="3.175" y1="22.86" x2="3.81" y2="23.495" width="0.254" layer="22"/>
+<wire x1="1.27" y1="19.685" x2="1.905" y2="20.32" width="0.254" layer="22"/>
+<wire x1="1.27" y1="24.765" x2="1.905" y2="25.4" width="0.254" layer="22"/>
+<wire x1="1.905" y1="25.4" x2="3.175" y2="25.4" width="0.254" layer="22"/>
+<wire x1="3.175" y1="25.4" x2="3.81" y2="24.765" width="0.254" layer="22"/>
+<wire x1="1.27" y1="18.415" x2="1.905" y2="17.78" width="0.254" layer="22"/>
+<wire x1="3.175" y1="17.78" x2="3.81" y2="18.415" width="0.254" layer="22"/>
+<wire x1="1.27" y1="14.605" x2="1.905" y2="15.24" width="0.254" layer="22"/>
+<wire x1="3.81" y1="13.335" x2="3.175" y2="12.7" width="0.254" layer="22"/>
+<wire x1="3.175" y1="12.7" x2="3.81" y2="12.065" width="0.254" layer="22"/>
+<wire x1="1.27" y1="12.065" x2="1.905" y2="12.7" width="0.254" layer="22"/>
+<wire x1="3.175" y1="10.16" x2="3.81" y2="10.795" width="0.254" layer="22"/>
+<wire x1="22.86" y1="12.446" x2="15.24" y2="12.446" width="0.254" layer="22"/>
+<wire x1="15.24" y1="12.446" x2="14.224" y2="11.43" width="0.254" layer="22" curve="90"/>
+<wire x1="14.224" y1="11.43" x2="15.24" y2="10.414" width="0.254" layer="22" curve="90"/>
+<wire x1="15.24" y1="10.414" x2="22.987" y2="10.414" width="0.254" layer="22"/>
+<wire x1="22.987" y1="10.414" x2="23.876" y2="11.303" width="0.254" layer="22" curve="90"/>
+<wire x1="23.876" y1="11.303" x2="23.876" y2="11.43" width="0.254" layer="22"/>
+<wire x1="23.876" y1="11.43" x2="22.86" y2="12.446" width="0.254" layer="22" curve="90"/>
+<wire x1="10.16" y1="14.986" x2="9.144" y2="13.97" width="0.254" layer="22" curve="90"/>
+<wire x1="9.144" y1="13.97" x2="10.16" y2="12.954" width="0.254" layer="22" curve="90"/>
+<wire x1="10.16" y1="12.954" x2="25.527" y2="12.954" width="0.254" layer="22"/>
+<wire x1="25.527" y1="12.954" x2="26.416" y2="13.843" width="0.254" layer="22" curve="90"/>
+<wire x1="26.416" y1="13.843" x2="26.416" y2="13.97" width="0.254" layer="22"/>
+<wire x1="26.416" y1="13.97" x2="25.4" y2="14.986" width="0.254" layer="22" curve="90"/>
+<wire x1="25.4" y1="14.986" x2="10.16" y2="14.986" width="0.254" layer="22"/>
+<wire x1="3.81" y1="27.94" x2="1.27" y2="27.94" width="0.254" layer="21"/>
+<wire x1="1.27" y1="27.94" x2="1.27" y2="48.26" width="0.254" layer="21"/>
+<wire x1="1.27" y1="48.26" x2="3.81" y2="48.26" width="0.254" layer="21"/>
+<wire x1="3.81" y1="48.26" x2="3.81" y2="27.94" width="0.254" layer="21"/>
+<polygon width="0.254" layer="21">
+<vertex x="1.27" y="28.448"/>
+<vertex x="1.27" y="27.94"/>
+<vertex x="1.778" y="27.94"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="3.302" y="27.94"/>
+<vertex x="3.81" y="28.448"/>
+<vertex x="3.81" y="27.94"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="3.81" y="29.972"/>
+<vertex x="3.81" y="30.988"/>
+<vertex x="3.302" y="30.48"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="1.27" y="30.988"/>
+<vertex x="1.27" y="29.972"/>
+<vertex x="1.778" y="30.48"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="3.81" y="32.512"/>
+<vertex x="3.81" y="33.528"/>
+<vertex x="3.302" y="33.02"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="1.27" y="33.528"/>
+<vertex x="1.27" y="32.512"/>
+<vertex x="1.778" y="33.02"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="3.81" y="36.068"/>
+<vertex x="3.302" y="35.56"/>
+<vertex x="3.81" y="35.052"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="1.27" y="35.052"/>
+<vertex x="1.778" y="35.56"/>
+<vertex x="1.27" y="36.068"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="1.27" y="37.592"/>
+<vertex x="1.778" y="38.1"/>
+<vertex x="1.27" y="38.608"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="3.81" y="38.608"/>
+<vertex x="3.302" y="38.1"/>
+<vertex x="3.81" y="37.592"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="3.81" y="41.148"/>
+<vertex x="3.302" y="40.64"/>
+<vertex x="3.81" y="40.132"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="1.27" y="40.132"/>
+<vertex x="1.778" y="40.64"/>
+<vertex x="1.27" y="41.148"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="1.27" y="42.672"/>
+<vertex x="1.778" y="43.18"/>
+<vertex x="1.27" y="43.688"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="3.81" y="43.688"/>
+<vertex x="3.302" y="43.18"/>
+<vertex x="3.81" y="42.672"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="1.27" y="45.212"/>
+<vertex x="1.778" y="45.72"/>
+<vertex x="1.27" y="46.228"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="3.81" y="46.228"/>
+<vertex x="3.302" y="45.72"/>
+<vertex x="3.81" y="45.212"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="1.27" y="47.752"/>
+<vertex x="1.27" y="48.26"/>
+<vertex x="1.778" y="48.26"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="3.81" y="47.752"/>
+<vertex x="3.81" y="48.26"/>
+<vertex x="3.302" y="48.26"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="49.53" y="51.562"/>
+<vertex x="50.038" y="52.07"/>
+<vertex x="49.53" y="52.578"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="52.07" y="52.578"/>
+<vertex x="51.562" y="52.07"/>
+<vertex x="52.07" y="51.562"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="49.53" y="54.102"/>
+<vertex x="50.038" y="54.61"/>
+<vertex x="49.53" y="55.118"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="52.07" y="55.118"/>
+<vertex x="51.562" y="54.61"/>
+<vertex x="52.07" y="54.102"/>
+</polygon>
+<wire x1="1.27" y1="27.94" x2="3.81" y2="27.94" width="0.254" layer="22"/>
+<wire x1="3.81" y1="27.94" x2="3.81" y2="48.26" width="0.254" layer="22"/>
+<wire x1="3.81" y1="48.26" x2="1.27" y2="48.26" width="0.254" layer="22"/>
+<wire x1="1.27" y1="48.26" x2="1.27" y2="27.94" width="0.254" layer="22"/>
+<polygon width="0.254" layer="22">
+<vertex x="3.81" y="28.448"/>
+<vertex x="3.81" y="27.94"/>
+<vertex x="3.302" y="27.94"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="1.778" y="27.94"/>
+<vertex x="1.27" y="28.448"/>
+<vertex x="1.27" y="27.94"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="1.27" y="29.972"/>
+<vertex x="1.27" y="30.988"/>
+<vertex x="1.778" y="30.48"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="3.81" y="30.988"/>
+<vertex x="3.81" y="29.972"/>
+<vertex x="3.302" y="30.48"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="1.27" y="32.512"/>
+<vertex x="1.27" y="33.528"/>
+<vertex x="1.778" y="33.02"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="3.81" y="33.528"/>
+<vertex x="3.81" y="32.512"/>
+<vertex x="3.302" y="33.02"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="1.27" y="36.068"/>
+<vertex x="1.778" y="35.56"/>
+<vertex x="1.27" y="35.052"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="3.81" y="35.052"/>
+<vertex x="3.302" y="35.56"/>
+<vertex x="3.81" y="36.068"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="3.81" y="37.592"/>
+<vertex x="3.302" y="38.1"/>
+<vertex x="3.81" y="38.608"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="1.27" y="38.608"/>
+<vertex x="1.778" y="38.1"/>
+<vertex x="1.27" y="37.592"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="1.27" y="41.148"/>
+<vertex x="1.778" y="40.64"/>
+<vertex x="1.27" y="40.132"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="3.81" y="40.132"/>
+<vertex x="3.302" y="40.64"/>
+<vertex x="3.81" y="41.148"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="3.81" y="42.672"/>
+<vertex x="3.302" y="43.18"/>
+<vertex x="3.81" y="43.688"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="1.27" y="43.688"/>
+<vertex x="1.778" y="43.18"/>
+<vertex x="1.27" y="42.672"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="3.81" y="45.212"/>
+<vertex x="3.302" y="45.72"/>
+<vertex x="3.81" y="46.228"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="1.27" y="46.228"/>
+<vertex x="1.778" y="45.72"/>
+<vertex x="1.27" y="45.212"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="3.81" y="47.752"/>
+<vertex x="3.81" y="48.26"/>
+<vertex x="3.302" y="48.26"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="1.27" y="47.752"/>
+<vertex x="1.27" y="48.26"/>
+<vertex x="1.778" y="48.26"/>
+</polygon>
+<wire x1="49.53" y1="10.16" x2="52.07" y2="10.16" width="0.254" layer="22"/>
+<wire x1="52.07" y1="10.16" x2="52.07" y2="30.48" width="0.254" layer="22"/>
+<wire x1="52.07" y1="30.48" x2="49.53" y2="30.48" width="0.254" layer="22"/>
+<wire x1="49.53" y1="30.48" x2="49.53" y2="10.16" width="0.254" layer="22"/>
+<polygon width="0.254" layer="22">
+<vertex x="52.07" y="10.668"/>
+<vertex x="52.07" y="10.16"/>
+<vertex x="51.562" y="10.16"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="50.038" y="10.16"/>
+<vertex x="49.53" y="10.668"/>
+<vertex x="49.53" y="10.16"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="49.53" y="12.192"/>
+<vertex x="49.53" y="13.208"/>
+<vertex x="50.038" y="12.7"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="52.07" y="13.208"/>
+<vertex x="52.07" y="12.192"/>
+<vertex x="51.562" y="12.7"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="49.53" y="14.732"/>
+<vertex x="49.53" y="15.748"/>
+<vertex x="50.038" y="15.24"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="52.07" y="15.748"/>
+<vertex x="52.07" y="14.732"/>
+<vertex x="51.562" y="15.24"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="49.53" y="18.288"/>
+<vertex x="50.038" y="17.78"/>
+<vertex x="49.53" y="17.272"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="52.07" y="17.272"/>
+<vertex x="51.562" y="17.78"/>
+<vertex x="52.07" y="18.288"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="52.07" y="19.812"/>
+<vertex x="51.562" y="20.32"/>
+<vertex x="52.07" y="20.828"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="49.53" y="20.828"/>
+<vertex x="50.038" y="20.32"/>
+<vertex x="49.53" y="19.812"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="49.53" y="23.368"/>
+<vertex x="50.038" y="22.86"/>
+<vertex x="49.53" y="22.352"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="52.07" y="22.352"/>
+<vertex x="51.562" y="22.86"/>
+<vertex x="52.07" y="23.368"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="52.07" y="24.892"/>
+<vertex x="51.562" y="25.4"/>
+<vertex x="52.07" y="25.908"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="49.53" y="25.908"/>
+<vertex x="50.038" y="25.4"/>
+<vertex x="49.53" y="24.892"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="52.07" y="27.432"/>
+<vertex x="51.562" y="27.94"/>
+<vertex x="52.07" y="28.448"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="49.53" y="28.448"/>
+<vertex x="50.038" y="27.94"/>
+<vertex x="49.53" y="27.432"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="52.07" y="29.972"/>
+<vertex x="52.07" y="30.48"/>
+<vertex x="51.562" y="30.48"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="49.53" y="29.972"/>
+<vertex x="49.53" y="30.48"/>
+<vertex x="50.038" y="30.48"/>
+</polygon>
+<wire x1="52.07" y1="10.16" x2="49.53" y2="10.16" width="0.254" layer="21"/>
+<wire x1="49.53" y1="10.16" x2="49.53" y2="30.48" width="0.254" layer="21"/>
+<wire x1="49.53" y1="30.48" x2="52.07" y2="30.48" width="0.254" layer="21"/>
+<wire x1="52.07" y1="30.48" x2="52.07" y2="10.16" width="0.254" layer="21"/>
+<polygon width="0.254" layer="21">
+<vertex x="49.53" y="10.668"/>
+<vertex x="49.53" y="10.16"/>
+<vertex x="50.038" y="10.16"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="51.562" y="10.16"/>
+<vertex x="52.07" y="10.668"/>
+<vertex x="52.07" y="10.16"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="52.07" y="12.192"/>
+<vertex x="52.07" y="13.208"/>
+<vertex x="51.562" y="12.7"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="49.53" y="13.208"/>
+<vertex x="49.53" y="12.192"/>
+<vertex x="50.038" y="12.7"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="52.07" y="14.732"/>
+<vertex x="52.07" y="15.748"/>
+<vertex x="51.562" y="15.24"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="49.53" y="15.748"/>
+<vertex x="49.53" y="14.732"/>
+<vertex x="50.038" y="15.24"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="52.07" y="18.288"/>
+<vertex x="51.562" y="17.78"/>
+<vertex x="52.07" y="17.272"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="49.53" y="17.272"/>
+<vertex x="50.038" y="17.78"/>
+<vertex x="49.53" y="18.288"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="49.53" y="19.812"/>
+<vertex x="50.038" y="20.32"/>
+<vertex x="49.53" y="20.828"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="52.07" y="20.828"/>
+<vertex x="51.562" y="20.32"/>
+<vertex x="52.07" y="19.812"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="52.07" y="23.368"/>
+<vertex x="51.562" y="22.86"/>
+<vertex x="52.07" y="22.352"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="49.53" y="22.352"/>
+<vertex x="50.038" y="22.86"/>
+<vertex x="49.53" y="23.368"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="49.53" y="24.892"/>
+<vertex x="50.038" y="25.4"/>
+<vertex x="49.53" y="25.908"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="52.07" y="25.908"/>
+<vertex x="51.562" y="25.4"/>
+<vertex x="52.07" y="24.892"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="49.53" y="27.432"/>
+<vertex x="50.038" y="27.94"/>
+<vertex x="49.53" y="28.448"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="52.07" y="28.448"/>
+<vertex x="51.562" y="27.94"/>
+<vertex x="52.07" y="27.432"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="49.53" y="29.972"/>
+<vertex x="49.53" y="30.48"/>
+<vertex x="50.038" y="30.48"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="52.07" y="29.972"/>
+<vertex x="52.07" y="30.48"/>
+<vertex x="51.562" y="30.48"/>
+</polygon>
+<wire x1="3.81" y1="25.4" x2="3.81" y2="10.16" width="0.254" layer="21"/>
+<wire x1="3.81" y1="10.16" x2="1.27" y2="10.16" width="0.254" layer="21"/>
+<wire x1="1.27" y1="10.16" x2="1.27" y2="25.4" width="0.254" layer="21"/>
+<wire x1="1.27" y1="25.4" x2="3.81" y2="25.4" width="0.254" layer="21"/>
+<polygon width="0.254" layer="21">
+<vertex x="3.81" y="12.192"/>
+<vertex x="3.81" y="13.208"/>
+<vertex x="3.302" y="12.7"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="1.27" y="13.208"/>
+<vertex x="1.27" y="12.192"/>
+<vertex x="1.778" y="12.7"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="3.81" y="14.732"/>
+<vertex x="3.81" y="15.748"/>
+<vertex x="3.302" y="15.24"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="1.27" y="15.748"/>
+<vertex x="1.27" y="14.732"/>
+<vertex x="1.778" y="15.24"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="3.81" y="18.288"/>
+<vertex x="3.302" y="17.78"/>
+<vertex x="3.81" y="17.272"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="1.27" y="17.272"/>
+<vertex x="1.778" y="17.78"/>
+<vertex x="1.27" y="18.288"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="1.27" y="19.812"/>
+<vertex x="1.778" y="20.32"/>
+<vertex x="1.27" y="20.828"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="3.81" y="20.828"/>
+<vertex x="3.302" y="20.32"/>
+<vertex x="3.81" y="19.812"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="3.81" y="12.192"/>
+<vertex x="3.81" y="13.208"/>
+<vertex x="3.302" y="12.7"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="1.27" y="13.208"/>
+<vertex x="1.27" y="12.192"/>
+<vertex x="1.778" y="12.7"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="3.81" y="14.732"/>
+<vertex x="3.81" y="15.748"/>
+<vertex x="3.302" y="15.24"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="1.27" y="15.748"/>
+<vertex x="1.27" y="14.732"/>
+<vertex x="1.778" y="15.24"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="3.81" y="18.288"/>
+<vertex x="3.302" y="17.78"/>
+<vertex x="3.81" y="17.272"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="1.27" y="17.272"/>
+<vertex x="1.778" y="17.78"/>
+<vertex x="1.27" y="18.288"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="1.27" y="19.812"/>
+<vertex x="1.778" y="20.32"/>
+<vertex x="1.27" y="20.828"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="3.81" y="20.828"/>
+<vertex x="3.302" y="20.32"/>
+<vertex x="3.81" y="19.812"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="1.27" y="22.352"/>
+<vertex x="1.778" y="22.86"/>
+<vertex x="1.27" y="23.368"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="3.81" y="23.368"/>
+<vertex x="3.302" y="22.86"/>
+<vertex x="3.81" y="22.352"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="1.27" y="22.352"/>
+<vertex x="1.778" y="22.86"/>
+<vertex x="1.27" y="23.368"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="3.81" y="23.368"/>
+<vertex x="3.302" y="22.86"/>
+<vertex x="3.81" y="22.352"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="3.302" y="25.4"/>
+<vertex x="3.81" y="25.4"/>
+<vertex x="3.81" y="24.892"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="1.778" y="25.4"/>
+<vertex x="1.27" y="24.892"/>
+<vertex x="1.27" y="25.4"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="3.81" y="10.668"/>
+<vertex x="3.81" y="10.16"/>
+<vertex x="3.302" y="10.16"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="1.778" y="10.16"/>
+<vertex x="1.27" y="10.16"/>
+<vertex x="1.27" y="10.668"/>
+</polygon>
+<wire x1="1.27" y1="25.4" x2="1.27" y2="10.16" width="0.254" layer="22"/>
+<wire x1="1.27" y1="10.16" x2="3.81" y2="10.16" width="0.254" layer="22"/>
+<wire x1="3.81" y1="10.16" x2="3.81" y2="25.4" width="0.254" layer="22"/>
+<wire x1="3.81" y1="25.4" x2="1.27" y2="25.4" width="0.254" layer="22"/>
+<polygon width="0.254" layer="22">
+<vertex x="1.27" y="12.192"/>
+<vertex x="1.27" y="13.208"/>
+<vertex x="1.778" y="12.7"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="3.81" y="13.208"/>
+<vertex x="3.81" y="12.192"/>
+<vertex x="3.302" y="12.7"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="1.27" y="14.732"/>
+<vertex x="1.27" y="15.748"/>
+<vertex x="1.778" y="15.24"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="3.81" y="15.748"/>
+<vertex x="3.81" y="14.732"/>
+<vertex x="3.302" y="15.24"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="1.27" y="18.288"/>
+<vertex x="1.778" y="17.78"/>
+<vertex x="1.27" y="17.272"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="3.81" y="17.272"/>
+<vertex x="3.302" y="17.78"/>
+<vertex x="3.81" y="18.288"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="3.81" y="19.812"/>
+<vertex x="3.302" y="20.32"/>
+<vertex x="3.81" y="20.828"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="1.27" y="20.828"/>
+<vertex x="1.778" y="20.32"/>
+<vertex x="1.27" y="19.812"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="1.27" y="12.192"/>
+<vertex x="1.27" y="13.208"/>
+<vertex x="1.778" y="12.7"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="3.81" y="13.208"/>
+<vertex x="3.81" y="12.192"/>
+<vertex x="3.302" y="12.7"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="1.27" y="14.732"/>
+<vertex x="1.27" y="15.748"/>
+<vertex x="1.778" y="15.24"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="3.81" y="15.748"/>
+<vertex x="3.81" y="14.732"/>
+<vertex x="3.302" y="15.24"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="1.27" y="18.288"/>
+<vertex x="1.778" y="17.78"/>
+<vertex x="1.27" y="17.272"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="3.81" y="17.272"/>
+<vertex x="3.302" y="17.78"/>
+<vertex x="3.81" y="18.288"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="3.81" y="19.812"/>
+<vertex x="3.302" y="20.32"/>
+<vertex x="3.81" y="20.828"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="1.27" y="20.828"/>
+<vertex x="1.778" y="20.32"/>
+<vertex x="1.27" y="19.812"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="3.81" y="22.352"/>
+<vertex x="3.302" y="22.86"/>
+<vertex x="3.81" y="23.368"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="1.27" y="23.368"/>
+<vertex x="1.778" y="22.86"/>
+<vertex x="1.27" y="22.352"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="3.81" y="22.352"/>
+<vertex x="3.302" y="22.86"/>
+<vertex x="3.81" y="23.368"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="1.27" y="23.368"/>
+<vertex x="1.778" y="22.86"/>
+<vertex x="1.27" y="22.352"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="1.778" y="25.4"/>
+<vertex x="1.27" y="25.4"/>
+<vertex x="1.27" y="24.892"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="3.302" y="25.4"/>
+<vertex x="3.81" y="24.892"/>
+<vertex x="3.81" y="25.4"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="1.27" y="10.668"/>
+<vertex x="1.27" y="10.16"/>
+<vertex x="1.778" y="10.16"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="3.302" y="10.16"/>
+<vertex x="3.81" y="10.16"/>
+<vertex x="3.81" y="10.668"/>
+</polygon>
+<wire x1="52.07" y1="31.75" x2="52.07" y2="57.15" width="0.254" layer="21"/>
+<wire x1="52.07" y1="57.15" x2="49.53" y2="57.15" width="0.254" layer="21"/>
+<wire x1="49.53" y1="57.15" x2="49.53" y2="31.75" width="0.254" layer="21"/>
+<wire x1="49.53" y1="31.75" x2="52.07" y2="31.75" width="0.254" layer="21"/>
+<polygon width="0.254" layer="21">
+<vertex x="52.07" y="33.782"/>
+<vertex x="52.07" y="34.798"/>
+<vertex x="51.562" y="34.29"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="49.53" y="34.798"/>
+<vertex x="49.53" y="33.782"/>
+<vertex x="50.038" y="34.29"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="52.07" y="36.322"/>
+<vertex x="52.07" y="37.338"/>
+<vertex x="51.562" y="36.83"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="49.53" y="37.338"/>
+<vertex x="49.53" y="36.322"/>
+<vertex x="50.038" y="36.83"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="52.07" y="39.878"/>
+<vertex x="51.562" y="39.37"/>
+<vertex x="52.07" y="38.862"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="49.53" y="38.862"/>
+<vertex x="50.038" y="39.37"/>
+<vertex x="49.53" y="39.878"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="49.53" y="41.402"/>
+<vertex x="50.038" y="41.91"/>
+<vertex x="49.53" y="42.418"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="52.07" y="42.418"/>
+<vertex x="51.562" y="41.91"/>
+<vertex x="52.07" y="41.402"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="52.07" y="44.958"/>
+<vertex x="51.562" y="44.45"/>
+<vertex x="52.07" y="43.942"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="49.53" y="43.942"/>
+<vertex x="50.038" y="44.45"/>
+<vertex x="49.53" y="44.958"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="49.53" y="46.482"/>
+<vertex x="50.038" y="46.99"/>
+<vertex x="49.53" y="47.498"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="52.07" y="47.498"/>
+<vertex x="51.562" y="46.99"/>
+<vertex x="52.07" y="46.482"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="49.53" y="49.022"/>
+<vertex x="50.038" y="49.53"/>
+<vertex x="49.53" y="50.038"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="52.07" y="50.038"/>
+<vertex x="51.562" y="49.53"/>
+<vertex x="52.07" y="49.022"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="52.07" y="57.15"/>
+<vertex x="51.562" y="57.15"/>
+<vertex x="52.07" y="56.642"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="50.038" y="57.15"/>
+<vertex x="49.53" y="57.15"/>
+<vertex x="49.53" y="56.642"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="52.07" y="51.562"/>
+<vertex x="51.562" y="52.07"/>
+<vertex x="52.07" y="52.578"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="49.53" y="52.578"/>
+<vertex x="50.038" y="52.07"/>
+<vertex x="49.53" y="51.562"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="52.07" y="54.102"/>
+<vertex x="51.562" y="54.61"/>
+<vertex x="52.07" y="55.118"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="49.53" y="55.118"/>
+<vertex x="50.038" y="54.61"/>
+<vertex x="49.53" y="54.102"/>
+</polygon>
+<wire x1="49.53" y1="31.75" x2="49.53" y2="57.15" width="0.254" layer="22"/>
+<wire x1="49.53" y1="57.15" x2="52.07" y2="57.15" width="0.254" layer="22"/>
+<wire x1="52.07" y1="57.15" x2="52.07" y2="31.75" width="0.254" layer="22"/>
+<wire x1="52.07" y1="31.75" x2="49.53" y2="31.75" width="0.254" layer="22"/>
+<polygon width="0.254" layer="22">
+<vertex x="49.53" y="33.782"/>
+<vertex x="49.53" y="34.798"/>
+<vertex x="50.038" y="34.29"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="52.07" y="34.798"/>
+<vertex x="52.07" y="33.782"/>
+<vertex x="51.562" y="34.29"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="49.53" y="36.322"/>
+<vertex x="49.53" y="37.338"/>
+<vertex x="50.038" y="36.83"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="52.07" y="37.338"/>
+<vertex x="52.07" y="36.322"/>
+<vertex x="51.562" y="36.83"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="49.53" y="39.878"/>
+<vertex x="50.038" y="39.37"/>
+<vertex x="49.53" y="38.862"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="52.07" y="38.862"/>
+<vertex x="51.562" y="39.37"/>
+<vertex x="52.07" y="39.878"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="52.07" y="41.402"/>
+<vertex x="51.562" y="41.91"/>
+<vertex x="52.07" y="42.418"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="49.53" y="42.418"/>
+<vertex x="50.038" y="41.91"/>
+<vertex x="49.53" y="41.402"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="49.53" y="44.958"/>
+<vertex x="50.038" y="44.45"/>
+<vertex x="49.53" y="43.942"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="52.07" y="43.942"/>
+<vertex x="51.562" y="44.45"/>
+<vertex x="52.07" y="44.958"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="52.07" y="46.482"/>
+<vertex x="51.562" y="46.99"/>
+<vertex x="52.07" y="47.498"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="49.53" y="47.498"/>
+<vertex x="50.038" y="46.99"/>
+<vertex x="49.53" y="46.482"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="52.07" y="49.022"/>
+<vertex x="51.562" y="49.53"/>
+<vertex x="52.07" y="50.038"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="49.53" y="50.038"/>
+<vertex x="50.038" y="49.53"/>
+<vertex x="49.53" y="49.022"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="49.53" y="57.15"/>
+<vertex x="50.038" y="57.15"/>
+<vertex x="49.53" y="56.642"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="51.562" y="57.15"/>
+<vertex x="52.07" y="57.15"/>
+<vertex x="52.07" y="56.642"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="49.53" y="32.258"/>
+<vertex x="49.53" y="31.75"/>
+<vertex x="50.038" y="31.75"/>
+</polygon>
+<polygon width="0.254" layer="22">
+<vertex x="51.562" y="31.75"/>
+<vertex x="52.07" y="31.75"/>
+<vertex x="52.07" y="32.258"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="52.07" y="32.258"/>
+<vertex x="51.562" y="31.75"/>
+<vertex x="52.07" y="31.75"/>
+</polygon>
+<polygon width="0.254" layer="21">
+<vertex x="50.038" y="31.75"/>
+<vertex x="49.53" y="32.258"/>
+<vertex x="49.53" y="31.75"/>
+</polygon>
+<wire x1="33.9852" y1="2.7051" x2="32.6898" y2="2.7051" width="0.254" layer="22"/>
+<wire x1="32.6898" y1="2.7051" x2="32.1564" y2="2.1717" width="0.254" layer="22"/>
+<wire x1="32.1564" y1="2.1717" x2="32.1564" y2="0.762" width="0.254" layer="22"/>
+<wire x1="32.1564" y1="0.762" x2="32.6898" y2="0.2286" width="0.254" layer="22"/>
+<wire x1="32.6898" y1="0.2286" x2="33.9852" y2="0.2286" width="0.254" layer="22"/>
+<wire x1="33.9852" y1="0.2286" x2="34.5948" y2="0.8382" width="0.254" layer="22"/>
+<wire x1="34.5948" y1="0.8382" x2="34.5948" y2="2.0955" width="0.254" layer="22"/>
+<wire x1="34.5948" y1="2.0955" x2="33.9852" y2="2.7051" width="0.254" layer="22"/>
+<wire x1="23.8125" y1="2.7051" x2="22.5171" y2="2.7051" width="0.254" layer="22"/>
+<wire x1="22.5171" y1="2.7051" x2="21.9837" y2="2.1717" width="0.254" layer="22"/>
+<wire x1="21.9837" y1="2.1717" x2="21.9837" y2="0.762" width="0.254" layer="22"/>
+<wire x1="21.9837" y1="0.762" x2="22.5171" y2="0.2286" width="0.254" layer="22"/>
+<wire x1="22.5171" y1="0.2286" x2="23.8125" y2="0.2286" width="0.254" layer="22"/>
+<wire x1="23.8125" y1="0.2286" x2="24.4221" y2="0.8382" width="0.254" layer="22"/>
+<wire x1="24.4221" y1="0.8382" x2="24.4221" y2="2.0955" width="0.254" layer="22"/>
+<wire x1="24.4221" y1="2.0955" x2="23.8125" y2="2.7051" width="0.254" layer="22"/>
+<wire x1="31.4325" y1="2.7051" x2="30.1371" y2="2.7051" width="0.254" layer="22"/>
+<wire x1="30.1371" y1="2.7051" x2="29.6037" y2="2.1717" width="0.254" layer="22"/>
+<wire x1="29.6037" y1="2.1717" x2="29.6037" y2="0.762" width="0.254" layer="22"/>
+<wire x1="29.6037" y1="0.762" x2="30.1371" y2="0.2286" width="0.254" layer="22"/>
+<wire x1="30.1371" y1="0.2286" x2="31.4325" y2="0.2286" width="0.254" layer="22"/>
+<wire x1="31.4325" y1="0.2286" x2="32.0421" y2="0.8382" width="0.254" layer="22"/>
+<wire x1="32.0421" y1="0.8382" x2="32.0421" y2="2.0955" width="0.254" layer="22"/>
+<wire x1="32.0421" y1="2.0955" x2="31.4325" y2="2.7051" width="0.254" layer="22"/>
+<wire x1="28.9179" y1="2.7051" x2="27.6225" y2="2.7051" width="0.254" layer="22"/>
+<wire x1="27.6225" y1="2.7051" x2="27.0891" y2="2.1717" width="0.254" layer="22"/>
+<wire x1="27.0891" y1="2.1717" x2="27.0891" y2="0.762" width="0.254" layer="22"/>
+<wire x1="27.0891" y1="0.762" x2="27.6225" y2="0.2286" width="0.254" layer="22"/>
+<wire x1="27.6225" y1="0.2286" x2="28.9179" y2="0.2286" width="0.254" layer="22"/>
+<wire x1="28.9179" y1="0.2286" x2="29.5275" y2="0.8382" width="0.254" layer="22"/>
+<wire x1="29.5275" y1="0.8382" x2="29.5275" y2="2.0955" width="0.254" layer="22"/>
+<wire x1="29.5275" y1="2.0955" x2="28.9179" y2="2.7051" width="0.254" layer="22"/>
+<wire x1="26.3652" y1="2.7051" x2="25.0698" y2="2.7051" width="0.254" layer="22"/>
+<wire x1="25.0698" y1="2.7051" x2="24.5364" y2="2.1717" width="0.254" layer="22"/>
+<wire x1="24.5364" y1="2.1717" x2="24.5364" y2="0.762" width="0.254" layer="22"/>
+<wire x1="24.5364" y1="0.762" x2="25.0698" y2="0.2286" width="0.254" layer="22"/>
+<wire x1="25.0698" y1="0.2286" x2="26.3652" y2="0.2286" width="0.254" layer="22"/>
+<wire x1="26.3652" y1="0.2286" x2="26.9748" y2="0.8382" width="0.254" layer="22"/>
+<wire x1="26.9748" y1="0.8382" x2="26.9748" y2="2.0955" width="0.254" layer="22"/>
+<wire x1="26.9748" y1="2.0955" x2="26.3652" y2="2.7051" width="0.254" layer="22"/>
+<text x="33.1216" y="11.049" size="1.4" layer="22" font="vector" ratio="15" rot="MR0">1</text>
+<text x="40.6654" y="3.4036" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">10k</text>
+<text x="53.0225" y="5.0165" size="0.8128" layer="22" font="vector" ratio="15" rot="MR270">SW2</text>
+<text x="16.9545" y="0.6985" size="0.8128" layer="22" font="vector" ratio="15" rot="SMR0">L2</text>
+<text x="5.969" y="2.667" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">L1</text>
+<text x="11.049" y="0.889" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">330</text>
+<text x="12.573" y="3.175" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">330</text>
+<text x="4.826" y="4.064" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">-</text>
+<text x="21.336" y="0.508" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">-</text>
 </plain>
 <libraries>
 <library name="SparkFun-Aesthetics">
@@ -1063,6 +1992,11 @@ We've spent an enormous amount of time creating and checking these footprints an
 You are welcome to use this library for commercial purposes. For attribution, we ask that when you begin to sell your device using our footprint, you email us with a link to the product being sold. We want bragging rights that we helped (in a very small part) to create your 8th world wonder. We would like the opportunity to feature your device on our homepage.</description>
 <packages>
 <package name="CREATIVE_COMMONS">
+<description>&lt;h3&gt;Creative Commons License Template&lt;/h3&gt;
+&lt;p&gt;CC BY-SA 4.0 License with &lt;a href="https://creativecommons.org/licenses/by-sa/4.0/"&gt;link to license&lt;/a&gt; and placeholder for designer name.&lt;/p&gt;
+&lt;p&gt;Devices using:
+&lt;ul&gt;&lt;li&gt;FRAME_LEDGER&lt;/li&gt;
+&lt;li&gt;FRAME_LETTER&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;</description>
 <text x="-20.32" y="5.08" size="1.778" layer="51" font="vector">Released under the Creative Commons Attribution Share-Alike 4.0 License</text>
 <text x="0" y="2.54" size="1.778" layer="51" font="vector"> https://creativecommons.org/licenses/by-sa/4.0/</text>
 <text x="11.43" y="0" size="1.778" layer="51" font="vector">Designed by:</text>
@@ -2637,172 +3571,6 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <text x="-1.27" y="-1.524" size="0.6096" layer="27" font="vector" ratio="20" align="top-left">&gt;VALUE</text>
 <rectangle x1="-0.254" y1="-0.254" x2="0.254" y2="0.254" layer="51"/>
 </package>
-<package name="1X19">
-<description>&lt;h3&gt;Plated Through Hole -19 Pin&lt;/h3&gt;
-&lt;p&gt;Specifications:
-&lt;ul&gt;&lt;li&gt;Pin count:19&lt;/li&gt;
-&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
-&lt;/ul&gt;&lt;/p&gt;
-&lt;p&gt;Example device(s):
-&lt;ul&gt;&lt;li&gt;CONN_19&lt;/li&gt;
-&lt;/ul&gt;&lt;/p&gt;</description>
-<wire x1="14.605" y1="1.27" x2="15.875" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="15.875" y1="1.27" x2="16.51" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="16.51" y1="-0.635" x2="15.875" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="11.43" y1="0.635" x2="12.065" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="12.065" y1="1.27" x2="13.335" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="13.335" y1="1.27" x2="13.97" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="13.97" y1="-0.635" x2="13.335" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="13.335" y1="-1.27" x2="12.065" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="12.065" y1="-1.27" x2="11.43" y2="-0.635" width="0.2032" layer="21"/>
-<wire x1="14.605" y1="1.27" x2="13.97" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="13.97" y1="-0.635" x2="14.605" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="15.875" y1="-1.27" x2="14.605" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="6.985" y1="1.27" x2="8.255" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="8.255" y1="1.27" x2="8.89" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="8.89" y1="-0.635" x2="8.255" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="8.89" y1="0.635" x2="9.525" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="9.525" y1="1.27" x2="10.795" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="10.795" y1="1.27" x2="11.43" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="11.43" y1="-0.635" x2="10.795" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="10.795" y1="-1.27" x2="9.525" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="9.525" y1="-1.27" x2="8.89" y2="-0.635" width="0.2032" layer="21"/>
-<wire x1="3.81" y1="0.635" x2="4.445" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="4.445" y1="1.27" x2="5.715" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="5.715" y1="1.27" x2="6.35" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="6.35" y1="-0.635" x2="5.715" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="5.715" y1="-1.27" x2="4.445" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="4.445" y1="-1.27" x2="3.81" y2="-0.635" width="0.2032" layer="21"/>
-<wire x1="6.985" y1="1.27" x2="6.35" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="6.35" y1="-0.635" x2="6.985" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="8.255" y1="-1.27" x2="6.985" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="-0.635" y1="1.27" x2="0.635" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="0.635" y1="1.27" x2="1.27" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="1.27" y1="-0.635" x2="0.635" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="1.27" y1="0.635" x2="1.905" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="1.905" y1="1.27" x2="3.175" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="3.175" y1="1.27" x2="3.81" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="3.81" y1="-0.635" x2="3.175" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="3.175" y1="-1.27" x2="1.905" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="1.905" y1="-1.27" x2="1.27" y2="-0.635" width="0.2032" layer="21"/>
-<wire x1="-1.27" y1="0.635" x2="-1.27" y2="-0.635" width="0.2032" layer="21"/>
-<wire x1="-0.635" y1="1.27" x2="-1.27" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="-1.27" y1="-0.635" x2="-0.635" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="0.635" y1="-1.27" x2="-0.635" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="32.385" y1="1.27" x2="33.655" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="33.655" y1="1.27" x2="34.29" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="34.29" y1="-0.635" x2="33.655" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="29.21" y1="0.635" x2="29.845" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="29.845" y1="1.27" x2="31.115" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="31.115" y1="1.27" x2="31.75" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="31.75" y1="-0.635" x2="31.115" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="31.115" y1="-1.27" x2="29.845" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="29.845" y1="-1.27" x2="29.21" y2="-0.635" width="0.2032" layer="21"/>
-<wire x1="32.385" y1="1.27" x2="31.75" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="31.75" y1="-0.635" x2="32.385" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="33.655" y1="-1.27" x2="32.385" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="24.765" y1="1.27" x2="26.035" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="26.035" y1="1.27" x2="26.67" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="26.67" y1="-0.635" x2="26.035" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="26.67" y1="0.635" x2="27.305" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="27.305" y1="1.27" x2="28.575" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="28.575" y1="1.27" x2="29.21" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="29.21" y1="-0.635" x2="28.575" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="28.575" y1="-1.27" x2="27.305" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="27.305" y1="-1.27" x2="26.67" y2="-0.635" width="0.2032" layer="21"/>
-<wire x1="21.59" y1="0.635" x2="22.225" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="22.225" y1="1.27" x2="23.495" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="23.495" y1="1.27" x2="24.13" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="24.13" y1="-0.635" x2="23.495" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="23.495" y1="-1.27" x2="22.225" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="22.225" y1="-1.27" x2="21.59" y2="-0.635" width="0.2032" layer="21"/>
-<wire x1="24.765" y1="1.27" x2="24.13" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="24.13" y1="-0.635" x2="24.765" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="26.035" y1="-1.27" x2="24.765" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="17.145" y1="1.27" x2="18.415" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="18.415" y1="1.27" x2="19.05" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="19.05" y1="-0.635" x2="18.415" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="19.05" y1="0.635" x2="19.685" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="19.685" y1="1.27" x2="20.955" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="20.955" y1="1.27" x2="21.59" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="21.59" y1="-0.635" x2="20.955" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="20.955" y1="-1.27" x2="19.685" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="19.685" y1="-1.27" x2="19.05" y2="-0.635" width="0.2032" layer="21"/>
-<wire x1="17.145" y1="1.27" x2="16.51" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="16.51" y1="-0.635" x2="17.145" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="18.415" y1="-1.27" x2="17.145" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="34.925" y1="1.27" x2="34.29" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="34.925" y1="1.27" x2="36.195" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="36.195" y1="1.27" x2="36.83" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="36.83" y1="-0.635" x2="36.195" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="36.195" y1="-1.27" x2="34.925" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="34.29" y1="-0.635" x2="34.925" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="37.465" y1="1.27" x2="36.83" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="37.465" y1="1.27" x2="38.735" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="38.735" y1="1.27" x2="39.37" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="39.37" y1="-0.635" x2="38.735" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="38.735" y1="-1.27" x2="37.465" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="36.83" y1="-0.635" x2="37.465" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="40.005" y1="1.27" x2="39.37" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="40.005" y1="1.27" x2="41.275" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="41.275" y1="1.27" x2="41.91" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="41.91" y1="-0.635" x2="41.275" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="41.275" y1="-1.27" x2="40.005" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="39.37" y1="-0.635" x2="40.005" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="42.545" y1="1.27" x2="41.91" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="42.545" y1="1.27" x2="43.815" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="43.815" y1="1.27" x2="44.45" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="44.45" y1="-0.635" x2="43.815" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="43.815" y1="-1.27" x2="42.545" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="41.91" y1="-0.635" x2="42.545" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="45.085" y1="1.27" x2="44.45" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="45.085" y1="1.27" x2="46.355" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="46.355" y1="1.27" x2="46.99" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="46.99" y1="-0.635" x2="46.355" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="46.355" y1="-1.27" x2="45.085" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="44.45" y1="-0.635" x2="45.085" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="46.99" y1="0.635" x2="46.99" y2="-0.635" width="0.2032" layer="21"/>
-<pad name="1" x="0" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="2" x="2.54" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="3" x="5.08" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="4" x="7.62" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="5" x="10.16" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="6" x="12.7" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="7" x="15.24" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="8" x="17.78" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="9" x="20.32" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="10" x="22.86" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="11" x="25.4" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="12" x="27.94" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="13" x="30.48" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="14" x="33.02" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="15" x="35.56" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="16" x="38.1" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="17" x="40.64" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="18" x="43.18" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="19" x="45.72" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<rectangle x1="14.986" y1="-0.254" x2="15.494" y2="0.254" layer="51"/>
-<rectangle x1="12.446" y1="-0.254" x2="12.954" y2="0.254" layer="51"/>
-<rectangle x1="9.906" y1="-0.254" x2="10.414" y2="0.254" layer="51"/>
-<rectangle x1="7.366" y1="-0.254" x2="7.874" y2="0.254" layer="51"/>
-<rectangle x1="4.826" y1="-0.254" x2="5.334" y2="0.254" layer="51"/>
-<rectangle x1="2.286" y1="-0.254" x2="2.794" y2="0.254" layer="51"/>
-<rectangle x1="-0.254" y1="-0.254" x2="0.254" y2="0.254" layer="51"/>
-<rectangle x1="32.766" y1="-0.254" x2="33.274" y2="0.254" layer="51"/>
-<rectangle x1="30.226" y1="-0.254" x2="30.734" y2="0.254" layer="51"/>
-<rectangle x1="27.686" y1="-0.254" x2="28.194" y2="0.254" layer="51"/>
-<rectangle x1="25.146" y1="-0.254" x2="25.654" y2="0.254" layer="51"/>
-<rectangle x1="22.606" y1="-0.254" x2="23.114" y2="0.254" layer="51"/>
-<rectangle x1="20.066" y1="-0.254" x2="20.574" y2="0.254" layer="51"/>
-<rectangle x1="17.526" y1="-0.254" x2="18.034" y2="0.254" layer="51"/>
-<rectangle x1="35.306" y1="-0.254" x2="35.814" y2="0.254" layer="51"/>
-<rectangle x1="37.846" y1="-0.254" x2="38.354" y2="0.254" layer="51"/>
-<rectangle x1="40.386" y1="-0.254" x2="40.894" y2="0.254" layer="51"/>
-<rectangle x1="42.926" y1="-0.254" x2="43.434" y2="0.254" layer="51"/>
-<rectangle x1="45.466" y1="-0.254" x2="45.974" y2="0.254" layer="51"/>
-<text x="-1.27" y="1.397" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
-<text x="-1.27" y="-2.032" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
-</package>
 <package name="1X06">
 <description>&lt;h3&gt;Plated Through Hole - 6 Pin&lt;/h3&gt;
 &lt;p&gt;Specifications:
@@ -2991,6 +3759,70 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <rectangle x1="4.826" y1="-0.254" x2="5.334" y2="0.254" layer="51"/>
 <wire x1="-0.635" y1="-1.605" x2="0.635" y2="-1.605" width="0.2032" layer="22"/>
 </package>
+<package name="1X07_NO_SILK">
+<description>&lt;h3&gt;Plated Through Hole -7 Pin  No Silk&lt;/h3&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:7&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_07&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<pad name="1" x="0" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="2" x="2.54" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="3" x="5.08" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="4" x="7.62" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="5" x="10.16" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="6" x="12.7" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="7" x="15.24" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<rectangle x1="14.986" y1="-0.254" x2="15.494" y2="0.254" layer="51"/>
+<rectangle x1="12.446" y1="-0.254" x2="12.954" y2="0.254" layer="51"/>
+<rectangle x1="9.906" y1="-0.254" x2="10.414" y2="0.254" layer="51"/>
+<rectangle x1="7.366" y1="-0.254" x2="7.874" y2="0.254" layer="51"/>
+<rectangle x1="4.826" y1="-0.254" x2="5.334" y2="0.254" layer="51"/>
+<rectangle x1="2.286" y1="-0.254" x2="2.794" y2="0.254" layer="51"/>
+<rectangle x1="-0.254" y1="-0.254" x2="0.254" y2="0.254" layer="51"/>
+<text x="-1.27" y="1.397" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.27" y="-2.032" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="1X04_NO_SILK">
+<description>&lt;h3&gt;Plated Through Hole - 4 Pin No Silk Outline&lt;/h3&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:4&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_04&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<pad name="1" x="0" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="2" x="2.54" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="3" x="5.08" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="4" x="7.62" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<rectangle x1="7.366" y1="-0.254" x2="7.874" y2="0.254" layer="51"/>
+<rectangle x1="4.826" y1="-0.254" x2="5.334" y2="0.254" layer="51"/>
+<rectangle x1="2.286" y1="-0.254" x2="2.794" y2="0.254" layer="51"/>
+<rectangle x1="-0.254" y1="-0.254" x2="0.254" y2="0.254" layer="51"/>
+<text x="-1.27" y="1.397" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.27" y="-2.032" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="1X03_NO_SILK">
+<description>&lt;h3&gt;Plated Through Hole - 3 Pin No Silk Outline&lt;/h3&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:3&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_03&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<pad name="1" x="0" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="2" x="2.54" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="3" x="5.08" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<rectangle x1="4.826" y1="-0.254" x2="5.334" y2="0.254" layer="51"/>
+<rectangle x1="2.286" y1="-0.254" x2="2.794" y2="0.254" layer="51"/>
+<rectangle x1="-0.254" y1="-0.254" x2="0.254" y2="0.254" layer="51"/>
+<text x="-1.27" y="1.397" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.27" y="-2.032" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
 </packages>
 </library>
 <library name="SparkFun-LED">
@@ -3112,10 +3944,9 @@ We've spent an enormous amount of time creating and checking these footprints an
 &lt;br&gt;
 You are welcome to use this library for commercial purposes. For attribution, we ask that when you begin to sell your device using our footprint, you email us with a link to the product being sold. We want bragging rights that we helped (in a very small part) to create your 8th world wonder. We would like the opportunity to feature your device on our homepage.</description>
 <packages>
-<package name="TACTILE_SWITCH_PTH_6.0MM_KIT">
+<package name="TACTILE_SWITCH_PTH_6.0MM">
 <description>&lt;h3&gt;Momentary Switch (Pushbutton) - SPST - PTH, 6.0mm Square&lt;/h3&gt;
 &lt;p&gt;Normally-open (NO) SPST momentary switches (buttons, pushbuttons).&lt;/p&gt;
-&lt;p&gt;&lt;b&gt;Warning:&lt;/b&gt; This is the KIT version of this package. This package has a smaller diameter top stop mask, which doesn't cover the diameter of the pad. This means only the bottom side of the pads' copper will be exposed. You'll only be able to solder to the bottom side.&lt;/p&gt;
 &lt;p&gt;&lt;a href="https://www.omron.com/ecb/products/pdf/en-b3f.pdf"&gt;Datasheet&lt;/a&gt; (B3F-1000)&lt;/p&gt;</description>
 <wire x1="3.048" y1="1.016" x2="3.048" y2="2.54" width="0.2032" layer="51"/>
 <wire x1="3.048" y1="2.54" x2="2.54" y2="3.048" width="0.2032" layer="51"/>
@@ -3137,91 +3968,11 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <wire x1="-2.54" y1="-0.508" x2="-2.54" y2="-1.27" width="0.2032" layer="51"/>
 <wire x1="-2.54" y1="0.508" x2="-2.159" y2="-0.381" width="0.2032" layer="51"/>
 <circle x="0" y="0" radius="1.778" width="0.2032" layer="21"/>
-<pad name="1" x="-3.2512" y="2.2606" drill="1.016" diameter="1.8796" stop="no"/>
-<pad name="2" x="3.2512" y="2.2606" drill="1.016" diameter="1.8796" stop="no"/>
-<pad name="3" x="-3.2512" y="-2.2606" drill="1.016" diameter="1.8796" stop="no"/>
-<pad name="4" x="3.2512" y="-2.2606" drill="1.016" diameter="1.8796" stop="no"/>
-<polygon width="0.127" layer="30">
-<vertex x="-3.2664" y="3.142"/>
-<vertex x="-3.2589" y="3.1445" curve="89.986886"/>
-<vertex x="-4.1326" y="2.286"/>
-<vertex x="-4.1351" y="2.2657" curve="90.00652"/>
-<vertex x="-3.2563" y="1.392"/>
-<vertex x="-3.2487" y="1.3869" curve="90.006616"/>
-<vertex x="-2.3826" y="2.2403"/>
-<vertex x="-2.3775" y="2.2683" curve="89.98711"/>
-</polygon>
-<polygon width="0.127" layer="29">
-<vertex x="-3.2462" y="2.7026"/>
-<vertex x="-3.2589" y="2.7051" curve="90.026544"/>
-<vertex x="-3.6881" y="2.2733"/>
-<vertex x="-3.6881" y="2.2632" curve="89.974074"/>
-<vertex x="-3.2562" y="1.8213"/>
-<vertex x="-3.2259" y="1.8186" curve="90.051271"/>
-<vertex x="-2.8093" y="2.2658"/>
-<vertex x="-2.8093" y="2.2606" curve="90.012964"/>
-</polygon>
-<polygon width="0.127" layer="30">
-<vertex x="3.2411" y="3.1395"/>
-<vertex x="3.2486" y="3.142" curve="89.986886"/>
-<vertex x="2.3749" y="2.2835"/>
-<vertex x="2.3724" y="2.2632" curve="90.00652"/>
-<vertex x="3.2512" y="1.3895"/>
-<vertex x="3.2588" y="1.3844" curve="90.006616"/>
-<vertex x="4.1249" y="2.2378"/>
-<vertex x="4.13" y="2.2658" curve="89.98711"/>
-</polygon>
-<polygon width="0.127" layer="29">
-<vertex x="3.2613" y="2.7001"/>
-<vertex x="3.2486" y="2.7026" curve="90.026544"/>
-<vertex x="2.8194" y="2.2708"/>
-<vertex x="2.8194" y="2.2607" curve="89.974074"/>
-<vertex x="3.2513" y="1.8188"/>
-<vertex x="3.2816" y="1.8161" curve="90.051271"/>
-<vertex x="3.6982" y="2.2633"/>
-<vertex x="3.6982" y="2.2581" curve="90.012964"/>
-</polygon>
-<polygon width="0.127" layer="30">
-<vertex x="-3.2613" y="-1.3868"/>
-<vertex x="-3.2538" y="-1.3843" curve="89.986886"/>
-<vertex x="-4.1275" y="-2.2428"/>
-<vertex x="-4.13" y="-2.2631" curve="90.00652"/>
-<vertex x="-3.2512" y="-3.1368"/>
-<vertex x="-3.2436" y="-3.1419" curve="90.006616"/>
-<vertex x="-2.3775" y="-2.2885"/>
-<vertex x="-2.3724" y="-2.2605" curve="89.98711"/>
-</polygon>
-<polygon width="0.127" layer="29">
-<vertex x="-3.2411" y="-1.8262"/>
-<vertex x="-3.2538" y="-1.8237" curve="90.026544"/>
-<vertex x="-3.683" y="-2.2555"/>
-<vertex x="-3.683" y="-2.2656" curve="89.974074"/>
-<vertex x="-3.2511" y="-2.7075"/>
-<vertex x="-3.2208" y="-2.7102" curve="90.051271"/>
-<vertex x="-2.8042" y="-2.263"/>
-<vertex x="-2.8042" y="-2.2682" curve="90.012964"/>
-</polygon>
-<polygon width="0.127" layer="30">
-<vertex x="3.2411" y="-1.3843"/>
-<vertex x="3.2486" y="-1.3818" curve="89.986886"/>
-<vertex x="2.3749" y="-2.2403"/>
-<vertex x="2.3724" y="-2.2606" curve="90.00652"/>
-<vertex x="3.2512" y="-3.1343"/>
-<vertex x="3.2588" y="-3.1394" curve="90.006616"/>
-<vertex x="4.1249" y="-2.286"/>
-<vertex x="4.13" y="-2.258" curve="89.98711"/>
-</polygon>
-<polygon width="0.127" layer="29">
-<vertex x="3.2613" y="-1.8237"/>
-<vertex x="3.2486" y="-1.8212" curve="90.026544"/>
-<vertex x="2.8194" y="-2.253"/>
-<vertex x="2.8194" y="-2.2631" curve="89.974074"/>
-<vertex x="3.2513" y="-2.705"/>
-<vertex x="3.2816" y="-2.7077" curve="90.051271"/>
-<vertex x="3.6982" y="-2.2605"/>
-<vertex x="3.6982" y="-2.2657" curve="90.012964"/>
-</polygon>
-<text x="0" y="3.175" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
+<pad name="1" x="-3.2512" y="2.2606" drill="1.016" diameter="1.8796"/>
+<pad name="2" x="3.2512" y="2.2606" drill="1.016" diameter="1.8796"/>
+<pad name="3" x="-3.2512" y="-2.2606" drill="1.016" diameter="1.8796"/>
+<pad name="4" x="3.2512" y="-2.2606" drill="1.016" diameter="1.8796"/>
+<text x="0" y="3.302" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
 <text x="0" y="-3.175" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;Value</text>
 </package>
 </packages>
@@ -3261,6 +4012,12 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <vertex x="0.1905" y="-0.127"/>
 <vertex x="-0.1905" y="-0.127"/>
 </polygon>
+</package>
+<package name="SMT-JUMPER_2_NO_NO-SILK">
+<text x="0" y="1.143" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;NAME</text>
+<text x="0" y="-1.143" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;VALUE</text>
+<smd name="1" x="-0.4064" y="0" dx="0.635" dy="1.27" layer="1" cream="no"/>
+<smd name="2" x="0.4064" y="0" dx="0.635" dy="1.27" layer="1" cream="no"/>
 </package>
 </packages>
 </library>
@@ -3457,42 +4214,37 @@ These rules have been curated by SparkFuns DFM commitee. After doing much resear
 <element name="ICSP" library="SparkFun-Connectors" package="2X3" value="ICSP" x="30.43" y="11.417" smashed="yes" rot="R180">
 <attribute name="NAME" x="32.435" y="8.903" size="1.27" layer="25" ratio="10"/>
 </element>
-<element name="R1" library="SparkFun-Resistors" package="AXIAL-0.3" value="330" x="37.465" y="1.27">
-<attribute name="PROD_ID" value="RES-8371" x="37.465" y="1.27" size="1.778" layer="27" display="off"/>
-<attribute name="VALUE" value="330" x="37.465" y="1.27" size="1.778" layer="27" display="off"/>
+<element name="R1" library="SparkFun-Resistors" package="AXIAL-0.3" value="330" x="10.033" y="1.27" rot="R180">
+<attribute name="PROD_ID" value="RES-8371" x="10.033" y="1.27" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="VALUE" value="330" x="10.033" y="1.27" size="1.778" layer="27" rot="R180" display="off"/>
 </element>
-<element name="R2" library="SparkFun-Resistors" package="AXIAL-0.3" value="330" x="9.525" y="1.27" rot="R180">
-<attribute name="PROD_ID" value="RES-8371" x="9.525" y="1.27" size="1.778" layer="27" rot="R180" display="off"/>
-<attribute name="VALUE" value="330" x="9.525" y="1.27" size="1.778" layer="27" rot="R180" display="off"/>
+<element name="R2" library="SparkFun-Resistors" package="AXIAL-0.3" value="330" x="11.557" y="3.556">
+<attribute name="PROD_ID" value="RES-8371" x="11.557" y="3.556" size="1.778" layer="27" display="off"/>
+<attribute name="VALUE" value="330" x="11.557" y="3.556" size="1.778" layer="27" display="off"/>
 </element>
-<element name="LED1" library="SparkFun-LED" package="LED_3MM" value="" x="42.418" y="4.445">
-<attribute name="PROD_ID" value="DIO-08794" x="42.418" y="4.445" size="1.778" layer="27" display="off"/>
+<element name="L1" library="SparkFun-LED" package="LED_3MM" value="" x="2.54" y="2.413">
+<attribute name="PROD_ID" value="DIO-08794" x="2.54" y="2.413" size="1.778" layer="27" display="off"/>
 </element>
-<element name="LED2" library="SparkFun-LED" package="LED_3MM" value="" x="2.54" y="2.54">
-<attribute name="PROD_ID" value="DIO-08794" x="2.54" y="2.54" size="1.778" layer="27" display="off"/>
+<element name="L2" library="SparkFun-LED" package="LED_3MM" value="" x="19.05" y="2.54">
+<attribute name="PROD_ID" value="DIO-08794" x="19.05" y="2.54" size="1.778" layer="27" display="off"/>
 </element>
-<element name="JP4" library="SparkFun-Connectors" package="1X01" value="" x="18.6055" y="1.27" rot="R270"/>
-<element name="JP9" library="SparkFun-Connectors" package="1X01" value="" x="16.0655" y="1.27" rot="R270"/>
+<element name="JP_3" library="SparkFun-Connectors" package="1X01" value="" x="23.1775" y="1.4605" rot="R180"/>
+<element name="JP_4" library="SparkFun-Connectors" package="1X01" value="" x="25.7175" y="1.4605" rot="R180"/>
 <element name="JP12" library="SparkFun-Connectors" package="1X08" value="" x="45.72" y="11.43" rot="R90">
 <attribute name="PROD_ID" value="CONN-08438" x="45.72" y="11.43" size="1.778" layer="27" rot="R90" display="off"/>
 </element>
 <element name="JP10" library="SparkFun-Connectors" package="1X06" value="" x="7.62" y="11.43" rot="R90">
 <attribute name="PROD_ID" value="CONN-08437" x="7.62" y="11.43" size="1.778" layer="27" rot="R90" display="off"/>
 </element>
-<element name="5V_RAIL" library="SparkFun-Connectors" package="1X19" value="" x="11.43" y="59.69" rot="R270"/>
-<element name="GND_RAIL" library="SparkFun-Connectors" package="1X19" value="" x="41.91" y="59.69" rot="R270"/>
-<element name="BB1" library="SparkFun-Boards" package="BREADBOARD-MINI" value="BREADBOARDMINI" x="26.67" y="35.56" rot="R270">
-<attribute name="PROD_ID" value="COMP-12034" x="26.67" y="35.56" size="1.778" layer="27" rot="R270" display="off"/>
+<element name="BB1" library="SparkFun-Boards" package="BREADBOARD-MINI" value="BREADBOARDMINI" x="26.67" y="38.1" rot="R270">
+<attribute name="PROD_ID" value="COMP-12034" x="26.67" y="38.1" size="1.778" layer="27" rot="R270" display="off"/>
 </element>
-<element name="R4" library="SparkFun-Resistors" package="AXIAL-0.3" value="10k" x="27.6225" y="1.27">
-<attribute name="PROD_ID" value="RES-09435" x="27.6225" y="1.27" size="1.778" layer="27" display="off"/>
-<attribute name="VALUE" value="10k" x="27.6225" y="1.27" size="1.778" layer="27" display="off"/>
+<element name="R4" library="SparkFun-Resistors" package="AXIAL-0.3" value="10k" x="39.6875" y="3.81" rot="R180">
+<attribute name="PROD_ID" value="RES-09435" x="39.6875" y="3.81" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="VALUE" value="10k" x="39.6875" y="3.81" size="1.778" layer="27" rot="R180" display="off"/>
 </element>
-<element name="JP3" library="SparkFun-Connectors" package="1X01" value="" x="21.1455" y="1.27" smashed="yes" rot="R270">
-<attribute name="NAME" x="22.9743" y="0.0762" size="1.27" layer="25" rot="R270"/>
-<attribute name="VALUE" x="17.9705" y="2.54" size="1.27" layer="27" rot="R270"/>
-</element>
-<element name="U$1" library="SparkFun-Aesthetics" package="SFE_LOGO_NAME_FLAME_.1" value="SFE_LOGO_NAME_FLAME.1_INCH" x="9.525" y="6.858"/>
+<element name="JP_2" library="SparkFun-Connectors" package="1X01" value="" x="33.3375" y="1.4605" rot="R180"/>
+<element name="U$1" library="SparkFun-Aesthetics" package="SFE_LOGO_NAME_FLAME_.1" value="SFE_LOGO_NAME_FLAME.1_INCH" x="4.699" y="6.858"/>
 <element name="JP7" library="SparkFun-Connectors" package="1X06" value="" x="29.21" y="62.357" rot="R180">
 <attribute name="PROD_ID" value="CONN-08437" x="29.21" y="62.357" size="1.778" layer="27" rot="R180" display="off"/>
 </element>
@@ -3502,46 +4254,110 @@ These rules have been curated by SparkFuns DFM commitee. After doing much resear
 <element name="JP11" library="SparkFun-Connectors" package="1X08" value="" x="7.62" y="29.21" rot="R90">
 <attribute name="PROD_ID" value="CONN-08438" x="7.62" y="29.21" size="1.778" layer="27" rot="R90" display="off"/>
 </element>
-<element name="JP1" library="SparkFun-Connectors" package="1X10" value="" x="45.72" y="33.02" rot="R90">
-<attribute name="PROD_ID" value="CONN-11563" x="45.72" y="33.02" size="1.778" layer="27" font="vector" ratio="15" rot="R90" display="off"/>
+<element name="JP1" library="SparkFun-Connectors" package="1X10" value="" x="45.72" y="34.29" rot="R90">
+<attribute name="PROD_ID" value="CONN-11563" x="45.72" y="34.29" size="1.778" layer="27" font="vector" ratio="15" rot="R90" display="off"/>
 </element>
-<element name="S2" library="SparkFun-Switches" package="TACTILE_SWITCH_PTH_6.0MM_KIT" value="MOMENTARY-SWITCH-SPST-PTH-6.0MM-KIT" x="48.5775" y="3.81">
-<attribute name="PROD_ID" value="SWCH-08441" x="48.5775" y="3.81" size="1.778" layer="27" font="vector" ratio="15" display="off"/>
-<attribute name="SF_SKU" value="COM-00097 " x="48.5775" y="3.81" size="1.778" layer="27" display="off"/>
+<element name="SW2" library="SparkFun-Switches" package="TACTILE_SWITCH_PTH_6.0MM" value="MOMENTARY-SWITCH-SPST-PTH-6.0MM" x="48.5775" y="3.81">
+<attribute name="PROD_ID" value=" SWCH-08441" x="48.5775" y="3.81" size="1.778" layer="27" font="vector" ratio="15" display="off"/>
+<attribute name="SF_SKU" value="COM-00097" x="48.5775" y="3.81" size="1.778" layer="27" display="off"/>
 </element>
-<element name="S4" library="SparkFun-Switches" package="TACTILE_SWITCH_PTH_6.0MM_KIT" value="MOMENTARY-SWITCH-SPST-PTH-6.0MM-KIT" x="4.445" y="53.34" rot="R90">
-<attribute name="PROD_ID" value="SWCH-08441" x="4.445" y="53.34" size="1.778" layer="27" font="vector" ratio="15" rot="R90" display="off"/>
-<attribute name="SF_SKU" value="COM-00097 " x="4.445" y="53.34" size="1.778" layer="27" rot="R90" display="off"/>
+<element name="S4" library="SparkFun-Switches" package="TACTILE_SWITCH_PTH_6.0MM" value="MOMENTARY-SWITCH-SPST-PTH-6.0MM" x="4.445" y="55.626" rot="R90">
+<attribute name="PROD_ID" value=" SWCH-08441" x="4.445" y="55.626" size="1.778" layer="27" font="vector" ratio="15" rot="R90" display="off"/>
+<attribute name="SF_SKU" value="COM-00097" x="4.445" y="55.626" size="1.778" layer="27" rot="R90" display="off"/>
 </element>
 <element name="SJ1" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NC_TRACE_SILK" value="JUMPER-SMT_2_NC_TRACE_SILK" x="33.655" y="62.23" rot="MR180"/>
 <element name="SJ2" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NC_TRACE_SILK" value="JUMPER-SMT_2_NC_TRACE_SILK" x="33.655" y="59.69" rot="MR180"/>
 <element name="SJ3" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NC_TRACE_SILK" value="JUMPER-SMT_2_NC_TRACE_SILK" x="21.59" y="59.69" rot="MR0"/>
 <element name="SJ4" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NC_TRACE_SILK" value="JUMPER-SMT_2_NC_TRACE_SILK" x="13.97" y="59.69" rot="MR0"/>
-<element name="LOGO1" library="SparkFun-Aesthetics" package="OSHW-LOGO-S" value="OSHW-LOGOS" x="5.08" y="60.325"/>
+<element name="LOGO1" library="SparkFun-Aesthetics" package="OSHW-LOGO-S" value="OSHW-LOGOS" x="4.318" y="50.165"/>
 <element name="JP2" library="SparkFun-Connectors" package="1X06" value="BlueSMiRF" x="29.21" y="66.675" rot="R180">
 <attribute name="PROD_ID" value="CONN-08437" x="29.21" y="66.675" size="1.778" layer="27" font="vector" ratio="15" rot="R180" display="off"/>
 </element>
+<element name="5V" library="SparkFun-Connectors" package="1X01" value="" x="30.7975" y="1.4605" rot="R180"/>
+<element name="GND" library="SparkFun-Connectors" package="1X01" value="" x="28.2575" y="1.4605" rot="R180"/>
+<element name="5V_RAIL" library="SparkFun-Connectors" package="1X07_NO_SILK" value="" x="10.16" y="13.97"/>
+<element name="GND_RAIL_1" library="SparkFun-Connectors" package="1X07_NO_SILK" value="" x="43.18" y="13.97" rot="R180"/>
+<element name="VDD_RAIL" library="SparkFun-Connectors" package="1X04_NO_SILK" value="" x="15.24" y="11.43">
+<attribute name="PROD_ID" value="CONN-09696" x="15.24" y="11.43" size="1.778" layer="27" display="off"/>
+</element>
+<element name="GND_RAIL_2" library="SparkFun-Connectors" package="1X03_NO_SILK" value="" x="38.1" y="11.43"/>
+<element name="JP13" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL1" x="21.59" y="16.51" rot="MR180"/>
+<element name="JP14" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL1" x="19.05" y="16.51" rot="MR180"/>
+<element name="JP15" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL1" x="16.51" y="16.51" rot="MR180"/>
+<element name="JP16" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL2" x="21.59" y="19.05" rot="MR180"/>
+<element name="JP17" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL2" x="19.05" y="19.05" rot="MR180"/>
+<element name="JP18" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL2" x="16.51" y="19.05" rot="MR180"/>
+<element name="JP19" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL3" x="21.59" y="21.59" rot="MR180"/>
+<element name="JP20" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL3" x="19.05" y="21.59" rot="MR180"/>
+<element name="JP21" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL3" x="16.51" y="21.59" rot="MR180"/>
+<element name="JP22" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL4" x="21.59" y="24.13" rot="MR180"/>
+<element name="JP23" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL4" x="19.05" y="24.13" rot="MR180"/>
+<element name="JP24" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL4" x="16.51" y="24.13" rot="MR180"/>
+<element name="JP25" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL5" x="21.59" y="26.67" rot="MR180"/>
+<element name="JP26" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL5" x="19.05" y="26.67" rot="MR180"/>
+<element name="JP27" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL5" x="16.51" y="26.67" rot="MR180"/>
+<element name="JP28" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL6" x="21.59" y="29.21" rot="MR180"/>
+<element name="JP29" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL6" x="19.05" y="29.21" rot="MR180"/>
+<element name="JP30" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL6" x="16.51" y="29.21" rot="MR180"/>
+<element name="JP31" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL7" x="21.59" y="31.75" rot="MR180"/>
+<element name="JP32" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL7" x="19.05" y="31.75" rot="MR180"/>
+<element name="JP33" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL7" x="16.51" y="31.75" rot="MR180"/>
+<element name="JP34" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL8" x="21.59" y="34.29" rot="MR180"/>
+<element name="JP35" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL8" x="19.05" y="34.29" rot="MR180"/>
+<element name="JP36" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL8" x="16.51" y="34.29" rot="MR180"/>
+<element name="JP37" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL9" x="21.59" y="36.83" rot="MR180"/>
+<element name="JP38" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL9" x="19.05" y="36.83" rot="MR180"/>
+<element name="JP39" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL9" x="16.51" y="36.83" rot="MR0"/>
+<element name="JP40" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL18" x="31.75" y="36.83" rot="MR180"/>
+<element name="JP41" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL18" x="34.29" y="36.83" rot="MR180"/>
+<element name="JP42" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL18" x="36.83" y="36.83" rot="MR180"/>
+<element name="JP43" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL18" x="31.75" y="34.29" rot="MR180"/>
+<element name="JP44" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL18" x="34.29" y="34.29" rot="MR180"/>
+<element name="JP45" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL18" x="36.83" y="34.29" rot="MR180"/>
+<element name="JP46" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL18" x="31.75" y="31.75" rot="MR180"/>
+<element name="JP47" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL18" x="34.29" y="31.75" rot="MR180"/>
+<element name="JP48" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL18" x="36.83" y="31.75" rot="MR180"/>
+<element name="JP49" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL17" x="31.75" y="29.21" rot="MR180"/>
+<element name="JP50" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL17" x="34.29" y="29.21" rot="MR180"/>
+<element name="JP51" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL17" x="36.83" y="29.21" rot="MR180"/>
+<element name="JP52" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL16" x="31.75" y="26.67" rot="MR180"/>
+<element name="JP53" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL16" x="34.29" y="26.67" rot="MR180"/>
+<element name="JP54" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL16" x="36.83" y="26.67" rot="MR180"/>
+<element name="JP55" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL15" x="31.75" y="24.13" rot="MR180"/>
+<element name="JP56" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL15" x="34.29" y="24.13" rot="MR180"/>
+<element name="JP57" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL15" x="36.83" y="24.13" rot="MR180"/>
+<element name="JP58" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL14" x="31.75" y="21.59" rot="MR180"/>
+<element name="JP59" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL14" x="34.29" y="21.59" rot="MR180"/>
+<element name="JP60" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL14" x="36.83" y="21.59" rot="MR180"/>
+<element name="JP61" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL13" x="31.75" y="19.05" rot="MR180"/>
+<element name="JP62" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL13" x="34.29" y="19.05" rot="MR180"/>
+<element name="JP63" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL13" x="36.83" y="19.05" rot="MR180"/>
+<element name="JP64" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL12" x="31.75" y="16.51" rot="MR180"/>
+<element name="JP65" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL12" x="34.29" y="16.51" rot="MR180"/>
+<element name="JP66" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL12" x="36.83" y="16.51" rot="MR180"/>
+<element name="JP67" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL10" x="25.4" y="17.78" rot="MR270"/>
+<element name="JP68" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL10" x="25.4" y="20.32" rot="MR270"/>
+<element name="JP69" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL10" x="25.4" y="22.86" rot="MR270"/>
+<element name="JP70" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL10" x="25.4" y="25.4" rot="MR270"/>
+<element name="JP71" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL10" x="25.4" y="27.94" rot="MR270"/>
+<element name="JP72" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL10" x="25.4" y="30.48" rot="MR270"/>
+<element name="JP73" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL10" x="25.4" y="33.02" rot="MR270"/>
+<element name="JP74" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL10" x="25.4" y="35.56" rot="MR270"/>
+<element name="JP75" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL10" x="25.4" y="38.1" rot="MR270"/>
+<element name="JP76" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL11" x="27.94" y="17.78" rot="MR270"/>
+<element name="JP77" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL11" x="27.94" y="20.32" rot="MR270"/>
+<element name="JP78" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL11" x="27.94" y="22.86" rot="MR270"/>
+<element name="JP79" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL11" x="27.94" y="25.4" rot="MR270"/>
+<element name="JP80" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL11" x="27.94" y="27.94" rot="MR270"/>
+<element name="JP81" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL11" x="27.94" y="30.48" rot="MR270"/>
+<element name="JP82" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL11" x="27.94" y="33.02" rot="MR270"/>
+<element name="JP83" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL11" x="27.94" y="35.56" rot="MR270"/>
+<element name="JP84" library="SparkFun-Jumpers" package="SMT-JUMPER_2_NO_NO-SILK" value="D_RAIL11" x="27.94" y="38.1" rot="MR270"/>
 </elements>
 <signals>
 <signal name="GND" class="1">
 <contactref element="R2" pad="P$1"/>
 <contactref element="R1" pad="P$1"/>
-<contactref element="GND_RAIL" pad="16"/>
-<contactref element="GND_RAIL" pad="1"/>
-<contactref element="GND_RAIL" pad="2"/>
-<contactref element="GND_RAIL" pad="3"/>
-<contactref element="GND_RAIL" pad="4"/>
-<contactref element="GND_RAIL" pad="5"/>
-<contactref element="GND_RAIL" pad="6"/>
-<contactref element="GND_RAIL" pad="7"/>
-<contactref element="GND_RAIL" pad="8"/>
-<contactref element="GND_RAIL" pad="9"/>
-<contactref element="GND_RAIL" pad="10"/>
-<contactref element="GND_RAIL" pad="11"/>
-<contactref element="GND_RAIL" pad="12"/>
-<contactref element="GND_RAIL" pad="13"/>
-<contactref element="GND_RAIL" pad="14"/>
-<contactref element="GND_RAIL" pad="15"/>
 <contactref element="ICSP" pad="6"/>
 <polygon width="0.254" layer="1" isolate="0.3048">
 <vertex x="53.34" y="0"/>
@@ -3551,22 +4367,14 @@ These rules have been curated by SparkFuns DFM commitee. After doing much resear
 </polygon>
 <contactref element="JP1" pad="7"/>
 <contactref element="S4" pad="1"/>
-<contactref element="S2" pad="1"/>
-<contactref element="GND_RAIL" pad="17"/>
-<contactref element="GND_RAIL" pad="18"/>
+<contactref element="SW2" pad="1"/>
 <contactref element="JP8" pad="GND@0"/>
 <contactref element="SJ3" pad="2"/>
-<contactref element="GND_RAIL" pad="19"/>
 <contactref element="JP8" pad="GND@1"/>
 <contactref element="JP8" pad="GND@2"/>
 <contactref element="JP11" pad="3"/>
 <contactref element="JP11" pad="2"/>
 <via x="19.304" y="59.69" extent="1-16" drill="0.381"/>
-<wire x1="15.24" y1="4.445" x2="13.335" y2="2.54" width="0.254" layer="1"/>
-<wire x1="13.335" y1="2.54" x2="13.335" y2="1.27" width="0.254" layer="1"/>
-<wire x1="20.0025" y1="7.4295" x2="20.0025" y2="4.6355" width="0.2032" layer="1"/>
-<via x="25.146" y="3.302" extent="1-16" drill="0.508"/>
-<via x="32.004" y="3.429" extent="1-16" drill="0.508"/>
 <polygon width="0.254" layer="16" isolate="0.3048">
 <vertex x="53.34" y="0"/>
 <vertex x="0" y="0"/>
@@ -3575,753 +4383,742 @@ These rules have been curated by SparkFuns DFM commitee. After doing much resear
 </polygon>
 <wire x1="45.3263" y1="6.0706" x2="50.0126" y2="6.0706" width="0.254" layer="1"/>
 <wire x1="51.1175" y1="7.1755" x2="51.1175" y2="9.3345" width="0.2032" layer="1"/>
-<wire x1="51.1175" y1="7.1755" x2="50.9905" y2="7.0485" width="0.2032" layer="1"/>
 <wire x1="50.546" y1="9.906" x2="51.1175" y2="9.3345" width="0.2032" layer="1"/>
-<wire x1="50.0126" y1="6.0706" x2="50.9905" y2="7.0485" width="0.254" layer="1"/>
-<wire x1="15.24" y1="4.445" x2="19.812" y2="4.445" width="0.254" layer="1"/>
-<wire x1="19.812" y1="4.445" x2="20.0025" y2="4.6355" width="0.254" layer="1"/>
 <wire x1="19.304" y1="59.69" x2="21.082" y2="59.69" width="0.254" layer="16"/>
 <contactref element="JP7" pad="3"/>
 <contactref element="SJ3" pad="1"/>
 <wire x1="24.13" y1="60.452" x2="23.368" y2="59.69" width="0.254" layer="16"/>
 <wire x1="22.098" y1="59.69" x2="23.368" y2="59.69" width="0.254" layer="16"/>
-<wire x1="32.004" y1="3.429" x2="33.655" y2="1.778" width="0.254" layer="1"/>
-<wire x1="33.655" y1="1.778" x2="33.655" y2="1.27" width="0.254" layer="1"/>
 <contactref element="JP2" pad="3"/>
 <wire x1="24.13" y1="62.357" x2="24.13" y2="66.675" width="0.254" layer="1"/>
 <wire x1="24.13" y1="62.357" x2="24.13" y2="60.452" width="0.254" layer="16"/>
+<contactref element="GND" pad="1"/>
+<wire x1="7.747" y1="3.556" x2="11.557" y2="3.556" width="0.254" layer="16"/>
+<wire x1="11.557" y1="3.556" x2="13.843" y2="1.27" width="0.254" layer="16"/>
+<wire x1="20.574" y1="0.762" x2="14.351" y2="0.762" width="0.254" layer="16"/>
+<wire x1="14.351" y1="0.762" x2="13.843" y2="1.27" width="0.254" layer="16"/>
+<wire x1="35.433" y1="1.905" x2="39.116" y2="1.905" width="0.254" layer="16"/>
+<wire x1="39.116" y1="1.905" x2="43.307" y2="6.096" width="0.254" layer="16"/>
+<wire x1="43.307" y1="6.096" x2="45.3009" y2="6.096" width="0.254" layer="16"/>
+<wire x1="45.3009" y1="6.096" x2="45.3263" y2="6.0706" width="0.254" layer="16"/>
+<wire x1="50.0126" y1="6.0706" x2="51.1175" y2="7.1755" width="0.254" layer="1"/>
+<wire x1="20.574" y1="0.762" x2="21.59" y2="1.778" width="0.254" layer="16"/>
+<wire x1="21.59" y1="1.778" x2="21.59" y2="3.302" width="0.254" layer="16"/>
+<wire x1="21.59" y1="3.302" x2="22.606" y2="4.318" width="0.254" layer="16"/>
+<wire x1="28.2575" y1="1.4605" x2="28.2575" y2="3.0099" width="0.254" layer="16"/>
+<wire x1="28.2575" y1="3.0099" x2="28.2702" y2="3.0226" width="0.254" layer="16"/>
+<wire x1="28.2702" y1="3.0226" x2="34.3154" y2="3.0226" width="0.254" layer="16"/>
+<wire x1="22.606" y1="4.318" x2="26.9494" y2="4.318" width="0.254" layer="16"/>
+<wire x1="26.9494" y1="4.318" x2="28.2575" y2="3.0099" width="0.254" layer="16"/>
+<wire x1="34.3154" y1="3.0226" x2="35.433" y2="1.905" width="0.254" layer="16"/>
+<wire x1="6.0325" y1="6.858" x2="6.0325" y2="4.572" width="0.2032" layer="1"/>
+<wire x1="50.8" y1="48.26" x2="46.99" y2="48.26" width="0.254" layer="16"/>
+<wire x1="46.99" y1="48.26" x2="45.72" y2="49.53" width="0.254" layer="16"/>
+<contactref element="GND_RAIL_1" pad="7"/>
+<contactref element="GND_RAIL_1" pad="6"/>
+<contactref element="GND_RAIL_1" pad="5"/>
+<contactref element="GND_RAIL_1" pad="4"/>
+<contactref element="GND_RAIL_1" pad="3"/>
+<contactref element="GND_RAIL_1" pad="2"/>
+<contactref element="GND_RAIL_1" pad="1"/>
+<wire x1="27.94" y1="13.97" x2="43.18" y2="13.97" width="1.524" layer="16"/>
+<contactref element="GND_RAIL_2" pad="3"/>
+<contactref element="GND_RAIL_2" pad="2"/>
+<contactref element="GND_RAIL_2" pad="1"/>
+<wire x1="43.18" y1="11.43" x2="38.1" y2="11.43" width="1.524" layer="16"/>
+<wire x1="7.62" y1="34.29" x2="2.54" y2="34.29" width="0.254" layer="16"/>
+<wire x1="7.62" y1="31.75" x2="2.54" y2="31.75" width="0.254" layer="16"/>
+<wire x1="2.1844" y1="52.3748" x2="2.1844" y2="56.7944" width="0.254" layer="16"/>
+<wire x1="19.304" y1="59.69" x2="18.288" y2="59.69" width="0.254" layer="16"/>
+<wire x1="18.288" y1="59.69" x2="17.526" y2="60.452" width="0.254" layer="16"/>
+<wire x1="17.526" y1="60.452" x2="15.494" y2="60.452" width="0.254" layer="16"/>
+<wire x1="15.494" y1="60.452" x2="14.478" y2="61.468" width="0.254" layer="16"/>
+<wire x1="14.478" y1="61.468" x2="6.858" y2="61.468" width="0.254" layer="16"/>
+<wire x1="2.1844" y1="56.7944" x2="6.858" y2="61.468" width="0.254" layer="16"/>
+<wire x1="7.0485" y1="7.874" x2="6.0325" y2="6.858" width="0.254" layer="1"/>
+<wire x1="24.384" y1="7.874" x2="24.384" y2="7.911" width="0.254" layer="16"/>
+<wire x1="24.384" y1="7.911" x2="25.35" y2="8.877" width="0.254" layer="16"/>
+<wire x1="7.0485" y1="3.556" x2="6.0325" y2="4.572" width="0.254" layer="1"/>
+<wire x1="7.747" y1="3.556" x2="7.0485" y2="3.556" width="0.254" layer="1"/>
+<wire x1="7.0485" y1="7.874" x2="17.145" y2="7.874" width="0.254" layer="1"/>
+<via x="17.145" y="7.874" extent="1-16" drill="0.381"/>
+<wire x1="17.145" y1="7.874" x2="24.384" y2="7.874" width="0.254" layer="16"/>
 </signal>
 <signal name="N$6">
 <contactref element="R1" pad="P$2"/>
-<contactref element="LED1" pad="K"/>
-<wire x1="41.275" y1="1.27" x2="42.545" y2="1.27" width="0.254" layer="16"/>
-<wire x1="43.688" y1="4.445" x2="43.688" y2="2.413" width="0.254" layer="16"/>
-<wire x1="43.688" y1="2.413" x2="42.545" y2="1.27" width="0.254" layer="16"/>
+<contactref element="L1" pad="K"/>
+<wire x1="6.223" y1="1.27" x2="4.953" y2="1.27" width="0.254" layer="1"/>
+<wire x1="4.953" y1="1.27" x2="3.81" y2="2.413" width="0.254" layer="1"/>
 </signal>
 <signal name="N$7">
 <contactref element="R2" pad="P$2"/>
-<contactref element="LED2" pad="K"/>
-<wire x1="3.81" y1="2.54" x2="4.445" y2="2.54" width="0.254" layer="16"/>
-<wire x1="4.445" y1="2.54" x2="5.715" y2="1.27" width="0.254" layer="16"/>
-</signal>
-<signal name="LED1">
-<contactref element="LED1" pad="A"/>
-<contactref element="JP4" pad="1"/>
-<wire x1="41.148" y1="4.445" x2="21.7805" y2="4.445" width="0.254" layer="16"/>
-<wire x1="21.7805" y1="4.445" x2="18.6055" y2="1.27" width="0.254" layer="16"/>
-</signal>
-<signal name="LED2">
-<contactref element="LED2" pad="A"/>
-<contactref element="JP9" pad="1"/>
-<wire x1="1.27" y1="2.54" x2="1.27" y2="3.81" width="0.254" layer="16"/>
-<wire x1="1.27" y1="3.81" x2="1.905" y2="4.445" width="0.254" layer="16"/>
-<wire x1="1.905" y1="4.445" x2="14.605" y2="4.445" width="0.254" layer="16"/>
-<wire x1="16.0655" y1="1.27" x2="16.0655" y2="2.9845" width="0.254" layer="16"/>
-<wire x1="16.0655" y1="2.9845" x2="14.605" y2="4.445" width="0.254" layer="16"/>
+<contactref element="L2" pad="K"/>
+<wire x1="16.764" y1="4.318" x2="18.542" y2="4.318" width="0.254" layer="16"/>
+<wire x1="15.367" y1="3.556" x2="16.002" y2="3.556" width="0.254" layer="16"/>
+<wire x1="16.002" y1="3.556" x2="16.764" y2="4.318" width="0.254" layer="16"/>
+<wire x1="18.542" y1="4.318" x2="20.32" y2="2.54" width="0.254" layer="16"/>
 </signal>
 <signal name="RX">
 <contactref element="JP12" pad="1"/>
 <contactref element="JP8" pad="RX"/>
-<wire x1="45.72" y1="11.43" x2="50.8" y2="11.43" width="0.254" layer="1"/>
-<contactref element="SJ2" pad="2"/>
-<wire x1="34.163" y1="59.69" x2="38.735" y2="59.69" width="0.254" layer="16"/>
-<wire x1="38.735" y1="59.69" x2="40.005" y2="58.42" width="0.254" layer="16"/>
-<wire x1="40.005" y1="58.42" x2="43.18" y2="58.42" width="0.254" layer="16"/>
-<wire x1="43.18" y1="58.42" x2="43.815" y2="57.785" width="0.254" layer="16"/>
-<wire x1="43.815" y1="57.785" x2="43.815" y2="12.7" width="0.254" layer="16"/>
-<wire x1="43.815" y1="12.7" x2="45.085" y2="11.43" width="0.254" layer="16"/>
+<wire x1="45.72" y1="11.43" x2="50.8" y2="11.43" width="0.254" layer="16"/>
 <wire x1="45.085" y1="11.43" x2="45.72" y2="11.43" width="0.254" layer="16"/>
 <wire x1="46.355" y1="11.43" x2="45.72" y2="11.43" width="0.254" layer="16"/>
 </signal>
 <signal name="TX">
 <contactref element="JP12" pad="2"/>
 <contactref element="JP8" pad="TX"/>
-<wire x1="45.72" y1="13.97" x2="50.8" y2="13.97" width="0.254" layer="1"/>
-<contactref element="SJ1" pad="2"/>
-<wire x1="34.163" y1="62.23" x2="43.18" y2="62.23" width="0.254" layer="16"/>
-<wire x1="43.18" y1="62.23" x2="48.26" y2="57.15" width="0.254" layer="16"/>
-<wire x1="48.26" y1="57.15" x2="48.26" y2="14.605" width="0.254" layer="16"/>
-<wire x1="48.26" y1="14.605" x2="48.895" y2="13.97" width="0.254" layer="16"/>
+<wire x1="45.72" y1="13.97" x2="50.8" y2="13.97" width="0.254" layer="16"/>
 <wire x1="48.895" y1="13.97" x2="50.8" y2="13.97" width="0.254" layer="16"/>
 </signal>
 <signal name="D2">
 <contactref element="JP12" pad="3"/>
 <contactref element="JP8" pad="D2"/>
-<wire x1="45.72" y1="16.51" x2="50.8" y2="16.51" width="0.254" layer="1"/>
+<wire x1="45.72" y1="16.51" x2="50.8" y2="16.51" width="0.254" layer="16"/>
 </signal>
 <signal name="D3">
 <contactref element="JP12" pad="4"/>
 <contactref element="JP8" pad="D3"/>
-<wire x1="45.72" y1="19.05" x2="50.8" y2="19.05" width="0.254" layer="1"/>
+<wire x1="45.72" y1="19.05" x2="50.8" y2="19.05" width="0.254" layer="16"/>
 </signal>
 <signal name="D4">
 <contactref element="JP12" pad="5"/>
 <contactref element="JP8" pad="D4"/>
-<wire x1="45.72" y1="21.59" x2="50.8" y2="21.59" width="0.254" layer="1"/>
+<wire x1="45.72" y1="21.59" x2="50.8" y2="21.59" width="0.254" layer="16"/>
 </signal>
 <signal name="D5">
 <contactref element="JP12" pad="6"/>
 <contactref element="JP8" pad="D5"/>
-<wire x1="45.72" y1="24.13" x2="50.8" y2="24.13" width="0.254" layer="1"/>
+<wire x1="45.72" y1="24.13" x2="50.8" y2="24.13" width="0.254" layer="16"/>
 </signal>
 <signal name="D6">
 <contactref element="JP12" pad="7"/>
 <contactref element="JP8" pad="D6"/>
-<wire x1="45.72" y1="26.67" x2="50.8" y2="26.67" width="0.254" layer="1"/>
+<wire x1="45.72" y1="26.67" x2="50.8" y2="26.67" width="0.254" layer="16"/>
 </signal>
 <signal name="D7">
 <contactref element="JP12" pad="8"/>
 <contactref element="JP8" pad="D7"/>
-<wire x1="45.72" y1="29.21" x2="50.8" y2="29.21" width="0.254" layer="1"/>
+<wire x1="45.72" y1="29.21" x2="50.8" y2="29.21" width="0.254" layer="16"/>
 </signal>
 <signal name="D8">
 <contactref element="JP8" pad="D8"/>
 <contactref element="JP1" pad="1"/>
-<wire x1="45.72" y1="33.02" x2="50.8" y2="33.02" width="0.254" layer="1"/>
+<wire x1="50.8" y1="33.02" x2="46.99" y2="33.02" width="0.254" layer="16"/>
+<wire x1="46.99" y1="33.02" x2="45.72" y2="34.29" width="0.254" layer="16"/>
 </signal>
 <signal name="D9">
 <contactref element="JP8" pad="D9"/>
 <contactref element="JP1" pad="2"/>
-<wire x1="45.72" y1="35.56" x2="50.8" y2="35.56" width="0.254" layer="1"/>
+<wire x1="50.8" y1="35.56" x2="46.99" y2="35.56" width="0.254" layer="16"/>
+<wire x1="46.99" y1="35.56" x2="45.72" y2="36.83" width="0.254" layer="16"/>
 </signal>
 <signal name="D10">
 <contactref element="JP8" pad="D10"/>
 <contactref element="JP1" pad="3"/>
-<wire x1="45.72" y1="38.1" x2="50.8" y2="38.1" width="0.254" layer="1"/>
+<contactref element="SJ2" pad="2"/>
+<wire x1="50.8" y1="38.1" x2="46.99" y2="38.1" width="0.254" layer="16"/>
+<wire x1="46.99" y1="38.1" x2="45.72" y2="39.37" width="0.254" layer="16"/>
+<wire x1="48.768" y1="42.418" x2="48.768" y2="57.658" width="0.254" layer="1"/>
+<via x="48.768" y="57.658" extent="1-16" drill="0.381"/>
+<wire x1="45.212" y1="61.214" x2="37.084" y2="61.214" width="0.254" layer="16"/>
+<wire x1="35.56" y1="59.69" x2="34.163" y2="59.69" width="0.254" layer="16"/>
+<wire x1="48.768" y1="42.418" x2="45.72" y2="39.37" width="0.254" layer="1"/>
+<wire x1="48.768" y1="57.658" x2="45.212" y2="61.214" width="0.254" layer="16"/>
+<wire x1="35.56" y1="59.69" x2="37.084" y2="61.214" width="0.254" layer="16"/>
 </signal>
 <signal name="D11">
 <contactref element="JP8" pad="D11"/>
 <contactref element="JP1" pad="4"/>
-<wire x1="45.72" y1="40.64" x2="50.8" y2="40.64" width="0.254" layer="1"/>
+<contactref element="SJ1" pad="2"/>
+<wire x1="34.163" y1="62.23" x2="38.354" y2="62.23" width="0.254" layer="16"/>
+<via x="38.354" y="62.23" extent="1-16" drill="0.381"/>
+<wire x1="50.8" y1="40.64" x2="46.99" y2="40.64" width="0.254" layer="16"/>
+<wire x1="46.99" y1="40.64" x2="45.72" y2="41.91" width="0.254" layer="16"/>
+<wire x1="45.72" y1="41.91" x2="46.228" y2="41.91" width="0.254" layer="1"/>
+<wire x1="46.228" y1="41.91" x2="47.498" y2="43.18" width="0.254" layer="1"/>
+<wire x1="47.498" y1="43.18" x2="47.498" y2="59.69" width="0.254" layer="1"/>
+<wire x1="47.498" y1="59.69" x2="44.958" y2="62.23" width="0.254" layer="1"/>
+<wire x1="44.958" y1="62.23" x2="38.354" y2="62.23" width="0.254" layer="1"/>
 </signal>
 <signal name="D12">
 <contactref element="JP8" pad="D12"/>
 <contactref element="JP1" pad="5"/>
-<wire x1="45.72" y1="43.18" x2="50.8" y2="43.18" width="0.254" layer="1"/>
+<wire x1="50.8" y1="43.18" x2="46.99" y2="43.18" width="0.254" layer="16"/>
+<wire x1="46.99" y1="43.18" x2="45.72" y2="44.45" width="0.254" layer="16"/>
 </signal>
 <signal name="D13">
 <contactref element="JP8" pad="D13"/>
 <contactref element="JP1" pad="6"/>
-<wire x1="45.72" y1="45.72" x2="50.8" y2="45.72" width="0.254" layer="1"/>
+<wire x1="50.8" y1="45.72" x2="46.99" y2="45.72" width="0.254" layer="16"/>
+<wire x1="46.99" y1="45.72" x2="45.72" y2="46.99" width="0.254" layer="16"/>
 </signal>
 <signal name="RESET">
 <contactref element="ICSP" pad="5"/>
 <contactref element="S4" pad="3"/>
 <contactref element="JP11" pad="6"/>
 <contactref element="JP8" pad="RES"/>
-<wire x1="7.62" y1="41.91" x2="2.54" y2="41.91" width="0.254" layer="1"/>
-<wire x1="6.7056" y1="50.0888" x2="6.2738" y2="50.0888" width="0.254" layer="16"/>
-<wire x1="6.2738" y1="50.0888" x2="5.08" y2="48.895" width="0.254" layer="16"/>
-<wire x1="5.08" y1="48.895" x2="5.08" y2="42.545" width="0.254" layer="16"/>
-<wire x1="5.08" y1="42.545" x2="4.445" y2="41.91" width="0.254" layer="16"/>
-<wire x1="4.445" y1="41.91" x2="2.54" y2="41.91" width="0.254" layer="16"/>
-<wire x1="7.62" y1="41.91" x2="8.89" y2="41.91" width="0.254" layer="1"/>
-<wire x1="8.89" y1="41.91" x2="9.525" y2="41.275" width="0.254" layer="1"/>
-<wire x1="9.525" y1="41.275" x2="9.525" y2="13.335" width="0.254" layer="1"/>
-<wire x1="9.525" y1="13.335" x2="11.43" y2="11.43" width="0.254" layer="1"/>
-<wire x1="11.43" y1="11.43" x2="25.337" y2="11.43" width="0.254" layer="1"/>
-<wire x1="25.337" y1="11.43" x2="25.35" y2="11.417" width="0.254" layer="1"/>
+<wire x1="7.62" y1="41.91" x2="2.54" y2="41.91" width="0.254" layer="16"/>
+<wire x1="5.588" y1="41.91" x2="5.588" y2="51.2572" width="0.254" layer="1"/>
+<wire x1="5.588" y1="51.2572" x2="6.7056" y2="52.3748" width="0.254" layer="1"/>
+<wire x1="7.62" y1="41.91" x2="5.588" y2="41.91" width="0.254" layer="1"/>
+<wire x1="5.588" y1="41.91" x2="5.588" y2="38.354" width="0.254" layer="1"/>
+<wire x1="5.588" y1="38.354" x2="4.572" y2="37.338" width="0.254" layer="1"/>
+<wire x1="4.572" y1="37.338" x2="4.572" y2="9.652" width="0.254" layer="1"/>
+<via x="4.572" y="9.652" extent="1-16" drill="0.381"/>
+<wire x1="4.572" y1="9.652" x2="23.585" y2="9.652" width="0.254" layer="16"/>
+<wire x1="23.585" y1="9.652" x2="25.35" y2="11.417" width="0.254" layer="16"/>
 </signal>
 <signal name="5V" class="1">
-<contactref element="5V_RAIL" pad="1"/>
-<contactref element="5V_RAIL" pad="16"/>
-<contactref element="5V_RAIL" pad="15"/>
-<contactref element="5V_RAIL" pad="14"/>
-<contactref element="5V_RAIL" pad="13"/>
-<contactref element="5V_RAIL" pad="12"/>
-<contactref element="5V_RAIL" pad="11"/>
-<contactref element="5V_RAIL" pad="10"/>
-<contactref element="5V_RAIL" pad="9"/>
-<contactref element="5V_RAIL" pad="8"/>
+<contactref element="ICSP" pad="2"/>
+<contactref element="R4" pad="P$2"/>
+<contactref element="JP11" pad="4"/>
+<contactref element="JP8" pad="5V"/>
+<wire x1="7.62" y1="36.83" x2="2.54" y2="36.83" width="0.254" layer="16"/>
+<contactref element="SJ4" pad="2"/>
+<contactref element="5V" pad="1"/>
+<wire x1="30.7975" y1="7.62" x2="30.7975" y2="4.064" width="0.2032" layer="1"/>
+<wire x1="20.6375" y1="7.874" x2="20.6375" y2="4.826" width="0.2032" layer="1"/>
 <contactref element="5V_RAIL" pad="7"/>
 <contactref element="5V_RAIL" pad="6"/>
 <contactref element="5V_RAIL" pad="5"/>
 <contactref element="5V_RAIL" pad="4"/>
 <contactref element="5V_RAIL" pad="3"/>
 <contactref element="5V_RAIL" pad="2"/>
-<contactref element="ICSP" pad="2"/>
-<contactref element="R4" pad="P$2"/>
-<contactref element="5V_RAIL" pad="17"/>
-<contactref element="5V_RAIL" pad="18"/>
-<contactref element="JP11" pad="4"/>
-<contactref element="JP8" pad="5V"/>
-<wire x1="7.62" y1="36.83" x2="2.54" y2="36.83" width="0.254" layer="1"/>
-<contactref element="SJ4" pad="2"/>
-<wire x1="11.43" y1="59.69" x2="11.43" y2="57.15" width="0.254" layer="16"/>
-<wire x1="11.43" y1="57.15" x2="11.43" y2="54.61" width="0.254" layer="16"/>
-<wire x1="11.43" y1="54.61" x2="11.43" y2="52.07" width="0.254" layer="16"/>
-<wire x1="11.43" y1="52.07" x2="11.43" y2="49.53" width="0.254" layer="16"/>
-<wire x1="11.43" y1="49.53" x2="11.43" y2="46.99" width="0.254" layer="16"/>
-<wire x1="11.43" y1="46.99" x2="11.43" y2="44.45" width="0.254" layer="16"/>
-<wire x1="11.43" y1="44.45" x2="11.43" y2="41.91" width="0.254" layer="16"/>
-<wire x1="11.43" y1="41.91" x2="11.43" y2="39.37" width="0.254" layer="16"/>
-<wire x1="11.43" y1="39.37" x2="11.43" y2="36.83" width="0.254" layer="16"/>
-<wire x1="11.43" y1="36.83" x2="7.62" y2="36.83" width="0.254" layer="16"/>
-<wire x1="11.43" y1="36.83" x2="11.43" y2="34.29" width="0.254" layer="16"/>
-<wire x1="11.43" y1="34.29" x2="11.43" y2="31.75" width="0.254" layer="16"/>
-<wire x1="11.43" y1="31.75" x2="11.43" y2="29.21" width="0.254" layer="16"/>
-<wire x1="11.43" y1="29.21" x2="11.43" y2="26.67" width="0.254" layer="16"/>
-<wire x1="11.43" y1="26.67" x2="11.43" y2="24.13" width="0.254" layer="16"/>
-<wire x1="11.43" y1="24.13" x2="11.43" y2="21.59" width="0.254" layer="16"/>
-<wire x1="11.43" y1="21.59" x2="11.43" y2="19.05" width="0.254" layer="16"/>
-<wire x1="11.43" y1="19.05" x2="11.43" y2="16.51" width="0.254" layer="16"/>
-<contactref element="5V_RAIL" pad="19"/>
-<wire x1="11.43" y1="16.51" x2="11.43" y2="13.97" width="0.254" layer="16"/>
-<wire x1="11.43" y1="13.97" x2="11.43" y2="12.065" width="0.254" layer="16"/>
-<wire x1="11.43" y1="12.065" x2="12.065" y2="11.43" width="0.254" layer="16"/>
-<wire x1="12.065" y1="11.43" x2="22.86" y2="11.43" width="0.254" layer="16"/>
-<wire x1="22.86" y1="11.43" x2="24.13" y2="10.16" width="0.254" layer="16"/>
-<wire x1="24.13" y1="10.16" x2="29.147" y2="10.16" width="0.254" layer="16"/>
-<wire x1="13.462" y1="59.69" x2="11.43" y2="59.69" width="0.254" layer="16"/>
-<wire x1="30.7975" y1="8.5095" x2="30.7975" y2="1.905" width="0.2032" layer="1"/>
-<wire x1="30.7975" y1="8.5095" x2="30.43" y2="8.877" width="0.2032" layer="1"/>
-<wire x1="29.147" y1="10.16" x2="30.43" y2="8.877" width="0.254" layer="16"/>
-<wire x1="30.7975" y1="1.905" x2="31.4325" y2="1.27" width="0.2032" layer="1"/>
-</signal>
-<signal name="BUTTON">
-<contactref element="R4" pad="P$1"/>
-<contactref element="S2" pad="3"/>
-<via x="36.195" y="3.048" extent="1-16" drill="0.508"/>
-<contactref element="JP3" pad="1"/>
-<wire x1="25.0825" y1="2.54" x2="23.8125" y2="1.27" width="0.254" layer="16"/>
-<wire x1="25.0825" y1="2.54" x2="34.036" y2="2.54" width="0.254" layer="16"/>
-<wire x1="45.3263" y1="1.5494" x2="44.4246" y2="1.5494" width="0.254" layer="1"/>
-<wire x1="44.4246" y1="1.5494" x2="42.926" y2="3.048" width="0.254" layer="1"/>
-<wire x1="42.926" y1="3.048" x2="36.195" y2="3.048" width="0.254" layer="1"/>
-<wire x1="36.195" y1="3.048" x2="34.544" y2="3.048" width="0.254" layer="16"/>
-<wire x1="34.544" y1="3.048" x2="34.036" y2="2.54" width="0.254" layer="16"/>
-<wire x1="23.8125" y1="1.27" x2="21.1455" y2="1.27" width="0.254" layer="16"/>
-</signal>
-<signal name="N$3">
-<via x="39.37" y="13.97" extent="1-16" drill="1.016" diameter="1.8796"/>
-</signal>
-<signal name="N$4">
-<via x="36.83" y="13.97" extent="1-16" drill="1.016" diameter="1.8796"/>
-</signal>
-<signal name="N$5">
-<via x="13.97" y="13.97" extent="1-16" drill="1.016" diameter="1.8796"/>
-</signal>
-<signal name="N$10">
-<via x="16.51" y="13.97" extent="1-16" drill="1.016" diameter="1.8796"/>
-</signal>
-<signal name="N$11">
-<via x="19.05" y="13.97" extent="1-16" drill="1.016" diameter="1.8796"/>
-</signal>
-<signal name="N$12">
-<via x="21.59" y="13.97" extent="1-16" drill="1.016" diameter="1.8796"/>
-</signal>
-<signal name="N$13">
-<via x="24.13" y="13.97" extent="1-16" drill="1.016" diameter="1.8796"/>
-</signal>
-<signal name="N$14">
-<via x="26.67" y="13.97" extent="1-16" drill="1.016" diameter="1.8796"/>
-</signal>
-<signal name="N$15">
-<via x="29.21" y="13.97" extent="1-16" drill="1.016" diameter="1.8796"/>
-</signal>
-<signal name="N$16">
-<via x="31.75" y="13.97" extent="1-16" drill="1.016" diameter="1.8796"/>
-</signal>
-<signal name="N$17">
-<via x="34.29" y="13.97" extent="1-16" drill="1.016" diameter="1.8796"/>
+<contactref element="5V_RAIL" pad="1"/>
+<wire x1="10.16" y1="13.97" x2="25.4" y2="13.97" width="1.524" layer="16"/>
+<wire x1="10.16" y1="13.97" x2="14.478" y2="9.652" width="0.254" layer="1"/>
+<wire x1="14.478" y1="9.652" x2="20.574" y2="9.652" width="0.254" layer="1"/>
+<wire x1="20.574" y1="9.652" x2="21.844" y2="9.652" width="0.254" layer="1"/>
+<wire x1="28.665" y1="7.112" x2="24.384" y2="7.112" width="0.254" layer="1"/>
+<wire x1="24.384" y1="7.112" x2="21.844" y2="9.652" width="0.254" layer="1"/>
+<wire x1="20.6375" y1="7.874" x2="20.6375" y2="9.5885" width="0.254" layer="1"/>
+<wire x1="20.6375" y1="9.5885" x2="20.574" y2="9.652" width="0.254" layer="1"/>
+<wire x1="10.16" y1="13.97" x2="8.89" y2="15.24" width="0.254" layer="1"/>
+<wire x1="8.89" y1="15.24" x2="6.096" y2="15.24" width="0.254" layer="1"/>
+<wire x1="6.096" y1="15.24" x2="5.588" y2="15.748" width="0.254" layer="1"/>
+<wire x1="5.588" y1="15.748" x2="5.588" y2="34.798" width="0.254" layer="1"/>
+<wire x1="5.588" y1="34.798" x2="7.62" y2="36.83" width="0.254" layer="1"/>
+<wire x1="13.462" y1="59.69" x2="12.446" y2="59.69" width="0.254" layer="16"/>
+<wire x1="12.446" y1="59.69" x2="11.176" y2="58.42" width="0.254" layer="16"/>
+<wire x1="8.89" y1="57.912" x2="8.89" y2="38.1" width="0.254" layer="16"/>
+<wire x1="8.89" y1="38.1" x2="7.62" y2="36.83" width="0.254" layer="16"/>
+<wire x1="11.176" y1="58.42" x2="9.398" y2="58.42" width="0.254" layer="16"/>
+<wire x1="9.398" y1="58.42" x2="8.89" y2="57.912" width="0.254" layer="16"/>
+<wire x1="30.7975" y1="8.5095" x2="30.43" y2="8.877" width="0.254" layer="1"/>
+<wire x1="21.1455" y1="4.318" x2="20.6375" y2="4.826" width="0.2032" layer="1"/>
+<wire x1="30.7975" y1="8.5095" x2="30.7975" y2="7.62" width="0.254" layer="1"/>
+<wire x1="28.665" y1="7.112" x2="30.43" y2="8.877" width="0.254" layer="1"/>
+<wire x1="30.7975" y1="1.4605" x2="30.7975" y2="4.064" width="0.254" layer="1"/>
+<wire x1="21.1455" y1="4.318" x2="24.384" y2="4.318" width="0.2032" layer="1"/>
+<wire x1="24.384" y1="4.318" x2="24.638" y2="4.064" width="0.2032" layer="1"/>
+<wire x1="32.004" y1="3.81" x2="35.8775" y2="3.81" width="0.254" layer="1"/>
+<wire x1="32.004" y1="3.81" x2="31.75" y2="4.064" width="0.254" layer="1"/>
+<wire x1="24.638" y1="4.064" x2="30.734" y2="4.064" width="0.2032" layer="1"/>
+<wire x1="31.75" y1="4.064" x2="30.7975" y2="4.064" width="0.254" layer="1"/>
+<wire x1="20.32" y1="13.97" x2="22.86" y2="13.97" width="0" layer="19" extent="1-1"/>
+<wire x1="17.78" y1="13.97" x2="20.32" y2="13.97" width="0" layer="19" extent="1-1"/>
+<wire x1="15.24" y1="13.97" x2="17.78" y2="13.97" width="0" layer="19" extent="1-1"/>
+<wire x1="12.7" y1="13.97" x2="15.24" y2="13.97" width="0" layer="19" extent="1-1"/>
+<wire x1="25.4" y1="13.97" x2="22.86" y2="13.97" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="N$18">
-<via x="39.37" y="16.51" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="38.1" y="16.51" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$19">
-<via x="36.83" y="16.51" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="35.56" y="16.51" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$20">
-<via x="13.97" y="16.51" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="12.7" y="16.51" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$21">
-<via x="16.51" y="16.51" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="15.24" y="16.51" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$22">
-<via x="19.05" y="16.51" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="17.78" y="16.51" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$23">
-<via x="21.59" y="16.51" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="20.32" y="16.51" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$24">
-<via x="24.13" y="16.51" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="22.86" y="16.51" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$25">
-<via x="26.67" y="16.51" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="25.4" y="16.51" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$26">
-<via x="29.21" y="16.51" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="27.94" y="16.51" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$27">
-<via x="31.75" y="16.51" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="30.48" y="16.51" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$28">
-<via x="34.29" y="16.51" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="33.02" y="16.51" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$29">
-<via x="39.37" y="19.05" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="38.1" y="19.05" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$30">
-<via x="36.83" y="19.05" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="35.56" y="19.05" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$31">
-<via x="13.97" y="19.05" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="12.7" y="19.05" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$32">
-<via x="16.51" y="19.05" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="15.24" y="19.05" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$33">
-<via x="19.05" y="19.05" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="17.78" y="19.05" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$34">
-<via x="21.59" y="19.05" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="20.32" y="19.05" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$35">
-<via x="24.13" y="19.05" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="22.86" y="19.05" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$36">
-<via x="26.67" y="19.05" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="25.4" y="19.05" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$37">
-<via x="29.21" y="19.05" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="27.94" y="19.05" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$38">
-<via x="31.75" y="19.05" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="30.48" y="19.05" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$39">
-<via x="34.29" y="19.05" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="33.02" y="19.05" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$40">
-<via x="39.37" y="21.59" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="38.1" y="21.59" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$41">
-<via x="36.83" y="21.59" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="35.56" y="21.59" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$42">
-<via x="13.97" y="21.59" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="12.7" y="21.59" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$43">
-<via x="16.51" y="21.59" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="15.24" y="21.59" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$44">
-<via x="19.05" y="21.59" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="17.78" y="21.59" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$45">
-<via x="21.59" y="21.59" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="20.32" y="21.59" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$46">
-<via x="24.13" y="21.59" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="22.86" y="21.59" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$47">
-<via x="26.67" y="21.59" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="25.4" y="21.59" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$48">
-<via x="29.21" y="21.59" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="27.94" y="21.59" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$49">
-<via x="31.75" y="21.59" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="30.48" y="21.59" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$50">
-<via x="34.29" y="21.59" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="33.02" y="21.59" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$51">
-<via x="39.37" y="24.13" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="38.1" y="24.13" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$52">
-<via x="36.83" y="24.13" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="35.56" y="24.13" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$53">
-<via x="13.97" y="24.13" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="12.7" y="24.13" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$54">
-<via x="16.51" y="24.13" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="15.24" y="24.13" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$55">
-<via x="19.05" y="24.13" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="17.78" y="24.13" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$56">
-<via x="21.59" y="24.13" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="20.32" y="24.13" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$57">
-<via x="24.13" y="24.13" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="22.86" y="24.13" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$58">
-<via x="26.67" y="24.13" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="25.4" y="24.13" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$59">
-<via x="29.21" y="24.13" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="27.94" y="24.13" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$60">
-<via x="31.75" y="24.13" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="30.48" y="24.13" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$61">
-<via x="34.29" y="24.13" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="33.02" y="24.13" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$62">
-<via x="39.37" y="26.67" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="38.1" y="26.67" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$63">
-<via x="36.83" y="26.67" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="35.56" y="26.67" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$64">
-<via x="13.97" y="26.67" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="12.7" y="26.67" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$65">
-<via x="16.51" y="26.67" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="15.24" y="26.67" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$66">
-<via x="19.05" y="26.67" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="17.78" y="26.67" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$67">
-<via x="21.59" y="26.67" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="20.32" y="26.67" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$68">
-<via x="24.13" y="26.67" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="22.86" y="26.67" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$69">
-<via x="26.67" y="26.67" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="25.4" y="26.67" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$70">
-<via x="29.21" y="26.67" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="27.94" y="26.67" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$71">
-<via x="31.75" y="26.67" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="30.48" y="26.67" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$72">
-<via x="34.29" y="26.67" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="33.02" y="26.67" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$73">
-<via x="39.37" y="29.21" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="38.1" y="29.21" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$74">
-<via x="36.83" y="29.21" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="35.56" y="29.21" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$75">
-<via x="13.97" y="29.21" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="12.7" y="29.21" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$76">
-<via x="16.51" y="29.21" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="15.24" y="29.21" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$77">
-<via x="19.05" y="29.21" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="17.78" y="29.21" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$78">
-<via x="21.59" y="29.21" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="20.32" y="29.21" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$79">
-<via x="24.13" y="29.21" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="22.86" y="29.21" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$80">
-<via x="26.67" y="29.21" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="25.4" y="29.21" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$81">
-<via x="29.21" y="29.21" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="27.94" y="29.21" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$82">
-<via x="31.75" y="29.21" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="30.48" y="29.21" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$83">
-<via x="34.29" y="29.21" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="33.02" y="29.21" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$84">
-<via x="39.37" y="31.75" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="38.1" y="31.75" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$85">
-<via x="36.83" y="31.75" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="35.56" y="31.75" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$86">
-<via x="13.97" y="31.75" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="12.7" y="31.75" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$87">
-<via x="16.51" y="31.75" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="15.24" y="31.75" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$88">
-<via x="19.05" y="31.75" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="17.78" y="31.75" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$89">
-<via x="21.59" y="31.75" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="20.32" y="31.75" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$90">
-<via x="24.13" y="31.75" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="22.86" y="31.75" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$91">
-<via x="26.67" y="31.75" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="25.4" y="31.75" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$92">
-<via x="29.21" y="31.75" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="27.94" y="31.75" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$93">
-<via x="31.75" y="31.75" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="30.48" y="31.75" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$94">
-<via x="34.29" y="31.75" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="33.02" y="31.75" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$95">
-<via x="39.37" y="34.29" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="38.1" y="34.29" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$96">
-<via x="36.83" y="34.29" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="35.56" y="34.29" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$97">
-<via x="13.97" y="34.29" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="12.7" y="34.29" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$98">
-<via x="16.51" y="34.29" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="15.24" y="34.29" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$99">
-<via x="19.05" y="34.29" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="17.78" y="34.29" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$100">
-<via x="21.59" y="34.29" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="20.32" y="34.29" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$101">
-<via x="24.13" y="34.29" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="22.86" y="34.29" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$102">
-<via x="26.67" y="34.29" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="25.4" y="34.29" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$103">
-<via x="29.21" y="34.29" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="27.94" y="34.29" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$104">
-<via x="31.75" y="34.29" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="30.48" y="34.29" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$105">
-<via x="34.29" y="34.29" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="33.02" y="34.29" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$106">
-<via x="39.37" y="36.83" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="38.1" y="36.83" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$107">
-<via x="36.83" y="36.83" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="35.56" y="36.83" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$108">
-<via x="13.97" y="36.83" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="12.7" y="36.83" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$109">
-<via x="16.51" y="36.83" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="15.24" y="36.83" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$110">
-<via x="19.05" y="36.83" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="17.78" y="36.83" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$111">
-<via x="21.59" y="36.83" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="20.32" y="36.83" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$112">
-<via x="24.13" y="36.83" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="22.86" y="36.83" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$113">
-<via x="26.67" y="36.83" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="25.4" y="36.83" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$114">
-<via x="29.21" y="36.83" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="27.94" y="36.83" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$115">
-<via x="31.75" y="36.83" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="30.48" y="36.83" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$116">
-<via x="34.29" y="36.83" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="33.02" y="36.83" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$117">
-<via x="39.37" y="39.37" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="38.1" y="39.37" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$118">
-<via x="36.83" y="39.37" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="35.56" y="39.37" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$119">
-<via x="13.97" y="39.37" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="12.7" y="39.37" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$120">
-<via x="16.51" y="39.37" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="15.24" y="39.37" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$121">
-<via x="19.05" y="39.37" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="17.78" y="39.37" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$122">
-<via x="21.59" y="39.37" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="20.32" y="39.37" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$123">
-<via x="24.13" y="39.37" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="22.86" y="39.37" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$124">
-<via x="26.67" y="39.37" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="25.4" y="39.37" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$125">
-<via x="29.21" y="39.37" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="27.94" y="39.37" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$126">
-<via x="31.75" y="39.37" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="30.48" y="39.37" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$127">
-<via x="34.29" y="39.37" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="33.02" y="39.37" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$128">
-<via x="39.37" y="41.91" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="38.1" y="41.91" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$129">
-<via x="36.83" y="41.91" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="35.56" y="41.91" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$130">
-<via x="13.97" y="41.91" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="12.7" y="41.91" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$131">
-<via x="16.51" y="41.91" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="15.24" y="41.91" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$132">
-<via x="19.05" y="41.91" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="17.78" y="41.91" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$133">
-<via x="21.59" y="41.91" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="20.32" y="41.91" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$134">
-<via x="24.13" y="41.91" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="22.86" y="41.91" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$135">
-<via x="26.67" y="41.91" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="25.4" y="41.91" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$136">
-<via x="29.21" y="41.91" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="27.94" y="41.91" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$137">
-<via x="31.75" y="41.91" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="30.48" y="41.91" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$138">
-<via x="34.29" y="41.91" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="33.02" y="41.91" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$139">
-<via x="39.37" y="44.45" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="38.1" y="44.45" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$140">
-<via x="36.83" y="44.45" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="35.56" y="44.45" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$141">
-<via x="13.97" y="44.45" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="12.7" y="44.45" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$142">
-<via x="16.51" y="44.45" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="15.24" y="44.45" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$143">
-<via x="19.05" y="44.45" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="17.78" y="44.45" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$144">
-<via x="21.59" y="44.45" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="20.32" y="44.45" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$145">
-<via x="24.13" y="44.45" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="22.86" y="44.45" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$146">
-<via x="26.67" y="44.45" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="25.4" y="44.45" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$147">
-<via x="29.21" y="44.45" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="27.94" y="44.45" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$148">
-<via x="31.75" y="44.45" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="30.48" y="44.45" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$149">
-<via x="34.29" y="44.45" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="33.02" y="44.45" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$150">
-<via x="39.37" y="46.99" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="38.1" y="46.99" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$151">
-<via x="36.83" y="46.99" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="35.56" y="46.99" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$152">
-<via x="13.97" y="46.99" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="12.7" y="46.99" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$153">
-<via x="16.51" y="46.99" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="15.24" y="46.99" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$154">
-<via x="19.05" y="46.99" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="17.78" y="46.99" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$155">
-<via x="21.59" y="46.99" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="20.32" y="46.99" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$156">
-<via x="24.13" y="46.99" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="22.86" y="46.99" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$157">
-<via x="26.67" y="46.99" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="25.4" y="46.99" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$158">
-<via x="29.21" y="46.99" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="27.94" y="46.99" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$159">
-<via x="31.75" y="46.99" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="30.48" y="46.99" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$160">
-<via x="34.29" y="46.99" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="33.02" y="46.99" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$161">
-<via x="39.37" y="49.53" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="38.1" y="49.53" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$162">
-<via x="36.83" y="49.53" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="35.56" y="49.53" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$163">
-<via x="13.97" y="49.53" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="12.7" y="49.53" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$164">
-<via x="16.51" y="49.53" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="15.24" y="49.53" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$165">
-<via x="19.05" y="49.53" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="17.78" y="49.53" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$166">
-<via x="21.59" y="49.53" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="20.32" y="49.53" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$167">
-<via x="24.13" y="49.53" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="22.86" y="49.53" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$168">
-<via x="26.67" y="49.53" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="25.4" y="49.53" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$169">
-<via x="29.21" y="49.53" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="27.94" y="49.53" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$170">
-<via x="31.75" y="49.53" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="30.48" y="49.53" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$171">
-<via x="34.29" y="49.53" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="33.02" y="49.53" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$183">
-<via x="39.37" y="54.61" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="38.1" y="54.61" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$172">
-<via x="39.37" y="52.07" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="38.1" y="52.07" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$173">
-<via x="36.83" y="52.07" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="35.56" y="52.07" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$174">
-<via x="13.97" y="52.07" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="12.7" y="52.07" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$175">
-<via x="16.51" y="52.07" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="15.24" y="52.07" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$176">
-<via x="19.05" y="52.07" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="17.78" y="52.07" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$177">
-<via x="21.59" y="52.07" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="20.32" y="52.07" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$178">
-<via x="24.13" y="52.07" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="22.86" y="52.07" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$179">
-<via x="26.67" y="52.07" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="25.4" y="52.07" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$180">
-<via x="29.21" y="52.07" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="27.94" y="52.07" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$181">
-<via x="31.75" y="52.07" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="30.48" y="52.07" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$182">
-<via x="34.29" y="52.07" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="33.02" y="52.07" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="MOSI_NC">
 <contactref element="ICSP" pad="4"/>
@@ -4345,98 +5142,101 @@ These rules have been curated by SparkFuns DFM commitee. After doing much resear
 <signal name="N$1">
 <contactref element="JP11" pad="7"/>
 <contactref element="JP8" pad="IOREF"/>
-<wire x1="7.62" y1="44.45" x2="2.54" y2="44.45" width="0.254" layer="1"/>
+<wire x1="7.62" y1="44.45" x2="2.54" y2="44.45" width="0.254" layer="16"/>
 </signal>
 <signal name="3.3">
 <contactref element="JP11" pad="5"/>
 <contactref element="JP8" pad="3.3V"/>
-<wire x1="7.62" y1="39.37" x2="2.54" y2="39.37" width="0.254" layer="1"/>
+<wire x1="7.62" y1="39.37" x2="2.54" y2="39.37" width="0.254" layer="16"/>
 </signal>
 <signal name="AREF">
 <contactref element="JP1" pad="8"/>
 <contactref element="JP8" pad="AREF"/>
-<wire x1="45.72" y1="50.8" x2="50.8" y2="50.8" width="0.254" layer="1"/>
+<wire x1="50.8" y1="50.8" x2="46.99" y2="50.8" width="0.254" layer="16"/>
+<wire x1="46.99" y1="50.8" x2="45.72" y2="52.07" width="0.254" layer="16"/>
 </signal>
 <signal name="SDA">
 <contactref element="JP1" pad="9"/>
 <contactref element="JP8" pad="SDA"/>
-<wire x1="45.72" y1="53.34" x2="50.8" y2="53.34" width="0.254" layer="1"/>
+<wire x1="50.8" y1="53.34" x2="46.99" y2="53.34" width="0.254" layer="16"/>
+<wire x1="46.99" y1="53.34" x2="45.72" y2="54.61" width="0.254" layer="16"/>
 </signal>
 <signal name="SCL">
 <contactref element="JP8" pad="SCL"/>
 <contactref element="JP1" pad="10"/>
-<wire x1="45.72" y1="55.88" x2="50.8" y2="55.88" width="0.254" layer="1"/>
+<wire x1="50.8" y1="55.88" x2="46.99" y2="55.88" width="0.254" layer="16"/>
+<wire x1="46.99" y1="55.88" x2="45.72" y2="57.15" width="0.254" layer="16"/>
 </signal>
 <signal name="VIN">
 <contactref element="JP11" pad="1"/>
 <contactref element="JP8" pad="VIN"/>
-<wire x1="7.62" y1="29.21" x2="2.54" y2="29.21" width="0.254" layer="1"/>
+<wire x1="7.62" y1="29.21" x2="2.54" y2="29.21" width="0.254" layer="16"/>
 </signal>
 <signal name="N$188">
-<via x="36.83" y="54.61" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="35.56" y="54.61" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$189">
-<via x="13.97" y="54.61" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="12.7" y="54.61" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$190">
-<via x="16.51" y="54.61" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="15.24" y="54.61" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$191">
-<via x="19.05" y="54.61" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="17.78" y="54.61" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$192">
-<via x="21.59" y="54.61" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="20.32" y="54.61" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$193">
-<via x="24.13" y="54.61" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="22.86" y="54.61" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$194">
-<via x="26.67" y="54.61" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="25.4" y="54.61" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$195">
-<via x="29.21" y="54.61" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="27.94" y="54.61" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$196">
-<via x="31.75" y="54.61" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="30.48" y="54.61" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$197">
-<via x="34.29" y="54.61" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="33.02" y="54.61" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="NC3">
 <contactref element="JP11" pad="8"/>
 </signal>
 <signal name="N$198">
-<via x="39.37" y="57.15" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="38.1" y="57.15" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$199">
-<via x="36.83" y="57.15" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="35.56" y="57.15" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$200">
-<via x="13.97" y="57.15" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="12.7" y="57.15" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$201">
-<via x="16.51" y="57.15" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="15.24" y="57.15" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$202">
-<via x="19.05" y="57.15" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="17.78" y="57.15" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$203">
-<via x="21.59" y="57.15" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="20.32" y="57.15" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$204">
-<via x="24.13" y="57.15" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="22.86" y="57.15" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$205">
-<via x="26.67" y="57.15" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="25.4" y="57.15" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$206">
-<via x="29.21" y="57.15" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="27.94" y="57.15" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$207">
-<via x="31.75" y="57.15" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="30.48" y="57.15" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="N$208">
-<via x="34.29" y="57.15" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="33.02" y="57.15" extent="1-16" drill="1.016" diameter="1.8796"/>
 </signal>
 <signal name="RX-I">
 <contactref element="JP7" pad="5"/>
@@ -4473,35 +5273,238 @@ These rules have been curated by SparkFuns DFM commitee. After doing much resear
 <wire x1="24.892" y1="60.579" x2="18.034" y2="60.579" width="0.254" layer="1"/>
 <wire x1="18.034" y1="60.579" x2="17.145" y2="59.69" width="0.254" layer="1"/>
 </signal>
-<signal name="A0">
-<contactref element="JP10" pad="6"/>
-<contactref element="JP8" pad="A0"/>
-<wire x1="7.62" y1="24.13" x2="2.54" y2="24.13" width="0.254" layer="1"/>
-</signal>
 <signal name="A1">
 <contactref element="JP8" pad="A1"/>
 <contactref element="JP10" pad="5"/>
-<wire x1="7.62" y1="21.59" x2="2.54" y2="21.59" width="0.254" layer="1"/>
+<wire x1="2.54" y1="21.59" x2="7.62" y2="21.59" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="A2">
-<contactref element="JP10" pad="4"/>
 <contactref element="JP8" pad="A2"/>
-<wire x1="2.54" y1="19.05" x2="7.62" y2="19.05" width="0.254" layer="1"/>
-</signal>
-<signal name="A3">
-<contactref element="JP10" pad="3"/>
-<contactref element="JP8" pad="A3"/>
-<wire x1="7.62" y1="16.51" x2="2.54" y2="16.51" width="0.254" layer="1"/>
-</signal>
-<signal name="A4">
-<contactref element="JP8" pad="A4"/>
-<contactref element="JP10" pad="2"/>
-<wire x1="2.54" y1="13.97" x2="7.62" y2="13.97" width="0.254" layer="1"/>
+<contactref element="JP10" pad="4"/>
+<wire x1="2.54" y1="19.05" x2="7.62" y2="19.05" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="A5">
 <contactref element="JP8" pad="A5"/>
 <contactref element="JP10" pad="1"/>
-<wire x1="7.62" y1="11.43" x2="2.54" y2="11.43" width="0.254" layer="1"/>
+<wire x1="2.54" y1="11.43" x2="7.62" y2="11.43" width="0" layer="19" extent="1-1"/>
+</signal>
+<signal name="N$8">
+<via x="10.16" y="16.51" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$9">
+<via x="10.16" y="19.05" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$184">
+<via x="10.16" y="21.59" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$185">
+<via x="10.16" y="24.13" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$186">
+<via x="10.16" y="26.67" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$187">
+<via x="10.16" y="29.21" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$209">
+<via x="10.16" y="31.75" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$210">
+<via x="10.16" y="34.29" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$211">
+<via x="10.16" y="36.83" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$212">
+<via x="10.16" y="39.37" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$213">
+<via x="10.16" y="41.91" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$214">
+<via x="10.16" y="44.45" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$215">
+<via x="10.16" y="46.99" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$216">
+<via x="10.16" y="49.53" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$217">
+<via x="10.16" y="52.07" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$218">
+<via x="10.16" y="54.61" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$219">
+<via x="10.16" y="57.15" extent="1-16" drill="1.016" diameter="1.8796"/>
+<via x="10.16" y="59.69" extent="1-16" drill="1.016" diameter="1.8796"/>
+<wire x1="10.16" y1="57.15" x2="10.16" y2="59.69" width="0" layer="19" extent="1-1"/>
+</signal>
+<signal name="N$221">
+<via x="40.64" y="16.51" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$222">
+<via x="40.64" y="19.05" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$223">
+<via x="40.64" y="21.59" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$224">
+<via x="40.64" y="24.13" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$225">
+<via x="40.64" y="26.67" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$226">
+<via x="40.64" y="29.21" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$227">
+<via x="40.64" y="31.75" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$228">
+<via x="40.64" y="34.29" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$229">
+<via x="40.64" y="36.83" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$230">
+<via x="40.64" y="39.37" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$231">
+<via x="40.64" y="41.91" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$232">
+<via x="40.64" y="44.45" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$233">
+<via x="40.64" y="46.99" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$234">
+<via x="40.64" y="49.53" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$235">
+<via x="40.64" y="52.07" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$236">
+<via x="40.64" y="54.61" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$237">
+<via x="40.64" y="57.15" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$239">
+<via x="43.18" y="16.51" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$240">
+<via x="43.18" y="19.05" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$241">
+<via x="43.18" y="21.59" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$242">
+<via x="43.18" y="24.13" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$243">
+<via x="43.18" y="26.67" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$244">
+<via x="43.18" y="29.21" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$245">
+<via x="43.18" y="31.75" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$246">
+<via x="43.18" y="34.29" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$247">
+<via x="43.18" y="36.83" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$248">
+<via x="43.18" y="39.37" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$249">
+<via x="43.18" y="41.91" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$250">
+<via x="43.18" y="44.45" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$251">
+<via x="43.18" y="46.99" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$252">
+<via x="43.18" y="49.53" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$253">
+<via x="43.18" y="52.07" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$254">
+<via x="43.18" y="54.61" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$255">
+<via x="43.18" y="57.15" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$263">
+<via x="38.1" y="59.69" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$264">
+<via x="40.64" y="59.69" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$265">
+<via x="43.18" y="59.69" extent="1-16" drill="1.016" diameter="1.8796"/>
+</signal>
+<signal name="N$3">
+<contactref element="JP8" pad="A4"/>
+<contactref element="JP10" pad="2"/>
+<wire x1="2.54" y1="13.97" x2="7.62" y2="13.97" width="0" layer="19" extent="1-1"/>
+</signal>
+<signal name="N$4">
+<contactref element="JP8" pad="A3"/>
+<contactref element="JP10" pad="3"/>
+<wire x1="2.54" y1="16.51" x2="7.62" y2="16.51" width="0" layer="19" extent="1-1"/>
+</signal>
+<signal name="N$2">
+<contactref element="JP8" pad="A0"/>
+<contactref element="JP10" pad="6"/>
+<wire x1="2.54" y1="24.13" x2="7.62" y2="24.13" width="0" layer="19" extent="1-1"/>
+</signal>
+<signal name="VDD">
+<contactref element="VDD_RAIL" pad="3"/>
+<contactref element="VDD_RAIL" pad="2"/>
+<contactref element="VDD_RAIL" pad="1"/>
+<wire x1="15.24" y1="11.43" x2="22.86" y2="11.43" width="1.524" layer="16"/>
+<wire x1="17.78" y1="11.43" x2="20.32" y2="11.43" width="0" layer="19" extent="1-1"/>
+<wire x1="22.86" y1="11.43" x2="20.32" y2="11.43" width="0" layer="19" extent="16-16"/>
+</signal>
+<signal name="JP3">
+<contactref element="L1" pad="A"/>
+<contactref element="JP_3" pad="1"/>
+<wire x1="2.032" y1="3.81" x2="5.588" y2="3.81" width="0.254" layer="1"/>
+<wire x1="8.128" y1="1.27" x2="11.684" y2="1.27" width="0.254" layer="1"/>
+<wire x1="12.954" y1="2.54" x2="14.478" y2="2.54" width="0.254" layer="1"/>
+<wire x1="16.256" y1="0.762" x2="21.6535" y2="0.762" width="0.254" layer="1"/>
+<wire x1="11.684" y1="1.27" x2="12.954" y2="2.54" width="0.254" layer="1"/>
+<wire x1="1.27" y1="2.413" x2="1.27" y2="3.048" width="0.254" layer="1"/>
+<wire x1="1.27" y1="3.048" x2="2.032" y2="3.81" width="0.254" layer="1"/>
+<wire x1="23.1775" y1="1.4605" x2="22.352" y2="1.4605" width="0.254" layer="1"/>
+<wire x1="22.352" y1="1.4605" x2="21.6535" y2="0.762" width="0.254" layer="1"/>
+<wire x1="5.588" y1="3.81" x2="8.128" y2="1.27" width="0.254" layer="1"/>
+<wire x1="16.256" y1="0.762" x2="14.478" y2="2.54" width="0.254" layer="1"/>
+</signal>
+<signal name="JP4">
+<contactref element="L2" pad="A"/>
+<contactref element="JP_4" pad="1"/>
+<wire x1="23.368" y1="3.81" x2="25.7175" y2="1.4605" width="0.254" layer="1"/>
+<wire x1="19.05" y1="3.81" x2="17.78" y2="2.54" width="0.254" layer="1"/>
+<wire x1="19.05" y1="3.81" x2="23.368" y2="3.81" width="0.254" layer="1"/>
+</signal>
+<signal name="D2_NC">
+<contactref element="R4" pad="P$1"/>
+<contactref element="SW2" pad="3"/>
+<contactref element="JP_2" pad="1"/>
+<wire x1="45.3263" y1="1.5494" x2="45.3263" y2="1.9812" width="0.254" layer="1"/>
+<wire x1="45.3263" y1="1.9812" x2="43.4975" y2="3.81" width="0.254" layer="1"/>
+<wire x1="33.3375" y1="1.4605" x2="45.2374" y2="1.4605" width="0.254" layer="1"/>
+<wire x1="45.2374" y1="1.4605" x2="45.3263" y2="1.5494" width="0.254" layer="1"/>
 </signal>
 </signals>
 <errors>
@@ -4576,14 +5579,36 @@ These rules have been curated by SparkFuns DFM commitee. After doing much resear
 <approved hash="19,16,aacc49c3315930e0"/>
 <approved hash="19,16,dc22fc620537dd73"/>
 <approved hash="3,1,7620d360d38476c4"/>
-<approved hash="3,1,00de8d1e8d5c009c"/>
 <approved hash="3,1,6da169a8a76164a1"/>
-<approved hash="3,1,68e62ba61ba2a7ba"/>
 <approved hash="3,1,ff41e281e2a2ff62"/>
 <approved hash="3,1,76fa75fa6b34afba"/>
 <approved hash="3,1,1571d67515329335"/>
 <approved hash="4,1,7c24f277ffff47a8"/>
 <approved hash="4,1,bda3f876c9f9ba28"/>
+<approved hash="3,16,00de8d1e8d5c009c"/>
+<approved hash="3,16,68e62ba61ba2a7ba"/>
+<approved hash="3,16,706d932d90af73ef"/>
+<approved hash="3,1,4de5902591834c43"/>
+<approved hash="4,16,f92577767afec2a9"/>
+<approved hash="4,16,39a37d764cf93e28"/>
+<approved hash="4,16,02470cb005cd061e"/>
+<approved hash="4,16,4be51f9411cc4899"/>
+<approved hash="3,1,00de8d1e8d5c009c"/>
+<approved hash="3,1,68e62ba61ba2a7ba"/>
+<approved hash="3,1,706d932d90af73ef"/>
+<approved hash="3,1,ca2517e51763caa3"/>
+<approved hash="3,1,f59e505e503cf5fc"/>
+<approved hash="3,1,eb5af55a3666369e"/>
+<approved hash="3,1,ef526cd26d34eeb4"/>
+<approved hash="3,1,6286d9401f821f41"/>
+<approved hash="3,1,de6160a167e0d920"/>
+<approved hash="4,1,f92577767afec2a9"/>
+<approved hash="4,1,39a37d764cf93e28"/>
+<approved hash="4,1,b9a236713bf9822e"/>
+<approved hash="4,1,f9223c770dfbfeaa"/>
+<approved hash="4,1,d566ca8514387293"/>
+<approved hash="4,1,53334b4b12c4f4df"/>
+<approved hash="4,1,53ab4cda943074a7"/>
 <approved hash="4,1,b9a536763bfd822a"/>
 <approved hash="4,1,2123347605fb26aa"/>
 <approved hash="4,1,02470cb005cd061e"/>
@@ -4593,7 +5618,125 @@ These rules have been curated by SparkFuns DFM commitee. After doing much resear
 <approved hash="19,16,ec45b867be34ea16"/>
 <approved hash="19,16,c26c218330593100"/>
 <approved hash="19,16,e642ea60ec31e013"/>
+<approved hash="19,16,ecd88d5f827ae199"/>
+<approved hash="19,16,305c806f893a3a05"/>
+<approved hash="19,16,26cd89678ef223b4"/>
+<approved hash="19,16,3dab7fff853ac72a"/>
+<approved hash="19,16,dce982478482d9e8"/>
+<approved hash="19,16,f667841f810af1ee"/>
+<approved hash="19,16,d47a98179ff2d1bb"/>
+<approved hash="19,16,166f841f9bea0b96"/>
+<approved hash="19,16,1efe825784a21be7"/>
+<approved hash="19,16,a84a776088278789"/>
+<approved hash="19,16,db079799e070ae72"/>
+<approved hash="19,16,f26d94e1e61c8354"/>
+<approved hash="19,16,26df9339e74050aa"/>
+<approved hash="19,16,1d029e67e87e6817"/>
+<approved hash="19,16,09a99d11ed8c7bd8"/>
+<approved hash="19,16,c746911fe5feb1c3"/>
+<approved hash="19,16,345090ebe2164541"/>
+<approved hash="19,16,ec936ef918189a36"/>
+<approved hash="19,16,fcc48b3bfb568e8d"/>
+<approved hash="19,16,ff6fb31521f06fae"/>
+<approved hash="19,16,16be54fd3b38793f"/>
+<approved hash="19,16,1b49ab6d37388410"/>
+<approved hash="19,16,0dd8a26530f09da1"/>
+<approved hash="19,16,35eba9553aa0a5f2"/>
+<approved hash="19,16,3d7aaf1d25e8b583"/>
+<approved hash="19,16,c7cda65d3c785f8c"/>
+<approved hash="19,16,f7fca9453a8067fd"/>
+<approved hash="19,16,dd72af1d3f084ffb"/>
+<approved hash="19,16,720cf15f7246f219"/>
+<approved hash="19,16,839d01c182200038"/>
+<approved hash="19,16,b409f8a17a48347c"/>
+<approved hash="19,16,49d1fc017d78caa4"/>
+<approved hash="19,16,9d63fbd97c24195a"/>
+<approved hash="19,16,66a7f22977b4e1d6"/>
+<approved hash="19,16,93cae403616e1483"/>
+<approved hash="19,16,a848fe277fc62bcd"/>
+<approved hash="19,16,5b5effd3782edf4f"/>
+<approved hash="19,16,98470a1d63e8f3be"/>
+<approved hash="19,16,90d60c557ca0e3cf"/>
+<approved hash="19,16,a8e5076576f0db9c"/>
+<approved hash="19,16,784f0a1d790809c6"/>
+<approved hash="19,16,be740e6d7138c22d"/>
+<approved hash="19,16,62f0035d7a7819b1"/>
+<approved hash="19,16,5a52161567f02993"/>
+<approved hash="19,16,b383f1fd7d383f02"/>
+<approved hash="19,16,52c10c457c8021c0"/>
+<approved hash="19,16,ae6a0aed6e10c97b"/>
+<approved hash="19,16,76a9f4ff941e160c"/>
+<approved hash="19,16,5d7c0b1969f83df9"/>
+<approved hash="19,16,bce5093f6b46dc90"/>
+<approved hash="19,16,413d0d9f6c762248"/>
+<approved hash="19,16,93930717618af7e2"/>
+<approved hash="19,16,68570ee76a1a0f6e"/>
+<approved hash="19,16,66fe113d775002b7"/>
+<approved hash="19,16,873804616478e42d"/>
+<approved hash="19,16,f0ddd920e9d1002d"/>
+<approved hash="19,16,89a94d8b7b757f56"/>
+<approved hash="19,16,c701dc18e9693271"/>
+<approved hash="19,16,3294dd0cee33c1aa"/>
+<approved hash="19,16,9c504f1b7a01694b"/>
+<approved hash="19,16,db1edfece2f32600"/>
+<approved hash="19,16,bade726745614dd9"/>
+<approved hash="19,16,ae8c405b75095bdf"/>
+<approved hash="19,16,fc00df4cec2b0f66"/>
+<approved hash="19,16,ee93dfd8eb051a4f"/>
+<approved hash="19,16,b2b7486f7d7547ac"/>
+<approved hash="19,16,3e07df60ec05cd63"/>
+<approved hash="19,16,608b4c67793595d8"/>
+<approved hash="19,16,74b24c6f78898055"/>
+<approved hash="19,16,2892dffcef2bd844"/>
+<approved hash="19,16,1575d040e121e415"/>
+<approved hash="19,16,44fd725b79558ff2"/>
+<approved hash="19,16,4ba4498b7b69b947"/>
+<approved hash="19,16,2379255189068328"/>
+<approved hash="19,16,99f752433421f393"/>
+<approved hash="19,16,bee952e33af9daf5"/>
+<approved hash="19,16,372b176db96e952e"/>
+<approved hash="19,16,045c2881877aa7a1"/>
+<approved hash="19,16,a2f651173163ce84"/>
+<approved hash="19,16,4d6552f3372124b1"/>
+<approved hash="19,16,f9472965848658a2"/>
+<approved hash="19,16,11a52a11860eb1bc"/>
+<approved hash="19,16,5763500336393d5f"/>
+<approved hash="19,16,5bf0526f340f3196"/>
+<approved hash="19,16,ed7e296d853a4d2f"/>
+<approved hash="19,16,70825d4f392b18e0"/>
+<approved hash="19,16,c9081751855a5705"/>
+<approved hash="19,16,952a542f31dbfcd8"/>
+<approved hash="19,16,c6512c81876661b0"/>
+<approved hash="19,16,8b6452d7330fe6ba"/>
+<approved hash="19,16,3f422d65817a9f5b"/>
+<approved hash="19,16,c603a75d2a784942"/>
+<approved hash="19,16,dcbcae1d29085935"/>
+<approved hash="19,16,3425a8552ca0b33c"/>
+<approved hash="19,16,1a87aa6d213892de"/>
+<approved hash="19,16,3cb4ae1d33e8a34d"/>
+<approved hash="19,16,0c16a36526f08b6f"/>
+<approved hash="19,16,177055fd2d386ff1"/>
+<approved hash="19,16,fea1b21537f07960"/>
+<approved hash="19,16,f632a8452c807133"/>
+<approved hash="19,16,5a9cfeef5612f18d"/>
+<approved hash="19,16,9208e53f4f523a41"/>
+<approved hash="19,16,9ca1fae552183798"/>
+<approved hash="19,16,825f00fdac1c2efa"/>
+<approved hash="19,16,73cef0635c7adcdb"/>
+<approved hash="19,16,4813fd3d5344e466"/>
+<approved hash="19,16,a98aff1b51fa050f"/>
+<approved hash="19,16,b5cbf99d54741abe"/>
+<approved hash="19,16,6765f3155988cf14"/>
 <approved hash="19,16,fc4242605dd1e3f3"/>
+<approved hash="19,16,a5b2156dd33860eb"/>
+<approved hash="19,16,7936185dd878bb77"/>
+<approved hash="19,16,8b101755dea04109"/>
+<approved hash="19,16,a845eafddf389dc4"/>
+<approved hash="19,16,49071745de808306"/>
+<approved hash="19,16,b3231c65d4f0795a"/>
+<approved hash="19,16,41940d15c5f08b55"/>
+<approved hash="19,16,8381111dc1e85178"/>
+<approved hash="19,16,6389111ddb08ab00"/>
 <approved hash="19,16,e5c25be05db1e393"/>
 <approved hash="19,16,c77904b318493935"/>
 <approved hash="19,16,ca641a7707cd3448"/>
@@ -4603,13 +5746,34 @@ These rules have been curated by SparkFuns DFM commitee. After doing much resear
 <approved hash="19,16,f3c5b1e7b7b4f596"/>
 <approved hash="19,16,a5cc46c21cd81d60"/>
 <approved hash="19,16,f9c2e7e0e1b3ff91"/>
+<approved hash="19,16,796bfbff8a1e08ce"/>
+<approved hash="19,16,693c1e3d69501c75"/>
+<approved hash="19,16,9c5108177f8ae920"/>
+<approved hash="19,16,52be041977f8233b"/>
+<approved hash="19,16,679501e7741a11ac"/>
+<approved hash="19,16,b327063f7546c252"/>
+<approved hash="19,16,a1a805ed7010d7b9"/>
+<approved hash="19,16,4eff029f72763c8a"/>
+<approved hash="19,16,88fa0b617a78faef"/>
+<approved hash="19,16,88be386dd9386ae7"/>
+<approved hash="19,16,4e853c1dd108a10c"/>
+<approved hash="19,16,9e2f3165def07356"/>
+<approved hash="19,16,a61c3a55d4a04b05"/>
+<approved hash="19,16,640b3a45d480890a"/>
+<approved hash="19,16,ae8d3c1dcbe85b74"/>
+<approved hash="19,16,543a355dd278b17b"/>
+<approved hash="19,16,8549c7fdd53897c8"/>
+<approved hash="19,16,6c982015cff08159"/>
+<approved hash="19,16,0cb5a8ed6210c5a4"/>
+<approved hash="19,16,c421b33d7b500e68"/>
+<approved hash="19,16,ffa3a91965f83126"/>
+<approved hash="19,16,314ca5176d8afb3d"/>
+<approved hash="19,16,d47656ff981e1ad3"/>
+<approved hash="19,16,1e3aab3f6746d04f"/>
+<approved hash="19,16,ca88ace7661a03b1"/>
+<approved hash="19,16,25e7a6616878e8f2"/>
+<approved hash="19,16,e3e2af9f60762e97"/>
 </errors>
 </board>
 </drawing>
-<compatibility>
-<note version="6.3" minversion="6.2.2" severity="warning">
-Since Version 6.2.2 text objects can contain more than one line,
-which will not be processed correctly with this version.
-</note>
-</compatibility>
 </eagle>

--- a/Hardware/SparkFun_ProtoShield_Kit_rev32.sch
+++ b/Hardware/SparkFun_ProtoShield_Kit_rev32.sch
@@ -28,18 +28,18 @@
 <layer number="18" name="Vias" color="2" fill="1" visible="no" active="no"/>
 <layer number="19" name="Unrouted" color="6" fill="1" visible="no" active="no"/>
 <layer number="20" name="Dimension" color="15" fill="1" visible="no" active="no"/>
-<layer number="21" name="tPlace" color="7" fill="1" visible="no" active="no"/>
-<layer number="22" name="bPlace" color="7" fill="1" visible="no" active="no"/>
+<layer number="21" name="tPlace" color="16" fill="1" visible="no" active="no"/>
+<layer number="22" name="bPlace" color="14" fill="1" visible="no" active="no"/>
 <layer number="23" name="tOrigins" color="15" fill="1" visible="no" active="no"/>
 <layer number="24" name="bOrigins" color="15" fill="1" visible="no" active="no"/>
 <layer number="25" name="tNames" color="7" fill="1" visible="no" active="no"/>
 <layer number="26" name="bNames" color="7" fill="1" visible="no" active="no"/>
 <layer number="27" name="tValues" color="7" fill="1" visible="no" active="no"/>
 <layer number="28" name="bValues" color="7" fill="1" visible="no" active="no"/>
-<layer number="29" name="tStop" color="7" fill="3" visible="no" active="no"/>
-<layer number="30" name="bStop" color="7" fill="6" visible="no" active="no"/>
-<layer number="31" name="tCream" color="7" fill="4" visible="no" active="no"/>
-<layer number="32" name="bCream" color="7" fill="5" visible="no" active="no"/>
+<layer number="29" name="tStop" color="7" fill="6" visible="no" active="no"/>
+<layer number="30" name="bStop" color="7" fill="3" visible="no" active="no"/>
+<layer number="31" name="tCream" color="7" fill="5" visible="no" active="no"/>
+<layer number="32" name="bCream" color="7" fill="4" visible="no" active="no"/>
 <layer number="33" name="tFinish" color="6" fill="3" visible="no" active="no"/>
 <layer number="34" name="bFinish" color="6" fill="6" visible="no" active="no"/>
 <layer number="35" name="tGlue" color="7" fill="4" visible="no" active="no"/>
@@ -58,8 +58,8 @@
 <layer number="48" name="Document" color="7" fill="1" visible="no" active="no"/>
 <layer number="49" name="Reference" color="7" fill="1" visible="no" active="no"/>
 <layer number="50" name="dxf" color="7" fill="1" visible="no" active="no"/>
-<layer number="51" name="tDocu" color="7" fill="1" visible="no" active="no"/>
-<layer number="52" name="bDocu" color="7" fill="1" visible="no" active="no"/>
+<layer number="51" name="tDocu" color="6" fill="1" visible="no" active="no"/>
+<layer number="52" name="bDocu" color="6" fill="1" visible="no" active="no"/>
 <layer number="53" name="tGND_GNDA" color="7" fill="9" visible="no" active="no"/>
 <layer number="54" name="bGND_GNDA" color="1" fill="9" visible="no" active="no"/>
 <layer number="56" name="wert" color="7" fill="1" visible="no" active="no"/>
@@ -166,12 +166,14 @@ We've spent an enormous amount of time creating and checking these footprints an
 You are welcome to use this library for commercial purposes. For attribution, we ask that when you begin to sell your device using our footprint, you email us with a link to the product being sold. We want bragging rights that we helped (in a very small part) to create your 8th world wonder. We would like the opportunity to feature your device on our homepage.</description>
 <packages>
 <package name="CREATIVE_COMMONS">
+<description>&lt;h3&gt;Creative Commons License Template&lt;/h3&gt;
+&lt;p&gt;CC BY-SA 4.0 License with &lt;a href="https://creativecommons.org/licenses/by-sa/4.0/"&gt;link to license&lt;/a&gt; and placeholder for designer name.&lt;/p&gt;
+&lt;p&gt;Devices using:
+&lt;ul&gt;&lt;li&gt;FRAME_LEDGER&lt;/li&gt;
+&lt;li&gt;FRAME_LETTER&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;</description>
 <text x="-20.32" y="5.08" size="1.778" layer="51" font="vector">Released under the Creative Commons Attribution Share-Alike 4.0 License</text>
 <text x="0" y="2.54" size="1.778" layer="51" font="vector"> https://creativecommons.org/licenses/by-sa/4.0/</text>
 <text x="11.43" y="0" size="1.778" layer="51" font="vector">Designed by:</text>
-</package>
-<package name="DUMMY">
-<description>NOTHING HERE!!! For when you want a symbol with no package as an option against symbols with a package.</description>
 </package>
 <package name="REVISION">
 <text x="0" y="0" size="1.778" layer="51" font="vector">Revision By: </text>
@@ -11529,15 +11531,31 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <vertex x="0.8866" y="-0.23263125"/>
 </polygon>
 </package>
+<package name="DUMMY">
+<description>&lt;h3&gt;Dummy Footprint&lt;/h3&gt;
+&lt;p&gt;NOTHING HERE!!! For when you want a symbol with no package as an option against symbols with a package.&lt;/p&gt;
+
+&lt;p&gt;Devices using:
+&lt;ul&gt;&lt;li&gt;BADGERHACK_LOGO&lt;/li&gt;
+&lt;li&gt;FRAME-LETTER&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;</description>
+</package>
 </packages>
 <symbols>
-<symbol name="LETTER_L">
+<symbol name="FRAME-LETTER">
+<description>&lt;h3&gt;Schematic Frame - Letter&lt;/h3&gt;
+&lt;p&gt;Standard 8.5x11 US Ledger frame&lt;/p&gt;
+&lt;p&gt;Devices using&lt;ul&gt;&lt;li&gt;FRAME-LETTER&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;</description>
 <wire x1="0" y1="185.42" x2="248.92" y2="185.42" width="0.4064" layer="94"/>
 <wire x1="248.92" y1="185.42" x2="248.92" y2="0" width="0.4064" layer="94"/>
 <wire x1="0" y1="185.42" x2="0" y2="0" width="0.4064" layer="94"/>
 <wire x1="0" y1="0" x2="248.92" y2="0" width="0.4064" layer="94"/>
 </symbol>
 <symbol name="DOCFIELD">
+<description>&lt;h3&gt;Schematic Documentation Field&lt;/h3&gt;
+&lt;p&gt;Autofilling schematic symbol-layer info including board name, designer, revision, and save date.&lt;/p&gt;
+&lt;p&gt;Devices using:
+&lt;ul&gt;&lt;li&gt;FRAME-LEDGER&lt;/li&gt;
+&lt;li&gt;FRAME-LETTER&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;</description>
 <wire x1="0" y1="0" x2="71.12" y2="0" width="0.254" layer="94"/>
 <wire x1="101.6" y1="15.24" x2="87.63" y2="15.24" width="0.254" layer="94"/>
 <wire x1="0" y1="0" x2="0" y2="5.08" width="0.254" layer="94"/>
@@ -16203,10 +16221,10 @@ You are welcome to use this library for commercial purposes. For attribution, we
 </symbols>
 <devicesets>
 <deviceset name="FRAME-LETTER" prefix="FRAME">
-<description>&lt;b&gt;Schematic Frame&lt;/b&gt;&lt;p&gt;
-Standard 8.5x11 US Letter frame</description>
+<description>&lt;h3&gt;Schematic Frame - Letter&lt;/h3&gt;
+&lt;p&gt;Standard 8.5x11 US Letter frame&lt;/p&gt;</description>
 <gates>
-<gate name="G$1" symbol="LETTER_L" x="0" y="0"/>
+<gate name="G$1" symbol="FRAME-LETTER" x="0" y="0"/>
 <gate name="V" symbol="DOCFIELD" x="147.32" y="0" addlevel="must"/>
 </gates>
 <devices>
@@ -17587,172 +17605,6 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <text x="-1.27" y="1.397" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
 <text x="-1.27" y="-1.524" size="0.6096" layer="27" font="vector" ratio="20" align="top-left">&gt;VALUE</text>
 <rectangle x1="-0.254" y1="-0.254" x2="0.254" y2="0.254" layer="51"/>
-</package>
-<package name="1X19">
-<description>&lt;h3&gt;Plated Through Hole -19 Pin&lt;/h3&gt;
-&lt;p&gt;Specifications:
-&lt;ul&gt;&lt;li&gt;Pin count:19&lt;/li&gt;
-&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
-&lt;/ul&gt;&lt;/p&gt;
-&lt;p&gt;Example device(s):
-&lt;ul&gt;&lt;li&gt;CONN_19&lt;/li&gt;
-&lt;/ul&gt;&lt;/p&gt;</description>
-<wire x1="14.605" y1="1.27" x2="15.875" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="15.875" y1="1.27" x2="16.51" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="16.51" y1="-0.635" x2="15.875" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="11.43" y1="0.635" x2="12.065" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="12.065" y1="1.27" x2="13.335" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="13.335" y1="1.27" x2="13.97" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="13.97" y1="-0.635" x2="13.335" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="13.335" y1="-1.27" x2="12.065" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="12.065" y1="-1.27" x2="11.43" y2="-0.635" width="0.2032" layer="21"/>
-<wire x1="14.605" y1="1.27" x2="13.97" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="13.97" y1="-0.635" x2="14.605" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="15.875" y1="-1.27" x2="14.605" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="6.985" y1="1.27" x2="8.255" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="8.255" y1="1.27" x2="8.89" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="8.89" y1="-0.635" x2="8.255" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="8.89" y1="0.635" x2="9.525" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="9.525" y1="1.27" x2="10.795" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="10.795" y1="1.27" x2="11.43" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="11.43" y1="-0.635" x2="10.795" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="10.795" y1="-1.27" x2="9.525" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="9.525" y1="-1.27" x2="8.89" y2="-0.635" width="0.2032" layer="21"/>
-<wire x1="3.81" y1="0.635" x2="4.445" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="4.445" y1="1.27" x2="5.715" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="5.715" y1="1.27" x2="6.35" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="6.35" y1="-0.635" x2="5.715" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="5.715" y1="-1.27" x2="4.445" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="4.445" y1="-1.27" x2="3.81" y2="-0.635" width="0.2032" layer="21"/>
-<wire x1="6.985" y1="1.27" x2="6.35" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="6.35" y1="-0.635" x2="6.985" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="8.255" y1="-1.27" x2="6.985" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="-0.635" y1="1.27" x2="0.635" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="0.635" y1="1.27" x2="1.27" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="1.27" y1="-0.635" x2="0.635" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="1.27" y1="0.635" x2="1.905" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="1.905" y1="1.27" x2="3.175" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="3.175" y1="1.27" x2="3.81" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="3.81" y1="-0.635" x2="3.175" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="3.175" y1="-1.27" x2="1.905" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="1.905" y1="-1.27" x2="1.27" y2="-0.635" width="0.2032" layer="21"/>
-<wire x1="-1.27" y1="0.635" x2="-1.27" y2="-0.635" width="0.2032" layer="21"/>
-<wire x1="-0.635" y1="1.27" x2="-1.27" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="-1.27" y1="-0.635" x2="-0.635" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="0.635" y1="-1.27" x2="-0.635" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="32.385" y1="1.27" x2="33.655" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="33.655" y1="1.27" x2="34.29" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="34.29" y1="-0.635" x2="33.655" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="29.21" y1="0.635" x2="29.845" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="29.845" y1="1.27" x2="31.115" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="31.115" y1="1.27" x2="31.75" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="31.75" y1="-0.635" x2="31.115" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="31.115" y1="-1.27" x2="29.845" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="29.845" y1="-1.27" x2="29.21" y2="-0.635" width="0.2032" layer="21"/>
-<wire x1="32.385" y1="1.27" x2="31.75" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="31.75" y1="-0.635" x2="32.385" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="33.655" y1="-1.27" x2="32.385" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="24.765" y1="1.27" x2="26.035" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="26.035" y1="1.27" x2="26.67" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="26.67" y1="-0.635" x2="26.035" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="26.67" y1="0.635" x2="27.305" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="27.305" y1="1.27" x2="28.575" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="28.575" y1="1.27" x2="29.21" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="29.21" y1="-0.635" x2="28.575" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="28.575" y1="-1.27" x2="27.305" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="27.305" y1="-1.27" x2="26.67" y2="-0.635" width="0.2032" layer="21"/>
-<wire x1="21.59" y1="0.635" x2="22.225" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="22.225" y1="1.27" x2="23.495" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="23.495" y1="1.27" x2="24.13" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="24.13" y1="-0.635" x2="23.495" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="23.495" y1="-1.27" x2="22.225" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="22.225" y1="-1.27" x2="21.59" y2="-0.635" width="0.2032" layer="21"/>
-<wire x1="24.765" y1="1.27" x2="24.13" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="24.13" y1="-0.635" x2="24.765" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="26.035" y1="-1.27" x2="24.765" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="17.145" y1="1.27" x2="18.415" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="18.415" y1="1.27" x2="19.05" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="19.05" y1="-0.635" x2="18.415" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="19.05" y1="0.635" x2="19.685" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="19.685" y1="1.27" x2="20.955" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="20.955" y1="1.27" x2="21.59" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="21.59" y1="-0.635" x2="20.955" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="20.955" y1="-1.27" x2="19.685" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="19.685" y1="-1.27" x2="19.05" y2="-0.635" width="0.2032" layer="21"/>
-<wire x1="17.145" y1="1.27" x2="16.51" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="16.51" y1="-0.635" x2="17.145" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="18.415" y1="-1.27" x2="17.145" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="34.925" y1="1.27" x2="34.29" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="34.925" y1="1.27" x2="36.195" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="36.195" y1="1.27" x2="36.83" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="36.83" y1="-0.635" x2="36.195" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="36.195" y1="-1.27" x2="34.925" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="34.29" y1="-0.635" x2="34.925" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="37.465" y1="1.27" x2="36.83" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="37.465" y1="1.27" x2="38.735" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="38.735" y1="1.27" x2="39.37" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="39.37" y1="-0.635" x2="38.735" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="38.735" y1="-1.27" x2="37.465" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="36.83" y1="-0.635" x2="37.465" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="40.005" y1="1.27" x2="39.37" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="40.005" y1="1.27" x2="41.275" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="41.275" y1="1.27" x2="41.91" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="41.91" y1="-0.635" x2="41.275" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="41.275" y1="-1.27" x2="40.005" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="39.37" y1="-0.635" x2="40.005" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="42.545" y1="1.27" x2="41.91" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="42.545" y1="1.27" x2="43.815" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="43.815" y1="1.27" x2="44.45" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="44.45" y1="-0.635" x2="43.815" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="43.815" y1="-1.27" x2="42.545" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="41.91" y1="-0.635" x2="42.545" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="45.085" y1="1.27" x2="44.45" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="45.085" y1="1.27" x2="46.355" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="46.355" y1="1.27" x2="46.99" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="46.99" y1="-0.635" x2="46.355" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="46.355" y1="-1.27" x2="45.085" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="44.45" y1="-0.635" x2="45.085" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="46.99" y1="0.635" x2="46.99" y2="-0.635" width="0.2032" layer="21"/>
-<pad name="1" x="0" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="2" x="2.54" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="3" x="5.08" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="4" x="7.62" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="5" x="10.16" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="6" x="12.7" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="7" x="15.24" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="8" x="17.78" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="9" x="20.32" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="10" x="22.86" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="11" x="25.4" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="12" x="27.94" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="13" x="30.48" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="14" x="33.02" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="15" x="35.56" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="16" x="38.1" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="17" x="40.64" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="18" x="43.18" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="19" x="45.72" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<rectangle x1="14.986" y1="-0.254" x2="15.494" y2="0.254" layer="51"/>
-<rectangle x1="12.446" y1="-0.254" x2="12.954" y2="0.254" layer="51"/>
-<rectangle x1="9.906" y1="-0.254" x2="10.414" y2="0.254" layer="51"/>
-<rectangle x1="7.366" y1="-0.254" x2="7.874" y2="0.254" layer="51"/>
-<rectangle x1="4.826" y1="-0.254" x2="5.334" y2="0.254" layer="51"/>
-<rectangle x1="2.286" y1="-0.254" x2="2.794" y2="0.254" layer="51"/>
-<rectangle x1="-0.254" y1="-0.254" x2="0.254" y2="0.254" layer="51"/>
-<rectangle x1="32.766" y1="-0.254" x2="33.274" y2="0.254" layer="51"/>
-<rectangle x1="30.226" y1="-0.254" x2="30.734" y2="0.254" layer="51"/>
-<rectangle x1="27.686" y1="-0.254" x2="28.194" y2="0.254" layer="51"/>
-<rectangle x1="25.146" y1="-0.254" x2="25.654" y2="0.254" layer="51"/>
-<rectangle x1="22.606" y1="-0.254" x2="23.114" y2="0.254" layer="51"/>
-<rectangle x1="20.066" y1="-0.254" x2="20.574" y2="0.254" layer="51"/>
-<rectangle x1="17.526" y1="-0.254" x2="18.034" y2="0.254" layer="51"/>
-<rectangle x1="35.306" y1="-0.254" x2="35.814" y2="0.254" layer="51"/>
-<rectangle x1="37.846" y1="-0.254" x2="38.354" y2="0.254" layer="51"/>
-<rectangle x1="40.386" y1="-0.254" x2="40.894" y2="0.254" layer="51"/>
-<rectangle x1="42.926" y1="-0.254" x2="43.434" y2="0.254" layer="51"/>
-<rectangle x1="45.466" y1="-0.254" x2="45.974" y2="0.254" layer="51"/>
-<text x="-1.27" y="1.397" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
-<text x="-1.27" y="-2.032" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
 </package>
 <package name="1X06">
 <description>&lt;h3&gt;Plated Through Hole - 6 Pin&lt;/h3&gt;
@@ -19550,56 +19402,6 @@ Holes are offset 0.005" to hold pins in place while soldering.
 <wire x1="-1.27" y1="-1.27" x2="24.13" y2="-1.27" width="0.127" layer="51"/>
 <wire x1="24.13" y1="-1.27" x2="24.13" y2="1.27" width="0.127" layer="51"/>
 </package>
-<package name="1X19_NO_SILK">
-<description>&lt;h3&gt;Plated Through Hole -19 Pin No Silk&lt;/h3&gt;
-&lt;p&gt;Specifications:
-&lt;ul&gt;&lt;li&gt;Pin count:19&lt;/li&gt;
-&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
-&lt;/ul&gt;&lt;/p&gt;
-&lt;p&gt;Example device(s):
-&lt;ul&gt;&lt;li&gt;CONN_19&lt;/li&gt;
-&lt;/ul&gt;&lt;/p&gt;</description>
-<pad name="1" x="0" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="2" x="2.54" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="3" x="5.08" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="4" x="7.62" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="5" x="10.16" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="6" x="12.7" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="7" x="15.24" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="8" x="17.78" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="9" x="20.32" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="10" x="22.86" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="11" x="25.4" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="12" x="27.94" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="13" x="30.48" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="14" x="33.02" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="15" x="35.56" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="16" x="38.1" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="17" x="40.64" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="18" x="43.18" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<pad name="19" x="45.72" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
-<rectangle x1="14.986" y1="-0.254" x2="15.494" y2="0.254" layer="51"/>
-<rectangle x1="12.446" y1="-0.254" x2="12.954" y2="0.254" layer="51"/>
-<rectangle x1="9.906" y1="-0.254" x2="10.414" y2="0.254" layer="51"/>
-<rectangle x1="7.366" y1="-0.254" x2="7.874" y2="0.254" layer="51"/>
-<rectangle x1="4.826" y1="-0.254" x2="5.334" y2="0.254" layer="51"/>
-<rectangle x1="2.286" y1="-0.254" x2="2.794" y2="0.254" layer="51"/>
-<rectangle x1="-0.254" y1="-0.254" x2="0.254" y2="0.254" layer="51"/>
-<rectangle x1="32.766" y1="-0.254" x2="33.274" y2="0.254" layer="51"/>
-<rectangle x1="30.226" y1="-0.254" x2="30.734" y2="0.254" layer="51"/>
-<rectangle x1="27.686" y1="-0.254" x2="28.194" y2="0.254" layer="51"/>
-<rectangle x1="25.146" y1="-0.254" x2="25.654" y2="0.254" layer="51"/>
-<rectangle x1="22.606" y1="-0.254" x2="23.114" y2="0.254" layer="51"/>
-<rectangle x1="20.066" y1="-0.254" x2="20.574" y2="0.254" layer="51"/>
-<rectangle x1="17.526" y1="-0.254" x2="18.034" y2="0.254" layer="51"/>
-<rectangle x1="35.306" y1="-0.254" x2="35.814" y2="0.254" layer="51"/>
-<rectangle x1="37.846" y1="-0.254" x2="38.354" y2="0.254" layer="51"/>
-<rectangle x1="40.386" y1="-0.254" x2="40.894" y2="0.254" layer="51"/>
-<rectangle x1="42.926" y1="-0.254" x2="43.434" y2="0.254" layer="51"/>
-<rectangle x1="45.466" y1="-0.254" x2="45.974" y2="0.254" layer="51"/>
-<text x="-1.27" y="1.397" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
-<text x="-1.27" y="-2.032" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
-</package>
 <package name="1X01_LONGPAD">
 <description>&lt;h3&gt;Plated Through Hole - Long Pad&lt;/h3&gt;
 &lt;p&gt;Specifications:
@@ -19943,6 +19745,1433 @@ Holes are offset from center 0.005", to hold pins in place while soldering.
 <text x="-3.048" y="-3.048" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
 <wire x1="-2.1844" y1="-2.0574" x2="-2.8702" y2="-2.0574" width="0.2032" layer="22"/>
 </package>
+<package name="1X07">
+<description>&lt;h3&gt;Plated Through Hole -7 Pin&lt;/h3&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:7&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_07&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="14.605" y1="1.27" x2="15.875" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="15.875" y1="1.27" x2="16.51" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="16.51" y1="-0.635" x2="15.875" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="11.43" y1="0.635" x2="12.065" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="12.065" y1="1.27" x2="13.335" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="13.335" y1="1.27" x2="13.97" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="13.97" y1="-0.635" x2="13.335" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="13.335" y1="-1.27" x2="12.065" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="12.065" y1="-1.27" x2="11.43" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="14.605" y1="1.27" x2="13.97" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="13.97" y1="-0.635" x2="14.605" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="15.875" y1="-1.27" x2="14.605" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="6.985" y1="1.27" x2="8.255" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="8.255" y1="1.27" x2="8.89" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="8.89" y1="-0.635" x2="8.255" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="8.89" y1="0.635" x2="9.525" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="9.525" y1="1.27" x2="10.795" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="10.795" y1="1.27" x2="11.43" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="11.43" y1="-0.635" x2="10.795" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="10.795" y1="-1.27" x2="9.525" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="9.525" y1="-1.27" x2="8.89" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="3.81" y1="0.635" x2="4.445" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="4.445" y1="1.27" x2="5.715" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="5.715" y1="1.27" x2="6.35" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="6.35" y1="-0.635" x2="5.715" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="5.715" y1="-1.27" x2="4.445" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="4.445" y1="-1.27" x2="3.81" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="6.985" y1="1.27" x2="6.35" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="6.35" y1="-0.635" x2="6.985" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="8.255" y1="-1.27" x2="6.985" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="-0.635" y1="1.27" x2="0.635" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="0.635" y1="1.27" x2="1.27" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="1.27" y1="-0.635" x2="0.635" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="1.27" y1="0.635" x2="1.905" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="1.905" y1="1.27" x2="3.175" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="3.175" y1="1.27" x2="3.81" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="3.81" y1="-0.635" x2="3.175" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="3.175" y1="-1.27" x2="1.905" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="1.905" y1="-1.27" x2="1.27" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="-1.27" y1="0.635" x2="-1.27" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="-0.635" y1="1.27" x2="-1.27" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="-1.27" y1="-0.635" x2="-0.635" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="0.635" y1="-1.27" x2="-0.635" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="16.51" y1="0.635" x2="16.51" y2="-0.635" width="0.2032" layer="21"/>
+<pad name="1" x="0" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="2" x="2.54" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="3" x="5.08" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="4" x="7.62" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="5" x="10.16" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="6" x="12.7" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="7" x="15.24" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<rectangle x1="14.986" y1="-0.254" x2="15.494" y2="0.254" layer="51"/>
+<rectangle x1="12.446" y1="-0.254" x2="12.954" y2="0.254" layer="51"/>
+<rectangle x1="9.906" y1="-0.254" x2="10.414" y2="0.254" layer="51"/>
+<rectangle x1="7.366" y1="-0.254" x2="7.874" y2="0.254" layer="51"/>
+<rectangle x1="4.826" y1="-0.254" x2="5.334" y2="0.254" layer="51"/>
+<rectangle x1="2.286" y1="-0.254" x2="2.794" y2="0.254" layer="51"/>
+<rectangle x1="-0.254" y1="-0.254" x2="0.254" y2="0.254" layer="51"/>
+<text x="-1.27" y="1.397" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.27" y="-2.032" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="1X07_LOCK">
+<description>&lt;h3&gt;Plated Through Hole -7 Pin Locking Footprint&lt;/h3&gt;
+Holes are offset 0.005" from center, locking pins in place during soldering.
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:7&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_07&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="14.605" y1="1.27" x2="15.875" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="15.875" y1="1.27" x2="16.51" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="16.51" y1="-0.635" x2="15.875" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="11.43" y1="0.635" x2="12.065" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="12.065" y1="1.27" x2="13.335" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="13.335" y1="1.27" x2="13.97" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="13.97" y1="-0.635" x2="13.335" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="13.335" y1="-1.27" x2="12.065" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="12.065" y1="-1.27" x2="11.43" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="14.605" y1="1.27" x2="13.97" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="13.97" y1="-0.635" x2="14.605" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="15.875" y1="-1.27" x2="14.605" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="6.985" y1="1.27" x2="8.255" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="8.255" y1="1.27" x2="8.89" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="8.89" y1="-0.635" x2="8.255" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="8.89" y1="0.635" x2="9.525" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="9.525" y1="1.27" x2="10.795" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="10.795" y1="1.27" x2="11.43" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="11.43" y1="-0.635" x2="10.795" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="10.795" y1="-1.27" x2="9.525" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="9.525" y1="-1.27" x2="8.89" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="3.81" y1="0.635" x2="4.445" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="4.445" y1="1.27" x2="5.715" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="5.715" y1="1.27" x2="6.35" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="6.35" y1="-0.635" x2="5.715" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="5.715" y1="-1.27" x2="4.445" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="4.445" y1="-1.27" x2="3.81" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="6.985" y1="1.27" x2="6.35" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="6.35" y1="-0.635" x2="6.985" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="8.255" y1="-1.27" x2="6.985" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="-0.635" y1="1.27" x2="0.635" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="0.635" y1="1.27" x2="1.27" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="1.27" y1="-0.635" x2="0.635" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="1.27" y1="0.635" x2="1.905" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="1.905" y1="1.27" x2="3.175" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="3.175" y1="1.27" x2="3.81" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="3.81" y1="-0.635" x2="3.175" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="3.175" y1="-1.27" x2="1.905" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="1.905" y1="-1.27" x2="1.27" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="-1.27" y1="0.635" x2="-1.27" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="-0.635" y1="1.27" x2="-1.27" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="-1.27" y1="-0.635" x2="-0.635" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="0.635" y1="-1.27" x2="-0.635" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="16.51" y1="0.635" x2="16.51" y2="-0.635" width="0.2032" layer="21"/>
+<pad name="1" x="0" y="0.127" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="2" x="2.54" y="-0.127" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="3" x="5.08" y="0.127" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="4" x="7.62" y="-0.127" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="5" x="10.16" y="0.127" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="6" x="12.7" y="-0.127" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="7" x="15.24" y="0.127" drill="1.016" diameter="1.8796" rot="R90"/>
+<rectangle x1="14.986" y1="-0.254" x2="15.494" y2="0.254" layer="51"/>
+<rectangle x1="12.446" y1="-0.254" x2="12.954" y2="0.254" layer="51"/>
+<rectangle x1="9.906" y1="-0.254" x2="10.414" y2="0.254" layer="51"/>
+<rectangle x1="7.366" y1="-0.254" x2="7.874" y2="0.254" layer="51"/>
+<rectangle x1="4.826" y1="-0.254" x2="5.334" y2="0.254" layer="51"/>
+<rectangle x1="2.286" y1="-0.254" x2="2.794" y2="0.254" layer="51"/>
+<rectangle x1="-0.254" y1="-0.254" x2="0.254" y2="0.254" layer="51"/>
+<text x="-1.27" y="1.397" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.27" y="-2.032" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="1X07_LOCK_LONGPADS">
+<description>&lt;h3&gt;Plated Through Hole -7 Pin Locking Footprint w/ Long Pads&lt;/h3&gt;
+Holes are offset 0.005" from center, locking pins in place during soldering.
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:7&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_07&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="1.524" y1="0" x2="1.016" y2="0" width="0.2032" layer="21"/>
+<wire x1="4.064" y1="0" x2="3.556" y2="0" width="0.2032" layer="21"/>
+<wire x1="6.604" y1="0" x2="6.096" y2="0" width="0.2032" layer="21"/>
+<wire x1="9.144" y1="0" x2="8.636" y2="0" width="0.2032" layer="21"/>
+<wire x1="11.684" y1="0" x2="11.176" y2="0" width="0.2032" layer="21"/>
+<wire x1="-1.27" y1="0" x2="-1.016" y2="0" width="0.2032" layer="21"/>
+<wire x1="-1.27" y1="0" x2="-1.27" y2="0.9906" width="0.2032" layer="21"/>
+<wire x1="-1.27" y1="0.9906" x2="-0.9906" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="-1.27" y1="0" x2="-1.27" y2="-0.9906" width="0.2032" layer="21"/>
+<wire x1="-1.27" y1="-0.9906" x2="-0.9906" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="16.51" y1="0" x2="16.256" y2="0" width="0.2032" layer="21"/>
+<wire x1="16.51" y1="0" x2="16.51" y2="-0.9906" width="0.2032" layer="21"/>
+<wire x1="16.51" y1="-0.9906" x2="16.2306" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="16.51" y1="0" x2="16.51" y2="0.9906" width="0.2032" layer="21"/>
+<wire x1="16.51" y1="0.9906" x2="16.2306" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="14.224" y1="0" x2="13.716" y2="0" width="0.2032" layer="21"/>
+<pad name="1" x="0" y="0.127" drill="1.016" shape="long" rot="R90"/>
+<pad name="2" x="2.54" y="-0.127" drill="1.016" shape="long" rot="R90"/>
+<pad name="3" x="5.08" y="0.127" drill="1.016" shape="long" rot="R90"/>
+<pad name="4" x="7.62" y="-0.127" drill="1.016" shape="long" rot="R90"/>
+<pad name="5" x="10.16" y="0.127" drill="1.016" shape="long" rot="R90"/>
+<pad name="6" x="12.7" y="-0.127" drill="1.016" shape="long" rot="R90"/>
+<pad name="7" x="15.24" y="0.127" drill="1.016" shape="long" rot="R90"/>
+<rectangle x1="-0.2921" y1="-0.2921" x2="0.2921" y2="0.2921" layer="51"/>
+<rectangle x1="2.2479" y1="-0.2921" x2="2.8321" y2="0.2921" layer="51"/>
+<rectangle x1="4.7879" y1="-0.2921" x2="5.3721" y2="0.2921" layer="51"/>
+<rectangle x1="7.3279" y1="-0.2921" x2="7.9121" y2="0.2921" layer="51" rot="R90"/>
+<rectangle x1="9.8679" y1="-0.2921" x2="10.4521" y2="0.2921" layer="51"/>
+<rectangle x1="12.4079" y1="-0.2921" x2="12.9921" y2="0.2921" layer="51"/>
+<rectangle x1="14.9479" y1="-0.2921" x2="15.5321" y2="0.2921" layer="51"/>
+<text x="-1.143" y="1.905" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.143" y="-2.286" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="1X07_LONGPADS">
+<description>&lt;h3&gt;Plated Through Hole -7 Pin  Long Pads&lt;/h3&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:7&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_07&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="-1.27" y1="0.635" x2="-1.27" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="16.51" y1="0.635" x2="16.51" y2="-0.635" width="0.2032" layer="21"/>
+<pad name="1" x="0" y="0" drill="1.016" diameter="1.8796" shape="long" rot="R90"/>
+<pad name="2" x="2.54" y="0" drill="1.016" diameter="1.8796" shape="long" rot="R90"/>
+<pad name="3" x="5.08" y="0" drill="1.016" diameter="1.8796" shape="long" rot="R90"/>
+<pad name="4" x="7.62" y="0" drill="1.016" diameter="1.8796" shape="long" rot="R90"/>
+<pad name="5" x="10.16" y="0" drill="1.016" diameter="1.8796" shape="long" rot="R90"/>
+<pad name="6" x="12.7" y="0" drill="1.016" diameter="1.8796" shape="long" rot="R90"/>
+<pad name="7" x="15.24" y="0" drill="1.016" diameter="1.8796" shape="long" rot="R90"/>
+<rectangle x1="14.986" y1="-0.254" x2="15.494" y2="0.254" layer="51"/>
+<rectangle x1="12.446" y1="-0.254" x2="12.954" y2="0.254" layer="51"/>
+<rectangle x1="9.906" y1="-0.254" x2="10.414" y2="0.254" layer="51"/>
+<rectangle x1="7.366" y1="-0.254" x2="7.874" y2="0.254" layer="51"/>
+<rectangle x1="4.826" y1="-0.254" x2="5.334" y2="0.254" layer="51"/>
+<rectangle x1="2.286" y1="-0.254" x2="2.794" y2="0.254" layer="51"/>
+<rectangle x1="-0.254" y1="-0.254" x2="0.254" y2="0.254" layer="51"/>
+<text x="-1.143" y="2.159" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.143" y="-2.667" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="1X07_HOLES_ONLY">
+<description>&lt;h3&gt; 7 Pin Holes&lt;/h3&gt;
+No plating, no silk outline.
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:7&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_07&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<circle x="0" y="0" radius="0.635" width="0.127" layer="51"/>
+<circle x="2.54" y="0" radius="0.635" width="0.127" layer="51"/>
+<circle x="5.08" y="0" radius="0.635" width="0.127" layer="51"/>
+<circle x="7.62" y="0" radius="0.635" width="0.127" layer="51"/>
+<circle x="10.16" y="0" radius="0.635" width="0.127" layer="51"/>
+<circle x="12.7" y="0" radius="0.635" width="0.127" layer="51"/>
+<circle x="15.24" y="0" radius="0.635" width="0.127" layer="51"/>
+<pad name="1" x="0" y="0" drill="0.889" diameter="0.8128" rot="R90"/>
+<pad name="2" x="2.54" y="0" drill="0.889" diameter="0.8128" rot="R90"/>
+<pad name="3" x="5.08" y="0" drill="0.889" diameter="0.8128" rot="R90"/>
+<pad name="4" x="7.62" y="0" drill="0.889" diameter="0.8128" rot="R90"/>
+<pad name="5" x="10.16" y="0" drill="0.889" diameter="0.8128" rot="R90"/>
+<pad name="6" x="12.7" y="0" drill="0.889" diameter="0.8128" rot="R90"/>
+<pad name="7" x="15.24" y="0" drill="0.889" diameter="0.8128" rot="R90"/>
+<hole x="0" y="0" drill="1.4732"/>
+<hole x="2.54" y="0" drill="1.4732"/>
+<hole x="5.08" y="0" drill="1.4732"/>
+<hole x="7.62" y="0" drill="1.4732"/>
+<hole x="10.16" y="0" drill="1.4732"/>
+<hole x="12.7" y="0" drill="1.4732"/>
+<hole x="15.24" y="0" drill="1.4732"/>
+</package>
+<package name="1X07_NO_SILK">
+<description>&lt;h3&gt;Plated Through Hole -7 Pin  No Silk&lt;/h3&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:7&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_07&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<pad name="1" x="0" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="2" x="2.54" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="3" x="5.08" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="4" x="7.62" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="5" x="10.16" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="6" x="12.7" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="7" x="15.24" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<rectangle x1="14.986" y1="-0.254" x2="15.494" y2="0.254" layer="51"/>
+<rectangle x1="12.446" y1="-0.254" x2="12.954" y2="0.254" layer="51"/>
+<rectangle x1="9.906" y1="-0.254" x2="10.414" y2="0.254" layer="51"/>
+<rectangle x1="7.366" y1="-0.254" x2="7.874" y2="0.254" layer="51"/>
+<rectangle x1="4.826" y1="-0.254" x2="5.334" y2="0.254" layer="51"/>
+<rectangle x1="2.286" y1="-0.254" x2="2.794" y2="0.254" layer="51"/>
+<rectangle x1="-0.254" y1="-0.254" x2="0.254" y2="0.254" layer="51"/>
+<text x="-1.27" y="1.397" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.27" y="-2.032" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="1X04">
+<description>&lt;h3&gt;Plated Through Hole - 4 Pin&lt;/h3&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:4&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_04&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="6.985" y1="1.27" x2="8.255" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="8.255" y1="1.27" x2="8.89" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="8.89" y1="-0.635" x2="8.255" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="3.81" y1="0.635" x2="4.445" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="4.445" y1="1.27" x2="5.715" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="5.715" y1="1.27" x2="6.35" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="6.35" y1="-0.635" x2="5.715" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="5.715" y1="-1.27" x2="4.445" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="4.445" y1="-1.27" x2="3.81" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="6.985" y1="1.27" x2="6.35" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="6.35" y1="-0.635" x2="6.985" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="8.255" y1="-1.27" x2="6.985" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="-0.635" y1="1.27" x2="0.635" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="0.635" y1="1.27" x2="1.27" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="1.27" y1="-0.635" x2="0.635" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="1.27" y1="0.635" x2="1.905" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="1.905" y1="1.27" x2="3.175" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="3.175" y1="1.27" x2="3.81" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="3.81" y1="-0.635" x2="3.175" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="3.175" y1="-1.27" x2="1.905" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="1.905" y1="-1.27" x2="1.27" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="-1.27" y1="0.635" x2="-1.27" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="-0.635" y1="1.27" x2="-1.27" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="-1.27" y1="-0.635" x2="-0.635" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="0.635" y1="-1.27" x2="-0.635" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="8.89" y1="0.635" x2="8.89" y2="-0.635" width="0.2032" layer="21"/>
+<pad name="1" x="0" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="2" x="2.54" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="3" x="5.08" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="4" x="7.62" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<rectangle x1="7.366" y1="-0.254" x2="7.874" y2="0.254" layer="51"/>
+<rectangle x1="4.826" y1="-0.254" x2="5.334" y2="0.254" layer="51"/>
+<rectangle x1="2.286" y1="-0.254" x2="2.794" y2="0.254" layer="51"/>
+<rectangle x1="-0.254" y1="-0.254" x2="0.254" y2="0.254" layer="51"/>
+<text x="-1.27" y="1.397" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.27" y="-2.032" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="MOLEX-1X4">
+<description>&lt;h3&gt;Molex 4-Pin Plated Through-Hole&lt;/h3&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:4&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;&lt;a href=”https://www.sparkfun.com/datasheets/Prototyping/2pin_molex_set_19iv10.pdf”&gt;Datasheet referenced for footprint&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_04&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="-1.27" y1="3.048" x2="-1.27" y2="-2.54" width="0.127" layer="21"/>
+<wire x1="8.89" y1="3.048" x2="8.89" y2="-2.54" width="0.127" layer="21"/>
+<wire x1="8.89" y1="3.048" x2="-1.27" y2="3.048" width="0.127" layer="21"/>
+<wire x1="8.89" y1="-2.54" x2="7.62" y2="-2.54" width="0.127" layer="21"/>
+<wire x1="7.62" y1="-2.54" x2="0" y2="-2.54" width="0.127" layer="21"/>
+<wire x1="0" y1="-2.54" x2="-1.27" y2="-2.54" width="0.127" layer="21"/>
+<wire x1="0" y1="-2.54" x2="0" y2="-1.27" width="0.127" layer="21"/>
+<wire x1="0" y1="-1.27" x2="7.62" y2="-1.27" width="0.127" layer="21"/>
+<wire x1="7.62" y1="-1.27" x2="7.62" y2="-2.54" width="0.127" layer="21"/>
+<pad name="1" x="0" y="0" drill="1.016" diameter="1.8796" shape="square"/>
+<pad name="2" x="2.54" y="0" drill="1.016" diameter="1.8796"/>
+<pad name="3" x="5.08" y="0" drill="1.016" diameter="1.8796"/>
+<pad name="4" x="7.62" y="0" drill="1.016" diameter="1.8796"/>
+<text x="2.286" y="3.302" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="2.286" y="-3.429" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="SCREWTERMINAL-3.5MM-4">
+<description>&lt;h3&gt;Screw Terminal  3.5mm Pitch -4 Pin PTH&lt;/h3&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count: 4&lt;/li&gt;
+&lt;li&gt;Pin pitch: 3.5mm/138mil&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;&lt;a href=”https://www.sparkfun.com/datasheets/Prototyping/Screw-Terminal-3.5mm.pdf”&gt;Datasheet referenced for footprint&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_04&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="-1.75" y1="3.4" x2="12.25" y2="3.4" width="0.2032" layer="21"/>
+<wire x1="12.25" y1="3.4" x2="12.25" y2="-2.8" width="0.2032" layer="21"/>
+<wire x1="12.25" y1="-2.8" x2="12.25" y2="-3.6" width="0.2032" layer="21"/>
+<wire x1="12.25" y1="-3.6" x2="-1.75" y2="-3.6" width="0.2032" layer="21"/>
+<wire x1="-1.75" y1="-3.6" x2="-1.75" y2="-2.8" width="0.2032" layer="21"/>
+<wire x1="-1.75" y1="-2.8" x2="-1.75" y2="3.4" width="0.2032" layer="21"/>
+<wire x1="12.25" y1="-2.8" x2="-1.75" y2="-2.8" width="0.2032" layer="21"/>
+<wire x1="-1.75" y1="-1.35" x2="-2.25" y2="-1.35" width="0.2032" layer="51"/>
+<wire x1="-2.25" y1="-1.35" x2="-2.25" y2="-2.35" width="0.2032" layer="51"/>
+<wire x1="-2.25" y1="-2.35" x2="-1.75" y2="-2.35" width="0.2032" layer="51"/>
+<wire x1="12.25" y1="3.15" x2="12.75" y2="3.15" width="0.2032" layer="51"/>
+<wire x1="12.75" y1="3.15" x2="12.75" y2="2.15" width="0.2032" layer="51"/>
+<wire x1="12.75" y1="2.15" x2="12.25" y2="2.15" width="0.2032" layer="51"/>
+<circle x="0" y="0" radius="0.425" width="0.001" layer="51"/>
+<circle x="3.5" y="0" radius="0.425" width="0.001" layer="51"/>
+<circle x="7" y="0" radius="0.425" width="0.001" layer="51"/>
+<circle x="10.5" y="0" radius="0.425" width="0.001" layer="51"/>
+<pad name="1" x="0" y="0" drill="1.2" diameter="2.032" shape="square"/>
+<pad name="2" x="3.5" y="0" drill="1.2" diameter="2.032"/>
+<pad name="3" x="7" y="0" drill="1.2" diameter="2.032"/>
+<pad name="4" x="10.5" y="0" drill="1.2" diameter="2.032"/>
+<text x="0" y="2.413" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="0" y="-2.286" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="1X04_1.27MM">
+<description>&lt;h3&gt;Plated Through Hole - 4 Pin&lt;/h3&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:4&lt;/li&gt;
+&lt;li&gt;Pin pitch: 1.27mm&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_04&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="-0.381" y1="-0.889" x2="0.381" y2="-0.889" width="0.127" layer="21"/>
+<wire x1="0.381" y1="-0.889" x2="0.635" y2="-0.635" width="0.127" layer="21"/>
+<wire x1="0.635" y1="-0.635" x2="0.889" y2="-0.889" width="0.127" layer="21"/>
+<wire x1="0.889" y1="-0.889" x2="1.651" y2="-0.889" width="0.127" layer="21"/>
+<wire x1="1.651" y1="-0.889" x2="1.905" y2="-0.635" width="0.127" layer="21"/>
+<wire x1="1.905" y1="-0.635" x2="2.159" y2="-0.889" width="0.127" layer="21"/>
+<wire x1="2.159" y1="-0.889" x2="2.921" y2="-0.889" width="0.127" layer="21"/>
+<wire x1="2.921" y1="-0.889" x2="3.175" y2="-0.635" width="0.127" layer="21"/>
+<wire x1="3.175" y1="-0.635" x2="3.429" y2="-0.889" width="0.127" layer="21"/>
+<wire x1="3.429" y1="-0.889" x2="4.191" y2="-0.889" width="0.127" layer="21"/>
+<wire x1="4.191" y1="0.889" x2="3.429" y2="0.889" width="0.127" layer="21"/>
+<wire x1="3.429" y1="0.889" x2="3.175" y2="0.635" width="0.127" layer="21"/>
+<wire x1="3.175" y1="0.635" x2="2.921" y2="0.889" width="0.127" layer="21"/>
+<wire x1="2.921" y1="0.889" x2="2.159" y2="0.889" width="0.127" layer="21"/>
+<wire x1="2.159" y1="0.889" x2="1.905" y2="0.635" width="0.127" layer="21"/>
+<wire x1="1.905" y1="0.635" x2="1.651" y2="0.889" width="0.127" layer="21"/>
+<wire x1="1.651" y1="0.889" x2="0.889" y2="0.889" width="0.127" layer="21"/>
+<wire x1="0.889" y1="0.889" x2="0.635" y2="0.635" width="0.127" layer="21"/>
+<wire x1="0.635" y1="0.635" x2="0.381" y2="0.889" width="0.127" layer="21"/>
+<wire x1="0.381" y1="0.889" x2="-0.381" y2="0.889" width="0.127" layer="21"/>
+<wire x1="-0.381" y1="0.889" x2="-0.889" y2="0.381" width="0.127" layer="21"/>
+<wire x1="-0.889" y1="-0.381" x2="-0.381" y2="-0.889" width="0.127" layer="21"/>
+<wire x1="-0.889" y1="0.381" x2="-0.889" y2="-0.381" width="0.127" layer="21"/>
+<wire x1="4.191" y1="0.889" x2="4.699" y2="0.381" width="0.127" layer="21"/>
+<wire x1="4.699" y1="0.381" x2="4.699" y2="-0.381" width="0.127" layer="21"/>
+<wire x1="4.699" y1="-0.381" x2="4.191" y2="-0.889" width="0.127" layer="21"/>
+<pad name="4" x="3.81" y="0" drill="0.508" diameter="1"/>
+<pad name="3" x="2.54" y="0" drill="0.508" diameter="1"/>
+<pad name="2" x="1.27" y="0" drill="0.508" diameter="1"/>
+<pad name="1" x="0" y="0" drill="0.508" diameter="1"/>
+<text x="-0.508" y="1.016" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-0.508" y="-1.651" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="1X04_LOCK">
+<description>&lt;h3&gt;Plated Through Hole - 4 Pin Locking Footprint&lt;/h3&gt;
+Pins are offset 0.005" from center to lock pins in place during soldering. 
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:4&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_04&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="6.985" y1="1.27" x2="8.255" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="8.255" y1="1.27" x2="8.89" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="8.89" y1="-0.635" x2="8.255" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="3.81" y1="0.635" x2="4.445" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="4.445" y1="1.27" x2="5.715" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="5.715" y1="1.27" x2="6.35" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="6.35" y1="-0.635" x2="5.715" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="5.715" y1="-1.27" x2="4.445" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="4.445" y1="-1.27" x2="3.81" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="6.985" y1="1.27" x2="6.35" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="6.35" y1="-0.635" x2="6.985" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="8.255" y1="-1.27" x2="6.985" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="-0.635" y1="1.27" x2="0.635" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="0.635" y1="1.27" x2="1.27" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="1.27" y1="-0.635" x2="0.635" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="1.27" y1="0.635" x2="1.905" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="1.905" y1="1.27" x2="3.175" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="3.175" y1="1.27" x2="3.81" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="3.81" y1="-0.635" x2="3.175" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="3.175" y1="-1.27" x2="1.905" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="1.905" y1="-1.27" x2="1.27" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="-1.27" y1="0.635" x2="-1.27" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="-0.635" y1="1.27" x2="-1.27" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="-1.27" y1="-0.635" x2="-0.635" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="0.635" y1="-1.27" x2="-0.635" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="8.89" y1="0.635" x2="8.89" y2="-0.635" width="0.2032" layer="21"/>
+<pad name="1" x="0" y="0.127" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="2" x="2.54" y="-0.127" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="3" x="5.08" y="0.127" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="4" x="7.62" y="-0.127" drill="1.016" diameter="1.8796" rot="R90"/>
+<rectangle x1="7.366" y1="-0.254" x2="7.874" y2="0.254" layer="51"/>
+<rectangle x1="4.826" y1="-0.254" x2="5.334" y2="0.254" layer="51"/>
+<rectangle x1="2.286" y1="-0.254" x2="2.794" y2="0.254" layer="51"/>
+<rectangle x1="-0.254" y1="-0.254" x2="0.254" y2="0.254" layer="51"/>
+<text x="-1.27" y="1.397" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.27" y="-2.032" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="1X04_LOCK_LONGPADS">
+<description>&lt;h3&gt;Plated Through Hole - 4 Pin Long Pads w/ Locking Footprint&lt;/h3&gt;
+Holes are offset 0.005" from center to lock pins in place during soldering. 
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:4&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_04&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="1.524" y1="-0.127" x2="1.016" y2="-0.127" width="0.2032" layer="21"/>
+<wire x1="4.064" y1="-0.127" x2="3.556" y2="-0.127" width="0.2032" layer="21"/>
+<wire x1="6.604" y1="-0.127" x2="6.096" y2="-0.127" width="0.2032" layer="21"/>
+<wire x1="-1.27" y1="-0.127" x2="-1.016" y2="-0.127" width="0.2032" layer="21"/>
+<wire x1="-1.27" y1="-0.127" x2="-1.27" y2="0.8636" width="0.2032" layer="21"/>
+<wire x1="-1.27" y1="0.8636" x2="-0.9906" y2="1.143" width="0.2032" layer="21"/>
+<wire x1="-1.27" y1="-0.127" x2="-1.27" y2="-1.1176" width="0.2032" layer="21"/>
+<wire x1="-1.27" y1="-1.1176" x2="-0.9906" y2="-1.397" width="0.2032" layer="21"/>
+<wire x1="8.89" y1="-0.127" x2="8.636" y2="-0.127" width="0.2032" layer="21"/>
+<wire x1="8.89" y1="-0.127" x2="8.89" y2="-1.1176" width="0.2032" layer="21"/>
+<wire x1="8.89" y1="-1.1176" x2="8.6106" y2="-1.397" width="0.2032" layer="21"/>
+<wire x1="8.89" y1="-0.127" x2="8.89" y2="0.8636" width="0.2032" layer="21"/>
+<wire x1="8.89" y1="0.8636" x2="8.6106" y2="1.143" width="0.2032" layer="21"/>
+<pad name="1" x="0" y="0" drill="1.016" shape="long" rot="R90"/>
+<pad name="2" x="2.54" y="-0.254" drill="1.016" shape="long" rot="R90"/>
+<pad name="3" x="5.08" y="0" drill="1.016" shape="long" rot="R90"/>
+<pad name="4" x="7.62" y="-0.254" drill="1.016" shape="long" rot="R90"/>
+<rectangle x1="-0.2921" y1="-0.4191" x2="0.2921" y2="0.1651" layer="51"/>
+<rectangle x1="2.2479" y1="-0.4191" x2="2.8321" y2="0.1651" layer="51"/>
+<rectangle x1="4.7879" y1="-0.4191" x2="5.3721" y2="0.1651" layer="51"/>
+<rectangle x1="7.3279" y1="-0.4191" x2="7.9121" y2="0.1651" layer="51" rot="R90"/>
+<text x="-1.27" y="1.651" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.27" y="-2.413" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="MOLEX-1X4_LOCK">
+<description>&lt;h3&gt;Molex 4-Pin Plated Through-Hole Locking&lt;/h3&gt;
+Holes are offset 0.005" from center to hold pins in place during soldering. 
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:4&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;&lt;a href=”https://www.sparkfun.com/datasheets/Prototyping/2pin_molex_set_19iv10.pdf”&gt;Datasheet referenced for footprint&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_04&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="-1.27" y1="3.048" x2="-1.27" y2="-2.54" width="0.127" layer="21"/>
+<wire x1="8.89" y1="3.048" x2="8.89" y2="-2.54" width="0.127" layer="21"/>
+<wire x1="8.89" y1="3.048" x2="-1.27" y2="3.048" width="0.127" layer="21"/>
+<wire x1="8.89" y1="-2.54" x2="7.62" y2="-2.54" width="0.127" layer="21"/>
+<wire x1="7.62" y1="-2.54" x2="0" y2="-2.54" width="0.127" layer="21"/>
+<wire x1="0" y1="-2.54" x2="-1.27" y2="-2.54" width="0.127" layer="21"/>
+<wire x1="0" y1="-2.54" x2="0" y2="-1.27" width="0.127" layer="21"/>
+<wire x1="0" y1="-1.27" x2="7.62" y2="-1.27" width="0.127" layer="21"/>
+<wire x1="7.62" y1="-1.27" x2="7.62" y2="-2.54" width="0.127" layer="21"/>
+<pad name="1" x="0" y="0.127" drill="1.016" diameter="1.8796" shape="square"/>
+<pad name="2" x="2.54" y="-0.127" drill="1.016" diameter="1.8796"/>
+<pad name="3" x="5.08" y="0.127" drill="1.016" diameter="1.8796"/>
+<pad name="4" x="7.62" y="-0.127" drill="1.016" diameter="1.8796"/>
+<text x="2.667" y="3.302" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="2.032" y="-3.556" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="1X04_SMD_RA_MALE">
+<description>&lt;h3&gt;SMD - 4 Pin Right Angle Male Header&lt;/h3&gt;
+tDocu layer shows pin locations.
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:4&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_04&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="5.08" y1="1.25" x2="-5.08" y2="1.25" width="0.127" layer="51"/>
+<wire x1="-5.08" y1="1.25" x2="-5.08" y2="-1.25" width="0.127" layer="51"/>
+<wire x1="-5.08" y1="-1.25" x2="-3.81" y2="-1.25" width="0.127" layer="51"/>
+<wire x1="-3.81" y1="-1.25" x2="-1.27" y2="-1.25" width="0.127" layer="51"/>
+<wire x1="-1.27" y1="-1.25" x2="1.27" y2="-1.25" width="0.127" layer="51"/>
+<wire x1="1.27" y1="-1.25" x2="3.81" y2="-1.25" width="0.127" layer="51"/>
+<wire x1="3.81" y1="-1.25" x2="5.08" y2="-1.25" width="0.127" layer="51"/>
+<wire x1="5.08" y1="-1.25" x2="5.08" y2="1.25" width="0.127" layer="51"/>
+<wire x1="3.81" y1="-1.25" x2="3.81" y2="-7.25" width="0.127" layer="51"/>
+<wire x1="1.27" y1="-1.25" x2="1.27" y2="-7.25" width="0.127" layer="51"/>
+<wire x1="-1.27" y1="-1.25" x2="-1.27" y2="-7.25" width="0.127" layer="51"/>
+<wire x1="-3.81" y1="-1.25" x2="-3.81" y2="-7.25" width="0.127" layer="51"/>
+<smd name="4" x="3.81" y="5" dx="3" dy="1" layer="1" rot="R90"/>
+<smd name="3" x="1.27" y="5" dx="3" dy="1" layer="1" rot="R90"/>
+<smd name="2" x="-1.27" y="5" dx="3" dy="1" layer="1" rot="R90"/>
+<smd name="1" x="-3.81" y="5" dx="3" dy="1" layer="1" rot="R90"/>
+<hole x="-2.54" y="0" drill="1.4"/>
+<hole x="2.54" y="0" drill="1.4"/>
+<text x="-4.318" y="6.731" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-4.318" y="2.667" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="1X04_LONGPADS">
+<description>&lt;h3&gt;Plated Through Hole - 4 Pin Long Pads&lt;/h3&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:4&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_04&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="-1.27" y1="0.635" x2="-1.27" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="8.89" y1="0.635" x2="8.89" y2="-0.635" width="0.2032" layer="21"/>
+<pad name="1" x="0" y="0" drill="1.1176" diameter="1.8796" shape="long" rot="R90"/>
+<pad name="2" x="2.54" y="0" drill="1.1176" diameter="1.8796" shape="long" rot="R90"/>
+<pad name="3" x="5.08" y="0" drill="1.1176" diameter="1.8796" shape="long" rot="R90"/>
+<pad name="4" x="7.62" y="0" drill="1.1176" diameter="1.8796" shape="long" rot="R90"/>
+<rectangle x1="7.366" y1="-0.254" x2="7.874" y2="0.254" layer="51"/>
+<rectangle x1="4.826" y1="-0.254" x2="5.334" y2="0.254" layer="51"/>
+<rectangle x1="2.286" y1="-0.254" x2="2.794" y2="0.254" layer="51"/>
+<rectangle x1="-0.254" y1="-0.254" x2="0.254" y2="0.254" layer="51"/>
+<text x="-1.27" y="2.032" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.27" y="-2.667" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="1X04_NO_SILK">
+<description>&lt;h3&gt;Plated Through Hole - 4 Pin No Silk Outline&lt;/h3&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:4&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_04&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<pad name="1" x="0" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="2" x="2.54" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="3" x="5.08" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="4" x="7.62" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<rectangle x1="7.366" y1="-0.254" x2="7.874" y2="0.254" layer="51"/>
+<rectangle x1="4.826" y1="-0.254" x2="5.334" y2="0.254" layer="51"/>
+<rectangle x1="2.286" y1="-0.254" x2="2.794" y2="0.254" layer="51"/>
+<rectangle x1="-0.254" y1="-0.254" x2="0.254" y2="0.254" layer="51"/>
+<text x="-1.27" y="1.397" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.27" y="-2.032" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="JST-4-PTH">
+<description>&lt;h3&gt;JST Right Angle 4 Pin Plated Through Hole&lt;/h3&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count: 4&lt;/li&gt;
+&lt;li&gt;Pin pitch: 2mm&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;&lt;a href=”https://www.sparkfun.com/datasheets/Prototyping/ePH.pdf”&gt;Datasheet referenced for footprint&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_04&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<pad name="1" x="-3" y="0" drill="0.7" diameter="1.6"/>
+<pad name="2" x="-1" y="0" drill="0.7" diameter="1.6"/>
+<pad name="3" x="1" y="0" drill="0.7" diameter="1.6"/>
+<pad name="4" x="3" y="0" drill="0.7" diameter="1.6"/>
+<text x="-3.4" y="0.7" size="1.27" layer="51">+</text>
+<text x="-1.4" y="0.7" size="1.27" layer="51">-</text>
+<text x="0.7" y="0.9" size="0.8" layer="51">S</text>
+<text x="2.7" y="0.9" size="0.8" layer="51">S</text>
+<wire x1="-4.95" y1="-1.6" x2="-4.95" y2="6" width="0.2032" layer="21"/>
+<wire x1="-4.95" y1="6" x2="4.95" y2="6" width="0.2032" layer="21"/>
+<wire x1="4.95" y1="6" x2="4.95" y2="-1.6" width="0.2032" layer="21"/>
+<wire x1="-4.95" y1="-1.6" x2="-4.3" y2="-1.6" width="0.2032" layer="21"/>
+<wire x1="4.95" y1="-1.6" x2="4.3" y2="-1.6" width="0.2032" layer="21"/>
+<wire x1="-4.3" y1="-1.6" x2="-4.3" y2="0" width="0.2032" layer="21"/>
+<wire x1="4.3" y1="-1.6" x2="4.3" y2="0" width="0.2032" layer="21"/>
+<text x="-1.397" y="3.429" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.651" y="2.54" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="SCREWTERMINAL-3.5MM-4_LOCK">
+<description>&lt;h3&gt;Screw Terminal  3.5mm Pitch -4 Pin PTH Locking&lt;/h3&gt;
+Holes are offset 0.005" from center to hold pins in place during soldering. 
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count: 4&lt;/li&gt;
+&lt;li&gt;Pin pitch: 3.5mm/138mil&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;&lt;a href=”https://www.sparkfun.com/datasheets/Prototyping/Screw-Terminal-3.5mm.pdf”&gt;Datasheet referenced for footprint&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_04&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="-2.3" y1="3.4" x2="12.8" y2="3.4" width="0.2032" layer="21"/>
+<wire x1="12.8" y1="3.4" x2="12.8" y2="-2.8" width="0.2032" layer="21"/>
+<wire x1="12.8" y1="-2.8" x2="12.8" y2="-3.6" width="0.2032" layer="21"/>
+<wire x1="12.8" y1="-3.6" x2="-2.3" y2="-3.6" width="0.2032" layer="21"/>
+<wire x1="-2.3" y1="-3.6" x2="-2.3" y2="-2.8" width="0.2032" layer="21"/>
+<wire x1="-2.3" y1="-2.8" x2="-2.3" y2="3.4" width="0.2032" layer="21"/>
+<wire x1="12.8" y1="-2.8" x2="-2.3" y2="-2.8" width="0.2032" layer="21"/>
+<wire x1="-2.3" y1="-1.35" x2="-2.7" y2="-1.35" width="0.2032" layer="51"/>
+<wire x1="-2.7" y1="-1.35" x2="-2.7" y2="-2.35" width="0.2032" layer="51"/>
+<wire x1="-2.7" y1="-2.35" x2="-2.3" y2="-2.35" width="0.2032" layer="51"/>
+<wire x1="12.8" y1="3.15" x2="13.2" y2="3.15" width="0.2032" layer="51"/>
+<wire x1="13.2" y1="3.15" x2="13.2" y2="2.15" width="0.2032" layer="51"/>
+<wire x1="13.2" y1="2.15" x2="12.8" y2="2.15" width="0.2032" layer="51"/>
+<circle x="0" y="0" radius="0.425" width="0.001" layer="51"/>
+<circle x="3.5" y="0" radius="0.425" width="0.001" layer="51"/>
+<circle x="7" y="0" radius="0.425" width="0.001" layer="51"/>
+<circle x="10.5" y="0" radius="0.425" width="0.001" layer="51"/>
+<pad name="1" x="-0.1778" y="0" drill="1.2" diameter="2.032" shape="square"/>
+<pad name="2" x="3.6778" y="0" drill="1.2" diameter="2.032"/>
+<pad name="3" x="6.8222" y="0" drill="1.2" diameter="2.032"/>
+<pad name="4" x="10.6778" y="0" drill="1.2" diameter="2.032"/>
+<text x="3.81" y="2.413" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="3.81" y="1.524" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="1X04_1MM_RA">
+<description>&lt;h3&gt;SMD- 4 Pin Right Angle &lt;/h3&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:4&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_04&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="-1.5" y1="-4.6" x2="1.5" y2="-4.6" width="0.254" layer="21"/>
+<wire x1="-3" y1="-2" x2="-3" y2="-0.35" width="0.254" layer="21"/>
+<wire x1="2.25" y1="-0.35" x2="3" y2="-0.35" width="0.254" layer="21"/>
+<wire x1="3" y1="-0.35" x2="3" y2="-2" width="0.254" layer="21"/>
+<wire x1="-3" y1="-0.35" x2="-2.25" y2="-0.35" width="0.254" layer="21"/>
+<circle x="-2.5" y="0.3" radius="0.1414" width="0.4" layer="21"/>
+<smd name="NC2" x="-2.8" y="-3.675" dx="1.2" dy="2" layer="1"/>
+<smd name="NC1" x="2.8" y="-3.675" dx="1.2" dy="2" layer="1"/>
+<smd name="1" x="-1.5" y="0" dx="0.6" dy="1.35" layer="1"/>
+<smd name="2" x="-0.5" y="0" dx="0.6" dy="1.35" layer="1"/>
+<smd name="3" x="0.5" y="0" dx="0.6" dy="1.35" layer="1"/>
+<smd name="4" x="1.5" y="0" dx="0.6" dy="1.35" layer="1"/>
+<text x="-1.397" y="-2.159" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.651" y="-3.302" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="1X04_SMD_VERTICAL_COMBO">
+<description>&lt;h3&gt;SMD - 4 Pin Vertical Connector&lt;/h3&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:4&lt;/li&gt;
+&lt;li&gt;SMD Pad count:8&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_04&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="7.62" y1="1.27" x2="7.62" y2="-1.27" width="0.4064" layer="1"/>
+<wire x1="5.08" y1="1.27" x2="5.08" y2="-1.27" width="0.4064" layer="1"/>
+<wire x1="2.54" y1="1.27" x2="2.54" y2="-1.27" width="0.4064" layer="1"/>
+<wire x1="0" y1="1.27" x2="0" y2="-1.27" width="0.4064" layer="1"/>
+<wire x1="-1.37" y1="-1.25" x2="-1.37" y2="1.25" width="0.1778" layer="21"/>
+<wire x1="8.99" y1="1.25" x2="8.99" y2="-1.25" width="0.1778" layer="21"/>
+<wire x1="-0.73" y1="-1.25" x2="-1.37" y2="-1.25" width="0.1778" layer="21"/>
+<wire x1="8.99" y1="-1.25" x2="8.32" y2="-1.25" width="0.1778" layer="21"/>
+<wire x1="8.32" y1="1.25" x2="8.99" y2="1.25" width="0.1778" layer="21"/>
+<wire x1="-1.37" y1="1.25" x2="-0.73" y2="1.25" width="0.1778" layer="21"/>
+<wire x1="5.869" y1="-1.29" x2="6.831" y2="-1.29" width="0.1778" layer="21"/>
+<wire x1="5.869" y1="1.25" x2="6.831" y2="1.25" width="0.1778" layer="21"/>
+<wire x1="3.329" y1="-1.29" x2="4.291" y2="-1.29" width="0.1778" layer="21"/>
+<wire x1="3.329" y1="1.25" x2="4.291" y2="1.25" width="0.1778" layer="21"/>
+<wire x1="0.789" y1="-1.29" x2="1.751" y2="-1.29" width="0.1778" layer="21"/>
+<wire x1="0.789" y1="1.25" x2="1.751" y2="1.25" width="0.1778" layer="21"/>
+<smd name="3" x="5.08" y="-1.65" dx="2" dy="1" layer="1" rot="R270"/>
+<smd name="1" x="0" y="-1.65" dx="2" dy="1" layer="1" rot="R270"/>
+<smd name="4" x="7.62" y="1.65" dx="2" dy="1" layer="1" rot="R270"/>
+<smd name="2" x="2.54" y="1.65" dx="2" dy="1" layer="1" rot="R270"/>
+<smd name="1-2" x="0" y="1.65" dx="2" dy="1" layer="1" rot="R90"/>
+<smd name="2-2" x="2.54" y="-1.65" dx="2" dy="1" layer="1" rot="R90"/>
+<smd name="3-2" x="5.08" y="1.65" dx="2" dy="1" layer="1" rot="R90"/>
+<smd name="4-2" x="7.62" y="-1.65" dx="2" dy="1" layer="1" rot="R90"/>
+<text x="-0.508" y="2.921" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-0.508" y="-3.429" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="1X04_SMD_LONG">
+<description>&lt;h3&gt;SMD - 4 Pin w/ Long Solder Pads&lt;/h3&gt;
+No silk, but tDocu layer shows pin position. 
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:4&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_04&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="5.08" y1="1.25" x2="-5.08" y2="1.25" width="0.127" layer="51"/>
+<wire x1="-5.08" y1="1.25" x2="-5.08" y2="-1.25" width="0.127" layer="51"/>
+<wire x1="-5.08" y1="-1.25" x2="-3.81" y2="-1.25" width="0.127" layer="51"/>
+<wire x1="-3.81" y1="-1.25" x2="-1.27" y2="-1.25" width="0.127" layer="51"/>
+<wire x1="-1.27" y1="-1.25" x2="1.27" y2="-1.25" width="0.127" layer="51"/>
+<wire x1="1.27" y1="-1.25" x2="3.81" y2="-1.25" width="0.127" layer="51"/>
+<wire x1="3.81" y1="-1.25" x2="5.08" y2="-1.25" width="0.127" layer="51"/>
+<wire x1="5.08" y1="-1.25" x2="5.08" y2="1.25" width="0.127" layer="51"/>
+<wire x1="3.81" y1="-1.25" x2="3.81" y2="-7.25" width="0.127" layer="51"/>
+<wire x1="1.27" y1="-1.25" x2="1.27" y2="-7.25" width="0.127" layer="51"/>
+<wire x1="-1.27" y1="-1.25" x2="-1.27" y2="-7.25" width="0.127" layer="51"/>
+<wire x1="-3.81" y1="-1.25" x2="-3.81" y2="-7.25" width="0.127" layer="51"/>
+<smd name="4" x="3.81" y="5.5" dx="4" dy="1" layer="1" rot="R90"/>
+<smd name="3" x="1.27" y="5.5" dx="4" dy="1" layer="1" rot="R90"/>
+<smd name="2" x="-1.27" y="5.5" dx="4" dy="1" layer="1" rot="R90"/>
+<smd name="1" x="-3.81" y="5.5" dx="4" dy="1" layer="1" rot="R90"/>
+<hole x="-2.54" y="0" drill="1.4"/>
+<hole x="2.54" y="0" drill="1.4"/>
+</package>
+<package name="JST-4-PTH-VERT">
+<description>&lt;h3&gt;JST Vertical 4 Pin Plated Through Hole&lt;/h3&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count: 4&lt;/li&gt;
+&lt;li&gt;Pin pitch: 2mm&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;&lt;a href="http://www.jst-mfg.com/product/pdf/eng/ePH.pdf"&gt;Datasheet referenced for footprint&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_04&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="-4.95" y1="-2.25" x2="-4.95" y2="2.25" width="0.2032" layer="21"/>
+<wire x1="-4.95" y1="2.25" x2="4.95" y2="2.25" width="0.2032" layer="21"/>
+<wire x1="4.95" y1="-2.25" x2="1" y2="-2.25" width="0.2032" layer="21"/>
+<wire x1="-1" y1="-2.25" x2="-4.95" y2="-2.25" width="0.2032" layer="21"/>
+<wire x1="-1" y1="-1.75" x2="1" y2="-1.75" width="0.2032" layer="21"/>
+<wire x1="1" y1="-1.75" x2="1" y2="-2.25" width="0.2032" layer="21"/>
+<wire x1="-1" y1="-1.75" x2="-1" y2="-2.25" width="0.2032" layer="21"/>
+<wire x1="4.95" y1="2.25" x2="4.95" y2="-2.25" width="0.2032" layer="21"/>
+<pad name="1" x="-3" y="-0.55" drill="0.7" diameter="1.6"/>
+<pad name="2" x="-1" y="-0.55" drill="0.7" diameter="1.6"/>
+<pad name="3" x="1" y="-0.55" drill="0.7" diameter="1.6"/>
+<pad name="4" x="3" y="-0.55" drill="0.7" diameter="1.6"/>
+<text x="-1.4" y="0.75" size="1.27" layer="51">+</text>
+<text x="0.6" y="0.75" size="1.27" layer="51">-</text>
+<text x="2.7" y="0.95" size="0.8" layer="51">Y</text>
+<text x="-3.3" y="0.95" size="0.8" layer="51">B</text>
+<text x="-1.143" y="2.54" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.651" y="-3.302" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="1X04_SMD_RA_FEMALE">
+<description>&lt;h3&gt;SMD - 4 Pin Right-Angle Female Header&lt;/h3&gt;
+Silk outline shows header location. 
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:4&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_04&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="-5.205" y1="4.25" x2="-5.205" y2="-4.25" width="0.1778" layer="21"/>
+<wire x1="5.205" y1="4.25" x2="-5.205" y2="4.25" width="0.1778" layer="21"/>
+<wire x1="5.205" y1="-4.25" x2="5.205" y2="4.25" width="0.1778" layer="21"/>
+<wire x1="-5.205" y1="-4.25" x2="5.205" y2="-4.25" width="0.1778" layer="21"/>
+<rectangle x1="-1.59" y1="6.8" x2="-0.95" y2="7.65" layer="51"/>
+<rectangle x1="0.95" y1="6.8" x2="1.59" y2="7.65" layer="51"/>
+<rectangle x1="-4.13" y1="6.8" x2="-3.49" y2="7.65" layer="51"/>
+<smd name="3" x="1.27" y="7.225" dx="1.25" dy="3" layer="1" rot="R180"/>
+<smd name="2" x="-1.27" y="7.225" dx="1.25" dy="3" layer="1" rot="R180"/>
+<smd name="1" x="-3.81" y="7.225" dx="1.25" dy="3" layer="1" rot="R180"/>
+<rectangle x1="3.49" y1="6.8" x2="4.13" y2="7.65" layer="51"/>
+<smd name="4" x="3.81" y="7.225" dx="1.25" dy="3" layer="1" rot="R180"/>
+<text x="-1.397" y="0.762" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.524" y="-1.27" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="1X03">
+<description>&lt;h3&gt;Plated Through Hole - 3 Pin&lt;/h3&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:3&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_03&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="3.81" y1="0.635" x2="4.445" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="4.445" y1="1.27" x2="5.715" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="5.715" y1="1.27" x2="6.35" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="6.35" y1="-0.635" x2="5.715" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="5.715" y1="-1.27" x2="4.445" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="4.445" y1="-1.27" x2="3.81" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="-0.635" y1="1.27" x2="0.635" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="0.635" y1="1.27" x2="1.27" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="1.27" y1="-0.635" x2="0.635" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="1.27" y1="0.635" x2="1.905" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="1.905" y1="1.27" x2="3.175" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="3.175" y1="1.27" x2="3.81" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="3.81" y1="-0.635" x2="3.175" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="3.175" y1="-1.27" x2="1.905" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="1.905" y1="-1.27" x2="1.27" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="-1.27" y1="0.635" x2="-1.27" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="-0.635" y1="1.27" x2="-1.27" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="-1.27" y1="-0.635" x2="-0.635" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="0.635" y1="-1.27" x2="-0.635" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="6.35" y1="0.635" x2="6.35" y2="-0.635" width="0.2032" layer="21"/>
+<pad name="1" x="0" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="2" x="2.54" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="3" x="5.08" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<rectangle x1="4.826" y1="-0.254" x2="5.334" y2="0.254" layer="51"/>
+<rectangle x1="2.286" y1="-0.254" x2="2.794" y2="0.254" layer="51"/>
+<rectangle x1="-0.254" y1="-0.254" x2="0.254" y2="0.254" layer="51"/>
+<text x="-1.27" y="1.397" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.27" y="-2.032" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="MOLEX-1X3">
+<description>&lt;h3&gt;PTH - 3 Pin Vertical Molex Polarized Header&lt;/h3&gt;
+&lt;p&gt;&lt;b&gt;Datasheet referenced for footprint:&lt;/b&gt;&lt;a href="http://www.4uconnector.com/online/object/4udrawing/01932.pdf"&gt; 4UCONN part # 01932 &lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:3&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_03&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="-1.27" y1="3.048" x2="-1.27" y2="-2.54" width="0.127" layer="21"/>
+<wire x1="6.35" y1="3.048" x2="6.35" y2="-2.54" width="0.127" layer="21"/>
+<wire x1="6.35" y1="3.048" x2="-1.27" y2="3.048" width="0.127" layer="21"/>
+<wire x1="6.35" y1="-2.54" x2="5.08" y2="-2.54" width="0.127" layer="21"/>
+<wire x1="5.08" y1="-2.54" x2="0" y2="-2.54" width="0.127" layer="21"/>
+<wire x1="0" y1="-2.54" x2="-1.27" y2="-2.54" width="0.127" layer="21"/>
+<wire x1="0" y1="-2.54" x2="0" y2="-1.27" width="0.127" layer="21"/>
+<wire x1="0" y1="-1.27" x2="5.08" y2="-1.27" width="0.127" layer="21"/>
+<wire x1="5.08" y1="-1.27" x2="5.08" y2="-2.54" width="0.127" layer="21"/>
+<pad name="1" x="0" y="0" drill="1.016" diameter="1.8796" shape="square"/>
+<pad name="2" x="2.54" y="0" drill="1.016" diameter="1.8796"/>
+<pad name="3" x="5.08" y="0" drill="1.016" diameter="1.8796"/>
+<text x="1.143" y="2.159" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="0.889" y="1.27" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="SCREWTERMINAL-3.5MM-3">
+<description>&lt;h3&gt;Screw Terminal  3.5mm Pitch -3 Pin PTH&lt;/h3&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count: 3&lt;/li&gt;
+&lt;li&gt;Pin pitch: 3.5mm/138mil&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;&lt;a href=”https://www.sparkfun.com/datasheets/Prototyping/Screw-Terminal-3.5mm.pdf”&gt;Datasheet referenced for footprint&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_03&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="-1.75" y1="3.4" x2="8.75" y2="3.4" width="0.2032" layer="21"/>
+<wire x1="8.75" y1="3.4" x2="8.75" y2="-2.8" width="0.2032" layer="21"/>
+<wire x1="8.75" y1="-2.8" x2="8.75" y2="-3.6" width="0.2032" layer="21"/>
+<wire x1="8.75" y1="-3.6" x2="-1.75" y2="-3.6" width="0.2032" layer="21"/>
+<wire x1="-1.75" y1="-3.6" x2="-1.75" y2="-2.8" width="0.2032" layer="21"/>
+<wire x1="-1.75" y1="-2.8" x2="-1.75" y2="3.4" width="0.2032" layer="21"/>
+<wire x1="8.75" y1="-2.8" x2="-1.75" y2="-2.8" width="0.2032" layer="21"/>
+<wire x1="-1.75" y1="-1.35" x2="-2.25" y2="-1.35" width="0.2032" layer="51"/>
+<wire x1="-2.25" y1="-1.35" x2="-2.25" y2="-2.35" width="0.2032" layer="51"/>
+<wire x1="-2.25" y1="-2.35" x2="-1.75" y2="-2.35" width="0.2032" layer="51"/>
+<wire x1="8.75" y1="3.15" x2="9.25" y2="3.15" width="0.2032" layer="51"/>
+<wire x1="9.25" y1="3.15" x2="9.25" y2="2.15" width="0.2032" layer="51"/>
+<wire x1="9.25" y1="2.15" x2="8.75" y2="2.15" width="0.2032" layer="51"/>
+<pad name="1" x="0" y="0" drill="1.2" diameter="2.413" shape="square"/>
+<pad name="2" x="3.5" y="0" drill="1.2" diameter="2.413"/>
+<pad name="3" x="7" y="0" drill="1.2" diameter="2.413"/>
+<text x="2.159" y="3.683" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="2.032" y="-4.572" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="1X03_LOCK">
+<description>&lt;h3&gt;Plated Through Hole - 3 Pin Locking Footprint&lt;/h3&gt;
+Pins are staggered 0.005" off center to lock pins while soldering. 
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:3&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_03&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="3.81" y1="0.635" x2="4.445" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="4.445" y1="1.27" x2="5.715" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="5.715" y1="1.27" x2="6.35" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="6.35" y1="-0.635" x2="5.715" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="5.715" y1="-1.27" x2="4.445" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="4.445" y1="-1.27" x2="3.81" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="-0.635" y1="1.27" x2="0.635" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="0.635" y1="1.27" x2="1.27" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="1.27" y1="-0.635" x2="0.635" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="1.27" y1="0.635" x2="1.905" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="1.905" y1="1.27" x2="3.175" y2="1.27" width="0.2032" layer="21"/>
+<wire x1="3.175" y1="1.27" x2="3.81" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="3.81" y1="-0.635" x2="3.175" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="3.175" y1="-1.27" x2="1.905" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="1.905" y1="-1.27" x2="1.27" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="-1.27" y1="0.635" x2="-1.27" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="-0.635" y1="1.27" x2="-1.27" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="-1.27" y1="-0.635" x2="-0.635" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="0.635" y1="-1.27" x2="-0.635" y2="-1.27" width="0.2032" layer="21"/>
+<wire x1="6.35" y1="0.635" x2="6.35" y2="-0.635" width="0.2032" layer="21"/>
+<pad name="1" x="0" y="0.127" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="2" x="2.54" y="-0.127" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="3" x="5.08" y="0.127" drill="1.016" diameter="1.8796" rot="R90"/>
+<rectangle x1="4.826" y1="-0.254" x2="5.334" y2="0.254" layer="51"/>
+<rectangle x1="2.286" y1="-0.254" x2="2.794" y2="0.254" layer="51"/>
+<rectangle x1="-0.254" y1="-0.254" x2="0.254" y2="0.254" layer="51"/>
+<text x="-1.27" y="1.397" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.27" y="-2.032" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="1X03_LOCK_LONGPADS">
+<description>&lt;h3&gt;Plated Through Hole - 3 Pin Long Pad w/ Locking Footprint&lt;/h3&gt;
+Holes are offset 0.005" from center to lock pins in place while soldering. 
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:3&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_03&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="1.524" y1="-0.127" x2="1.016" y2="-0.127" width="0.2032" layer="21"/>
+<wire x1="4.064" y1="-0.127" x2="3.556" y2="-0.127" width="0.2032" layer="21"/>
+<wire x1="-1.27" y1="-0.127" x2="-1.016" y2="-0.127" width="0.2032" layer="21"/>
+<wire x1="-1.27" y1="-0.127" x2="-1.27" y2="0.8636" width="0.2032" layer="21"/>
+<wire x1="-1.27" y1="0.8636" x2="-0.9906" y2="1.143" width="0.2032" layer="21"/>
+<wire x1="-1.27" y1="-0.127" x2="-1.27" y2="-1.1176" width="0.2032" layer="21"/>
+<wire x1="-1.27" y1="-1.1176" x2="-0.9906" y2="-1.397" width="0.2032" layer="21"/>
+<wire x1="6.35" y1="-0.127" x2="6.096" y2="-0.127" width="0.2032" layer="21"/>
+<wire x1="6.35" y1="-0.127" x2="6.35" y2="-1.1176" width="0.2032" layer="21"/>
+<wire x1="6.35" y1="-1.1176" x2="6.0706" y2="-1.397" width="0.2032" layer="21"/>
+<wire x1="6.35" y1="-0.127" x2="6.35" y2="0.8636" width="0.2032" layer="21"/>
+<wire x1="6.35" y1="0.8636" x2="6.0706" y2="1.143" width="0.2032" layer="21"/>
+<pad name="1" x="0" y="0" drill="1.016" shape="long" rot="R90"/>
+<pad name="2" x="2.54" y="-0.254" drill="1.016" shape="long" rot="R90"/>
+<pad name="3" x="5.08" y="0" drill="1.016" shape="long" rot="R90"/>
+<rectangle x1="-0.2921" y1="-0.4191" x2="0.2921" y2="0.1651" layer="51"/>
+<rectangle x1="2.2479" y1="-0.4191" x2="2.8321" y2="0.1651" layer="51"/>
+<rectangle x1="4.7879" y1="-0.4191" x2="5.3721" y2="0.1651" layer="51"/>
+<text x="-1.27" y="1.778" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.27" y="-2.413" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="MOLEX-1X3_LOCK">
+<description>&lt;h3&gt;PTH - 3 Pin Vertical Molex Polarized Header&lt;/h3&gt;
+Pins are offset 0.005" from center to lock pins in place during soldering. 
+&lt;p&gt;&lt;b&gt;Datasheet referenced for footprint:&lt;/b&gt;&lt;a href="http://www.4uconnector.com/online/object/4udrawing/01932.pdf"&gt; 4UCONN part # 01932 &lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:3&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_03&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="-1.27" y1="3.048" x2="-1.27" y2="-2.54" width="0.127" layer="21"/>
+<wire x1="6.35" y1="3.048" x2="6.35" y2="-2.54" width="0.127" layer="21"/>
+<wire x1="6.35" y1="3.048" x2="-1.27" y2="3.048" width="0.127" layer="21"/>
+<wire x1="6.35" y1="-2.54" x2="5.08" y2="-2.54" width="0.127" layer="21"/>
+<wire x1="5.08" y1="-2.54" x2="0" y2="-2.54" width="0.127" layer="21"/>
+<wire x1="0" y1="-2.54" x2="-1.27" y2="-2.54" width="0.127" layer="21"/>
+<wire x1="0" y1="-2.54" x2="0" y2="-1.27" width="0.127" layer="21"/>
+<wire x1="0" y1="-1.27" x2="5.08" y2="-1.27" width="0.127" layer="21"/>
+<wire x1="5.08" y1="-1.27" x2="5.08" y2="-2.54" width="0.127" layer="21"/>
+<pad name="1" x="0" y="0.127" drill="1.016" diameter="1.8796" shape="square"/>
+<pad name="2" x="2.54" y="-0.127" drill="1.016" diameter="1.8796"/>
+<pad name="3" x="5.08" y="0.127" drill="1.016" diameter="1.8796"/>
+<rectangle x1="-0.2921" y1="-0.2921" x2="0.2921" y2="0.2921" layer="51"/>
+<rectangle x1="2.2479" y1="-0.2921" x2="2.8321" y2="0.2921" layer="51"/>
+<rectangle x1="4.7879" y1="-0.2921" x2="5.3721" y2="0.2921" layer="51"/>
+<text x="1.143" y="3.429" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="0.889" y="-2.794" size="0.6096" layer="27" font="vector" ratio="20" align="top-left">&gt;VALUE</text>
+</package>
+<package name="SCREWTERMINAL-3.5MM-3_LOCK.007S">
+<description>&lt;h3&gt;Screw Terminal  3.5mm Pitch -3 Pin PTH Locking&lt;/h3&gt;
+Holes are offset 0.007" from center to hold pins in place during soldering. 
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count: 3&lt;/li&gt;
+&lt;li&gt;Pin pitch: 3.5mm/138mil&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;&lt;a href=”https://www.sparkfun.com/datasheets/Prototyping/Screw-Terminal-3.5mm.pdf”&gt;Datasheet referenced for footprint&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_03&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="-1.75" y1="3.4" x2="8.75" y2="3.4" width="0.2032" layer="21"/>
+<wire x1="8.75" y1="3.4" x2="8.75" y2="-2.8" width="0.2032" layer="21"/>
+<wire x1="8.75" y1="-2.8" x2="8.75" y2="-3.6" width="0.2032" layer="21"/>
+<wire x1="8.75" y1="-3.6" x2="-1.75" y2="-3.6" width="0.2032" layer="21"/>
+<wire x1="-1.75" y1="-3.6" x2="-1.75" y2="-2.8" width="0.2032" layer="21"/>
+<wire x1="-1.75" y1="-2.8" x2="-1.75" y2="3.4" width="0.2032" layer="21"/>
+<wire x1="8.75" y1="-2.8" x2="-1.75" y2="-2.8" width="0.2032" layer="21"/>
+<wire x1="-1.75" y1="-1.35" x2="-2.25" y2="-1.35" width="0.2032" layer="51"/>
+<wire x1="-2.25" y1="-1.35" x2="-2.25" y2="-2.35" width="0.2032" layer="51"/>
+<wire x1="-2.25" y1="-2.35" x2="-1.75" y2="-2.35" width="0.2032" layer="51"/>
+<wire x1="8.75" y1="3.15" x2="9.25" y2="3.15" width="0.2032" layer="51"/>
+<wire x1="9.25" y1="3.15" x2="9.25" y2="2.15" width="0.2032" layer="51"/>
+<wire x1="9.25" y1="2.15" x2="8.75" y2="2.15" width="0.2032" layer="51"/>
+<circle x="0" y="0" radius="0.425" width="0.001" layer="51"/>
+<circle x="3.5" y="0" radius="0.425" width="0.001" layer="51"/>
+<circle x="7" y="0" radius="0.425" width="0.001" layer="51"/>
+<pad name="1" x="-0.1778" y="0" drill="1.2" diameter="2.032" shape="square"/>
+<pad name="2" x="3.5" y="0" drill="1.2" diameter="2.032"/>
+<pad name="3" x="7.1778" y="0" drill="1.2" diameter="2.032"/>
+<text x="2.032" y="3.683" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="1.905" y="-4.699" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="1X03_NO_SILK">
+<description>&lt;h3&gt;Plated Through Hole - 3 Pin No Silk Outline&lt;/h3&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:3&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_03&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<pad name="1" x="0" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="2" x="2.54" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="3" x="5.08" y="0" drill="1.016" diameter="1.8796" rot="R90"/>
+<rectangle x1="4.826" y1="-0.254" x2="5.334" y2="0.254" layer="51"/>
+<rectangle x1="2.286" y1="-0.254" x2="2.794" y2="0.254" layer="51"/>
+<rectangle x1="-0.254" y1="-0.254" x2="0.254" y2="0.254" layer="51"/>
+<text x="-1.27" y="1.397" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.27" y="-2.032" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="1X03_LONGPADS">
+<description>&lt;h3&gt;Plated Through Hole - 3 Pin Long Pads&lt;/h3&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:3&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_03&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="-1.27" y1="0.635" x2="-1.27" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="6.35" y1="0.635" x2="6.35" y2="-0.635" width="0.2032" layer="21"/>
+<pad name="1" x="0" y="0" drill="1.1176" diameter="1.8796" shape="long" rot="R90"/>
+<pad name="2" x="2.54" y="0" drill="1.1176" diameter="1.8796" shape="long" rot="R90"/>
+<pad name="3" x="5.08" y="0" drill="1.1176" diameter="1.8796" shape="long" rot="R90"/>
+<rectangle x1="4.826" y1="-0.254" x2="5.334" y2="0.254" layer="51"/>
+<rectangle x1="2.286" y1="-0.254" x2="2.794" y2="0.254" layer="51"/>
+<rectangle x1="-0.254" y1="-0.254" x2="0.254" y2="0.254" layer="51"/>
+<text x="-1.27" y="2.032" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.27" y="-2.667" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="JST-3-PTH">
+<description>&lt;h3&gt;JST 3 Pin Right Angle Plated Through Hole&lt;/h3&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:3&lt;/li&gt;
+&lt;li&gt;Pin pitch:2mm&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;&lt;a href=”https://www.sparkfun.com/datasheets/Prototyping/ePH.pdf”&gt;Datasheet referenced for footprint&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_03&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="-3.95" y1="-1.6" x2="-3.95" y2="6" width="0.2032" layer="21"/>
+<wire x1="-3.95" y1="6" x2="3.95" y2="6" width="0.2032" layer="21"/>
+<wire x1="3.95" y1="6" x2="3.95" y2="-1.6" width="0.2032" layer="21"/>
+<wire x1="-3.95" y1="-1.6" x2="-3.3" y2="-1.6" width="0.2032" layer="21"/>
+<wire x1="3.95" y1="-1.6" x2="3.3" y2="-1.6" width="0.2032" layer="21"/>
+<wire x1="-3.3" y1="-1.6" x2="-3.3" y2="0" width="0.2032" layer="21"/>
+<wire x1="3.3" y1="-1.6" x2="3.3" y2="0" width="0.2032" layer="21"/>
+<pad name="1" x="-2" y="0" drill="0.7" diameter="1.6"/>
+<pad name="2" x="0" y="0" drill="0.7" diameter="1.6"/>
+<pad name="3" x="2" y="0" drill="0.7" diameter="1.6"/>
+<text x="-2.4" y="0.67" size="1.27" layer="51">+</text>
+<text x="-0.4" y="0.67" size="1.27" layer="51">-</text>
+<text x="1.7" y="0.87" size="0.8" layer="51">S</text>
+<text x="-1.397" y="3.429" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.651" y="2.54" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="1X03_PP_HOLES_ONLY">
+<description>&lt;h3&gt;Pogo Pins - 3 Pin&lt;/h3&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:3&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_03&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<circle x="0" y="0" radius="0.635" width="0.127" layer="51"/>
+<circle x="2.54" y="0" radius="0.635" width="0.127" layer="51"/>
+<circle x="5.08" y="0" radius="0.635" width="0.127" layer="51"/>
+<pad name="1" x="0" y="0" drill="0.9" diameter="0.8128" rot="R90"/>
+<pad name="2" x="2.54" y="0" drill="0.9" diameter="0.8128" rot="R90"/>
+<pad name="3" x="5.08" y="0" drill="0.9" diameter="0.8128" rot="R90"/>
+<hole x="0" y="0" drill="1.4732"/>
+<hole x="2.54" y="0" drill="1.4732"/>
+<hole x="5.08" y="0" drill="1.4732"/>
+<text x="-1.27" y="1.143" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.27" y="-1.778" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="SCREWTERMINAL-5MM-3">
+<description>&lt;h3&gt;Screw Terminal  5mm Pitch -3 Pin PTH&lt;/h3&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count: 3&lt;/li&gt;
+&lt;li&gt;Pin pitch: 5mm/197mil&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;&lt;a href=”https://www.sparkfun.com/datasheets/Prototyping/Screw-Terminal-5mm.pdf”&gt;Datasheet referenced for footprint&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_03&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="-3.1" y1="4.2" x2="13.1" y2="4.2" width="0.2032" layer="21"/>
+<wire x1="13.1" y1="4.2" x2="13.1" y2="-2.3" width="0.2032" layer="21"/>
+<wire x1="13.1" y1="-2.3" x2="13.1" y2="-3.3" width="0.2032" layer="21"/>
+<wire x1="13.1" y1="-3.3" x2="-3.1" y2="-3.3" width="0.2032" layer="21"/>
+<wire x1="-3.1" y1="-3.3" x2="-3.1" y2="-2.3" width="0.2032" layer="21"/>
+<wire x1="-3.1" y1="-2.3" x2="-3.1" y2="4.2" width="0.2032" layer="21"/>
+<wire x1="13.1" y1="-2.3" x2="-3.1" y2="-2.3" width="0.2032" layer="21"/>
+<wire x1="-3.1" y1="-1.35" x2="-3.7" y2="-1.35" width="0.2032" layer="51"/>
+<wire x1="-3.7" y1="-1.35" x2="-3.7" y2="-2.35" width="0.2032" layer="51"/>
+<wire x1="-3.7" y1="-2.35" x2="-3.1" y2="-2.35" width="0.2032" layer="51"/>
+<wire x1="13.1" y1="4" x2="13.7" y2="4" width="0.2032" layer="51"/>
+<wire x1="13.7" y1="4" x2="13.7" y2="3" width="0.2032" layer="51"/>
+<wire x1="13.7" y1="3" x2="13.1" y2="3" width="0.2032" layer="51"/>
+<circle x="2.5" y="3.7" radius="0.2828" width="0.127" layer="51"/>
+<pad name="1" x="0" y="0" drill="1.3" diameter="2.413" shape="square"/>
+<pad name="2" x="5" y="0" drill="1.3" diameter="2.413"/>
+<pad name="3" x="10" y="0" drill="1.3" diameter="2.413"/>
+<text x="3.683" y="2.794" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="3.429" y="1.905" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="1X03_LOCK_NO_SILK">
+<description>&lt;h3&gt;Plated Through Hole - 3 Pin Locking Footprint w/out Silk Outline&lt;/h3&gt;
+Holes are offset from center 0.005" to lock pins in place while soldering. 
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:3&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_03&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<pad name="1" x="0" y="0.127" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="2" x="2.54" y="-0.127" drill="1.016" diameter="1.8796" rot="R90"/>
+<pad name="3" x="5.08" y="0.127" drill="1.016" diameter="1.8796" rot="R90"/>
+<rectangle x1="4.826" y1="-0.254" x2="5.334" y2="0.254" layer="51"/>
+<rectangle x1="2.286" y1="-0.254" x2="2.794" y2="0.254" layer="51"/>
+<rectangle x1="-0.254" y1="-0.254" x2="0.254" y2="0.254" layer="51"/>
+<text x="-1.27" y="1.397" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.27" y="-2.032" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="JST-3-SMD">
+<description>&lt;h3&gt;JST 3 Pin Right Angle SMT&lt;/h3&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:3&lt;/li&gt;
+&lt;li&gt;Pin pitch:2mm&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_03&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="-4.99" y1="-2.07" x2="-4.99" y2="-5.57" width="0.2032" layer="21"/>
+<wire x1="-4.99" y1="-5.57" x2="-4.19" y2="-5.57" width="0.2032" layer="21"/>
+<wire x1="-4.19" y1="-5.57" x2="-4.19" y2="-3.07" width="0.2032" layer="21"/>
+<wire x1="-4.19" y1="-3.07" x2="-2.99" y2="-3.07" width="0.2032" layer="21"/>
+<wire x1="3.01" y1="-3.07" x2="4.21" y2="-3.07" width="0.2032" layer="21"/>
+<wire x1="4.21" y1="-3.07" x2="4.21" y2="-5.57" width="0.2032" layer="21"/>
+<wire x1="4.21" y1="-5.57" x2="5.01" y2="-5.57" width="0.2032" layer="21"/>
+<wire x1="5.01" y1="-5.57" x2="5.01" y2="-2.07" width="0.2032" layer="21"/>
+<wire x1="3.01" y1="1.93" x2="-2.99" y2="1.93" width="0.2032" layer="21"/>
+<smd name="3" x="-1.99" y="-4.77" dx="1" dy="4.6" layer="1"/>
+<smd name="1" x="2.01" y="-4.77" dx="1" dy="4.6" layer="1"/>
+<smd name="NC1" x="-4.39" y="0.43" dx="3.4" dy="1.6" layer="1" rot="R90"/>
+<smd name="NC2" x="4.41" y="0.43" dx="3.4" dy="1.6" layer="1" rot="R90"/>
+<smd name="2" x="0.01" y="-4.77" dx="1" dy="4.6" layer="1"/>
+<text x="-1.397" y="0.635" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.651" y="-1.27" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="1X03-1MM-RA">
+<description>&lt;h3&gt;Plated Through Hole - 3 Pin SMD&lt;/h3&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:3&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_03&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="-1" y1="-4.6" x2="1" y2="-4.6" width="0.254" layer="21"/>
+<wire x1="-2.5" y1="-2" x2="-2.5" y2="-0.35" width="0.254" layer="21"/>
+<wire x1="1.75" y1="-0.35" x2="2.4997" y2="-0.35" width="0.254" layer="21"/>
+<wire x1="2.4997" y1="-0.35" x2="2.4997" y2="-2" width="0.254" layer="21"/>
+<wire x1="-2.5" y1="-0.35" x2="-1.75" y2="-0.35" width="0.254" layer="21"/>
+<circle x="-2" y="0.3" radius="0.1414" width="0.4" layer="21"/>
+<smd name="NC2" x="-2.3" y="-3.675" dx="1.2" dy="2" layer="1"/>
+<smd name="NC1" x="2.3" y="-3.675" dx="1.2" dy="2" layer="1"/>
+<smd name="1" x="-1" y="0" dx="0.6" dy="1.35" layer="1"/>
+<smd name="2" x="0" y="0" dx="0.6" dy="1.35" layer="1"/>
+<smd name="3" x="1" y="0" dx="0.6" dy="1.35" layer="1"/>
+<text x="-1.397" y="-1.651" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.651" y="-2.54" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="1X03_SMD_RA_FEMALE">
+<description>&lt;h3&gt;SMD - 3 Pin Right Angle Female Header&lt;/h3&gt;
+Silk outline of pin location
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:3&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_03&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="-3.935" y1="4.25" x2="-3.935" y2="-4.25" width="0.1778" layer="21"/>
+<wire x1="3.935" y1="4.25" x2="-3.935" y2="4.25" width="0.1778" layer="21"/>
+<wire x1="3.935" y1="-4.25" x2="3.935" y2="4.25" width="0.1778" layer="21"/>
+<wire x1="-3.935" y1="-4.25" x2="3.935" y2="-4.25" width="0.1778" layer="21"/>
+<rectangle x1="-0.32" y1="6.8" x2="0.32" y2="7.65" layer="51"/>
+<rectangle x1="2.22" y1="6.8" x2="2.86" y2="7.65" layer="51"/>
+<rectangle x1="-2.86" y1="6.8" x2="-2.22" y2="7.65" layer="51"/>
+<smd name="3" x="2.54" y="7.225" dx="1.25" dy="3" layer="1" rot="R180"/>
+<smd name="2" x="0" y="7.225" dx="1.25" dy="3" layer="1" rot="R180"/>
+<smd name="1" x="-2.54" y="7.225" dx="1.25" dy="3" layer="1" rot="R180"/>
+<text x="-1.524" y="0.889" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.651" y="-1.27" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="1X03_SMD_RA_MALE">
+<description>&lt;h3&gt;SMD- 3 Pin Right Angle Male Headers&lt;/h3&gt;
+No silk outline, but tDocu layer shows pin location. 
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:3&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_03&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="3.81" y1="1.25" x2="-3.81" y2="1.25" width="0.1778" layer="51"/>
+<wire x1="-3.81" y1="1.25" x2="-3.81" y2="-1.25" width="0.1778" layer="51"/>
+<wire x1="3.81" y1="-1.25" x2="2.53" y2="-1.25" width="0.1778" layer="51"/>
+<wire x1="2.53" y1="-1.25" x2="-0.01" y2="-1.25" width="0.1778" layer="51"/>
+<wire x1="-0.01" y1="-1.25" x2="-2.55" y2="-1.25" width="0.1778" layer="51"/>
+<wire x1="-2.55" y1="-1.25" x2="-3.81" y2="-1.25" width="0.1778" layer="51"/>
+<wire x1="3.81" y1="-1.25" x2="3.81" y2="1.25" width="0.1778" layer="51"/>
+<wire x1="2.53" y1="-1.25" x2="2.53" y2="-7.25" width="0.127" layer="51"/>
+<wire x1="-0.01" y1="-1.25" x2="-0.01" y2="-7.25" width="0.127" layer="51"/>
+<wire x1="-2.55" y1="-1.25" x2="-2.55" y2="-7.25" width="0.127" layer="51"/>
+<rectangle x1="-0.32" y1="4.15" x2="0.32" y2="5.95" layer="51"/>
+<rectangle x1="-2.86" y1="4.15" x2="-2.22" y2="5.95" layer="51"/>
+<rectangle x1="2.22" y1="4.15" x2="2.86" y2="5.95" layer="51"/>
+<smd name="1" x="-2.54" y="5" dx="3" dy="1" layer="1" rot="R90"/>
+<smd name="2" x="0" y="5" dx="3" dy="1" layer="1" rot="R90"/>
+<smd name="3" x="2.54" y="5" dx="3" dy="1" layer="1" rot="R90"/>
+<text x="-1.524" y="0.254" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.651" y="-0.889" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="1X03_SMD_RA_MALE_POST">
+<description>&lt;h3&gt;SMD - 3 Pin Right Angle Male Header w/ Alignment Posts&lt;/h3&gt;
+&lt;p&gt;&lt;b&gt;Datasheet referenced for footprint:&lt;/b&gt;&lt;a href="http://www.4uconnector.com/online/object/4udrawing/11026.pdf"&gt; 4UCONN part # 11026 &lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:3&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_03&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="3.81" y1="1.25" x2="-3.81" y2="1.25" width="0.1778" layer="51"/>
+<wire x1="-3.81" y1="1.25" x2="-3.81" y2="-1.25" width="0.1778" layer="51"/>
+<wire x1="3.81" y1="-1.25" x2="2.53" y2="-1.25" width="0.1778" layer="51"/>
+<wire x1="2.53" y1="-1.25" x2="-0.01" y2="-1.25" width="0.1778" layer="51"/>
+<wire x1="-0.01" y1="-1.25" x2="-2.55" y2="-1.25" width="0.1778" layer="51"/>
+<wire x1="-2.55" y1="-1.25" x2="-3.81" y2="-1.25" width="0.1778" layer="51"/>
+<wire x1="3.81" y1="-1.25" x2="3.81" y2="1.25" width="0.1778" layer="51"/>
+<wire x1="2.53" y1="-1.25" x2="2.53" y2="-7.25" width="0.127" layer="51"/>
+<wire x1="-0.01" y1="-1.25" x2="-0.01" y2="-7.25" width="0.127" layer="51"/>
+<wire x1="-2.55" y1="-1.25" x2="-2.55" y2="-7.25" width="0.127" layer="51"/>
+<rectangle x1="-0.32" y1="4.15" x2="0.32" y2="5.95" layer="51"/>
+<rectangle x1="-2.86" y1="4.15" x2="-2.22" y2="5.95" layer="51"/>
+<rectangle x1="2.22" y1="4.15" x2="2.86" y2="5.95" layer="51"/>
+<smd name="1" x="-2.54" y="5.07" dx="2.5" dy="1.27" layer="1" rot="R90"/>
+<smd name="2" x="0" y="5.07" dx="2.5" dy="1.27" layer="1" rot="R90"/>
+<smd name="3" x="2.54" y="5.07" dx="2.5" dy="1.27" layer="1" rot="R90"/>
+<hole x="-1.27" y="0" drill="1.6"/>
+<hole x="1.27" y="0" drill="1.6"/>
+<text x="-1.397" y="1.524" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.651" y="-2.286" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="JST-3-PTH-VERT">
+<description>&lt;h3&gt;JST 3 Pin Vertical Plated Through Hole&lt;/h3&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:3&lt;/li&gt;
+&lt;li&gt;Pin pitch:2mm&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;&lt;a href=”https://www.sparkfun.com/datasheets/Prototyping/ePH.pdf”&gt;Datasheet referenced for footprint&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_03&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="-3.95" y1="-2.25" x2="-3.95" y2="2.25" width="0.2032" layer="21"/>
+<wire x1="-3.95" y1="2.25" x2="3.95" y2="2.25" width="0.2032" layer="21"/>
+<wire x1="3.95" y1="2.25" x2="3.95" y2="-2.25" width="0.2032" layer="21"/>
+<wire x1="3.95" y1="-2.25" x2="1" y2="-2.25" width="0.2032" layer="21"/>
+<wire x1="-1" y1="-2.25" x2="-3.95" y2="-2.25" width="0.2032" layer="21"/>
+<wire x1="-1" y1="-1.75" x2="1" y2="-1.75" width="0.2032" layer="21"/>
+<wire x1="1" y1="-1.75" x2="1" y2="-2.25" width="0.2032" layer="21"/>
+<wire x1="-1" y1="-1.75" x2="-1" y2="-2.25" width="0.2032" layer="21"/>
+<pad name="1" x="-2" y="-0.55" drill="0.7" diameter="1.6"/>
+<pad name="2" x="0" y="-0.55" drill="0.7" diameter="1.6"/>
+<pad name="3" x="2" y="-0.55" drill="0.7" diameter="1.6"/>
+<text x="-2.4" y="0.75" size="1.27" layer="51">+</text>
+<text x="-0.4" y="0.75" size="1.27" layer="51">-</text>
+<text x="1.7" y="0.95" size="0.8" layer="51">S</text>
+<text x="-1.397" y="2.54" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.651" y="-3.302" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="1X03_SMD_RA_MALE_POST_SMALLER">
+<description>&lt;h3&gt;SMD - 3 Pin Right Angle Male Header w/ Alignment Posts&lt;/h3&gt;
+&lt;p&gt;&lt;b&gt;Datasheet referenced for footprint:&lt;/b&gt;&lt;a href="http://www.4uconnector.com/online/object/4udrawing/11026.pdf"&gt; 4UCONN part # 11026 &lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:3&lt;/li&gt;
+&lt;li&gt;Pin pitch:0.1"&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_03&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="3.81" y1="1.25" x2="-3.81" y2="1.25" width="0.1778" layer="51"/>
+<wire x1="-3.81" y1="1.25" x2="-3.81" y2="-1.25" width="0.1778" layer="51"/>
+<wire x1="3.81" y1="-1.25" x2="2.53" y2="-1.25" width="0.1778" layer="51"/>
+<wire x1="2.53" y1="-1.25" x2="-0.01" y2="-1.25" width="0.1778" layer="51"/>
+<wire x1="-0.01" y1="-1.25" x2="-2.55" y2="-1.25" width="0.1778" layer="51"/>
+<wire x1="-2.55" y1="-1.25" x2="-3.81" y2="-1.25" width="0.1778" layer="51"/>
+<wire x1="3.81" y1="-1.25" x2="3.81" y2="1.25" width="0.1778" layer="51"/>
+<wire x1="2.53" y1="-1.25" x2="2.53" y2="-7.25" width="0.127" layer="51"/>
+<wire x1="-0.01" y1="-1.25" x2="-0.01" y2="-7.25" width="0.127" layer="51"/>
+<wire x1="-2.55" y1="-1.25" x2="-2.55" y2="-7.25" width="0.127" layer="51"/>
+<rectangle x1="-0.32" y1="4.15" x2="0.32" y2="5.95" layer="51"/>
+<rectangle x1="-2.86" y1="4.15" x2="-2.22" y2="5.95" layer="51"/>
+<rectangle x1="2.22" y1="4.15" x2="2.86" y2="5.95" layer="51"/>
+<smd name="1" x="-2.54" y="5.07" dx="2.5" dy="1.27" layer="1" rot="R90"/>
+<smd name="2" x="0" y="5.07" dx="2.5" dy="1.27" layer="1" rot="R90"/>
+<smd name="3" x="2.54" y="5.07" dx="2.5" dy="1.27" layer="1" rot="R90"/>
+<hole x="-1.27" y="0" drill="1.3589"/>
+<hole x="1.27" y="0" drill="1.3589"/>
+</package>
+<package name="1X03_SMD_RA_MALE_POST_SMALLEST">
+<wire x1="3.81" y1="1.25" x2="-3.81" y2="1.25" width="0.1778" layer="51"/>
+<wire x1="-3.81" y1="1.25" x2="-3.81" y2="-1.25" width="0.1778" layer="51"/>
+<wire x1="3.81" y1="-1.25" x2="2.53" y2="-1.25" width="0.1778" layer="51"/>
+<wire x1="2.53" y1="-1.25" x2="-0.01" y2="-1.25" width="0.1778" layer="51"/>
+<wire x1="-0.01" y1="-1.25" x2="-2.55" y2="-1.25" width="0.1778" layer="51"/>
+<wire x1="-2.55" y1="-1.25" x2="-3.81" y2="-1.25" width="0.1778" layer="51"/>
+<wire x1="3.81" y1="-1.25" x2="3.81" y2="1.25" width="0.1778" layer="51"/>
+<wire x1="2.53" y1="-1.25" x2="2.53" y2="-7.25" width="0.127" layer="51"/>
+<wire x1="-0.01" y1="-1.25" x2="-0.01" y2="-7.25" width="0.127" layer="51"/>
+<wire x1="-2.55" y1="-1.25" x2="-2.55" y2="-7.25" width="0.127" layer="51"/>
+<rectangle x1="-0.32" y1="4.15" x2="0.32" y2="5.95" layer="51"/>
+<rectangle x1="-2.86" y1="4.15" x2="-2.22" y2="5.95" layer="51"/>
+<rectangle x1="2.22" y1="4.15" x2="2.86" y2="5.95" layer="51"/>
+<smd name="1" x="-2.54" y="5.07" dx="2.5" dy="1.27" layer="1" rot="R90"/>
+<smd name="2" x="0" y="5.07" dx="2.5" dy="1.27" layer="1" rot="R90"/>
+<smd name="3" x="2.54" y="5.07" dx="2.5" dy="1.27" layer="1" rot="R90"/>
+<hole x="-1.27" y="0" drill="1.3462"/>
+<hole x="1.27" y="0" drill="1.3462"/>
+</package>
+<package name="JST-3-PTH-NS">
+<description>&lt;h3&gt;JST 3 Pin Right Angle Plated Through Hole &amp;ndash; NO SILK&lt;/h3&gt;
+&lt;p&gt;No silkscreen outline. tDoc layer (51) indicates connector footprint.&lt;/p&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count:3&lt;/li&gt;
+&lt;li&gt;Pin pitch:2mm&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;&lt;a href=”https://www.sparkfun.com/datasheets/Prototyping/ePH.pdf”&gt;Datasheet referenced for footprint&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_03&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="-3.95" y1="-1.6" x2="-3.95" y2="6" width="0.2032" layer="51"/>
+<wire x1="-3.95" y1="6" x2="3.95" y2="6" width="0.2032" layer="51"/>
+<wire x1="3.95" y1="6" x2="3.95" y2="-1.6" width="0.2032" layer="51"/>
+<wire x1="-3.95" y1="-1.6" x2="-3.3" y2="-1.6" width="0.2032" layer="51"/>
+<wire x1="3.95" y1="-1.6" x2="3.3" y2="-1.6" width="0.2032" layer="51"/>
+<wire x1="-3.3" y1="-1.6" x2="-3.3" y2="0" width="0.2032" layer="51"/>
+<wire x1="3.3" y1="-1.6" x2="3.3" y2="0" width="0.2032" layer="51"/>
+<pad name="1" x="-2" y="0" drill="0.7" diameter="1.6"/>
+<pad name="2" x="0" y="0" drill="0.7" diameter="1.6"/>
+<pad name="3" x="2" y="0" drill="0.7" diameter="1.6"/>
+<text x="-2.4" y="0.67" size="1.27" layer="51">+</text>
+<text x="-0.4" y="0.67" size="1.27" layer="51">-</text>
+<text x="1.7" y="0.87" size="0.8" layer="51">S</text>
+<text x="-1.397" y="3.429" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="-1.651" y="2.54" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
+<package name="SCREWTERMINAL-3.5MM-3-NS">
+<description>&lt;h3&gt;Screw Terminal  3.5mm Pitch -3 Pin PTH &amp;ndash; NO SILK&lt;/h3&gt;
+&lt;p&gt;No silkscreen outline. tDoc layer (51) indicates connector footprint.&lt;/p&gt;
+&lt;p&gt;Specifications:
+&lt;ul&gt;&lt;li&gt;Pin count: 3&lt;/li&gt;
+&lt;li&gt;Pin pitch: 3.5mm/138mil&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;&lt;a href=”https://www.sparkfun.com/datasheets/Prototyping/Screw-Terminal-3.5mm.pdf”&gt;Datasheet referenced for footprint&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;Example device(s):
+&lt;ul&gt;&lt;li&gt;CONN_03&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<wire x1="-1.75" y1="3.4" x2="8.75" y2="3.4" width="0.2032" layer="51"/>
+<wire x1="8.75" y1="3.4" x2="8.75" y2="-2.8" width="0.2032" layer="51"/>
+<wire x1="8.75" y1="-2.8" x2="8.75" y2="-3.6" width="0.2032" layer="51"/>
+<wire x1="8.75" y1="-3.6" x2="-1.75" y2="-3.6" width="0.2032" layer="51"/>
+<wire x1="-1.75" y1="-3.6" x2="-1.75" y2="-2.8" width="0.2032" layer="51"/>
+<wire x1="-1.75" y1="-2.8" x2="-1.75" y2="3.4" width="0.2032" layer="51"/>
+<wire x1="8.75" y1="-2.8" x2="-1.75" y2="-2.8" width="0.2032" layer="51"/>
+<wire x1="-1.75" y1="-1.35" x2="-2.25" y2="-1.35" width="0.2032" layer="51"/>
+<wire x1="-2.25" y1="-1.35" x2="-2.25" y2="-2.35" width="0.2032" layer="51"/>
+<wire x1="-2.25" y1="-2.35" x2="-1.75" y2="-2.35" width="0.2032" layer="51"/>
+<wire x1="8.75" y1="3.15" x2="9.25" y2="3.15" width="0.2032" layer="51"/>
+<wire x1="9.25" y1="3.15" x2="9.25" y2="2.15" width="0.2032" layer="51"/>
+<wire x1="9.25" y1="2.15" x2="8.75" y2="2.15" width="0.2032" layer="51"/>
+<pad name="1" x="0" y="0" drill="1.2" diameter="2.413"/>
+<pad name="2" x="3.5" y="0" drill="1.2" diameter="2.413"/>
+<pad name="3" x="7" y="0" drill="1.2" diameter="2.413"/>
+<text x="2.159" y="3.683" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
+<text x="2.032" y="-4.572" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
+</package>
 </packages>
 <symbols>
 <symbol name="CONN_10">
@@ -19984,53 +21213,6 @@ Holes are offset from center 0.005", to hold pins in place while soldering.
 <text x="-2.54" y="-4.826" size="1.778" layer="96" font="vector">&gt;VALUE</text>
 <text x="-2.54" y="3.048" size="1.778" layer="95" font="vector">&gt;NAME</text>
 <pin name="1" x="7.62" y="0" visible="off" length="middle" direction="pas" swaplevel="1" rot="R180"/>
-</symbol>
-<symbol name="CONN_19">
-<description>&lt;h3&gt; 19 Pin Connection&lt;/h3&gt;</description>
-<wire x1="6.35" y1="-25.4" x2="0" y2="-25.4" width="0.4064" layer="94"/>
-<wire x1="3.81" y1="-17.78" x2="5.08" y2="-17.78" width="0.6096" layer="94"/>
-<wire x1="3.81" y1="-20.32" x2="5.08" y2="-20.32" width="0.6096" layer="94"/>
-<wire x1="3.81" y1="-22.86" x2="5.08" y2="-22.86" width="0.6096" layer="94"/>
-<wire x1="3.81" y1="-12.7" x2="5.08" y2="-12.7" width="0.6096" layer="94"/>
-<wire x1="3.81" y1="-15.24" x2="5.08" y2="-15.24" width="0.6096" layer="94"/>
-<wire x1="3.81" y1="-10.16" x2="5.08" y2="-10.16" width="0.6096" layer="94"/>
-<wire x1="3.81" y1="-7.62" x2="5.08" y2="-7.62" width="0.6096" layer="94"/>
-<wire x1="3.81" y1="-5.08" x2="5.08" y2="-5.08" width="0.6096" layer="94"/>
-<wire x1="3.81" y1="-2.54" x2="5.08" y2="-2.54" width="0.6096" layer="94"/>
-<wire x1="3.81" y1="0" x2="5.08" y2="0" width="0.6096" layer="94"/>
-<wire x1="3.81" y1="7.62" x2="5.08" y2="7.62" width="0.6096" layer="94"/>
-<wire x1="3.81" y1="5.08" x2="5.08" y2="5.08" width="0.6096" layer="94"/>
-<wire x1="3.81" y1="2.54" x2="5.08" y2="2.54" width="0.6096" layer="94"/>
-<wire x1="0" y1="25.4" x2="0" y2="-25.4" width="0.4064" layer="94"/>
-<wire x1="6.35" y1="-25.4" x2="6.35" y2="25.4" width="0.4064" layer="94"/>
-<wire x1="0" y1="25.4" x2="6.35" y2="25.4" width="0.4064" layer="94"/>
-<wire x1="3.81" y1="12.7" x2="5.08" y2="12.7" width="0.6096" layer="94"/>
-<wire x1="3.81" y1="10.16" x2="5.08" y2="10.16" width="0.6096" layer="94"/>
-<wire x1="3.81" y1="15.24" x2="5.08" y2="15.24" width="0.6096" layer="94"/>
-<wire x1="3.81" y1="17.78" x2="5.08" y2="17.78" width="0.6096" layer="94"/>
-<wire x1="3.81" y1="20.32" x2="5.08" y2="20.32" width="0.6096" layer="94"/>
-<wire x1="3.81" y1="22.86" x2="5.08" y2="22.86" width="0.6096" layer="94"/>
-<text x="0" y="-27.686" size="1.778" layer="96" font="vector">&gt;VALUE</text>
-<text x="0" y="25.908" size="1.778" layer="95" font="vector">&gt;NAME</text>
-<pin name="1" x="10.16" y="-22.86" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
-<pin name="2" x="10.16" y="-20.32" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
-<pin name="3" x="10.16" y="-17.78" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
-<pin name="4" x="10.16" y="-15.24" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
-<pin name="5" x="10.16" y="-12.7" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
-<pin name="6" x="10.16" y="-10.16" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
-<pin name="7" x="10.16" y="-7.62" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
-<pin name="8" x="10.16" y="-5.08" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
-<pin name="9" x="10.16" y="-2.54" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
-<pin name="10" x="10.16" y="0" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
-<pin name="11" x="10.16" y="2.54" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
-<pin name="12" x="10.16" y="5.08" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
-<pin name="13" x="10.16" y="7.62" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
-<pin name="14" x="10.16" y="10.16" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
-<pin name="15" x="10.16" y="12.7" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
-<pin name="16" x="10.16" y="15.24" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
-<pin name="17" x="10.16" y="17.78" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
-<pin name="18" x="10.16" y="20.32" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
-<pin name="19" x="10.16" y="22.86" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
 </symbol>
 <symbol name="CONN_06">
 <description>&lt;h3&gt;6 Pin Connection&lt;/h3&gt;</description>
@@ -20099,6 +21281,61 @@ Holes are offset from center 0.005", to hold pins in place while soldering.
 <pin name="4" x="10.16" y="0" visible="pad" direction="pas" function="dot" rot="R180"/>
 <pin name="5" x="-7.62" y="-2.54" visible="pad" direction="pas" function="dot"/>
 <pin name="6" x="10.16" y="-2.54" visible="pad" direction="pas" function="dot" rot="R180"/>
+</symbol>
+<symbol name="CONN_07">
+<description>&lt;h3&gt; 7 Pin Connection&lt;/h3&gt;</description>
+<wire x1="1.27" y1="-7.62" x2="-5.08" y2="-7.62" width="0.4064" layer="94"/>
+<wire x1="-1.27" y1="0" x2="0" y2="0" width="0.6096" layer="94"/>
+<wire x1="-1.27" y1="-2.54" x2="0" y2="-2.54" width="0.6096" layer="94"/>
+<wire x1="-1.27" y1="-5.08" x2="0" y2="-5.08" width="0.6096" layer="94"/>
+<wire x1="-5.08" y1="12.7" x2="-5.08" y2="-7.62" width="0.4064" layer="94"/>
+<wire x1="1.27" y1="-7.62" x2="1.27" y2="12.7" width="0.4064" layer="94"/>
+<wire x1="-5.08" y1="12.7" x2="1.27" y2="12.7" width="0.4064" layer="94"/>
+<wire x1="-1.27" y1="5.08" x2="0" y2="5.08" width="0.6096" layer="94"/>
+<wire x1="-1.27" y1="2.54" x2="0" y2="2.54" width="0.6096" layer="94"/>
+<wire x1="-1.27" y1="7.62" x2="0" y2="7.62" width="0.6096" layer="94"/>
+<wire x1="-1.27" y1="10.16" x2="0" y2="10.16" width="0.6096" layer="94"/>
+<text x="-5.08" y="-9.906" size="1.778" layer="96" font="vector">&gt;VALUE</text>
+<text x="-5.08" y="13.208" size="1.778" layer="95" font="vector">&gt;NAME</text>
+<pin name="1" x="5.08" y="-5.08" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
+<pin name="2" x="5.08" y="-2.54" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
+<pin name="3" x="5.08" y="0" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
+<pin name="4" x="5.08" y="2.54" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
+<pin name="5" x="5.08" y="5.08" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
+<pin name="6" x="5.08" y="7.62" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
+<pin name="7" x="5.08" y="10.16" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
+</symbol>
+<symbol name="CONN_04">
+<description>&lt;h3&gt;4 Pin Connection&lt;/h3&gt;</description>
+<wire x1="1.27" y1="-5.08" x2="-5.08" y2="-5.08" width="0.4064" layer="94"/>
+<wire x1="-1.27" y1="2.54" x2="0" y2="2.54" width="0.6096" layer="94"/>
+<wire x1="-1.27" y1="0" x2="0" y2="0" width="0.6096" layer="94"/>
+<wire x1="-1.27" y1="-2.54" x2="0" y2="-2.54" width="0.6096" layer="94"/>
+<wire x1="-5.08" y1="7.62" x2="-5.08" y2="-5.08" width="0.4064" layer="94"/>
+<wire x1="1.27" y1="-5.08" x2="1.27" y2="7.62" width="0.4064" layer="94"/>
+<wire x1="-5.08" y1="7.62" x2="1.27" y2="7.62" width="0.4064" layer="94"/>
+<wire x1="-1.27" y1="5.08" x2="0" y2="5.08" width="0.6096" layer="94"/>
+<text x="-5.08" y="-7.366" size="1.778" layer="96" font="vector">&gt;VALUE</text>
+<text x="-5.08" y="8.128" size="1.778" layer="95" font="vector">&gt;NAME</text>
+<pin name="1" x="5.08" y="-2.54" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
+<pin name="2" x="5.08" y="0" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
+<pin name="3" x="5.08" y="2.54" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
+<pin name="4" x="5.08" y="5.08" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
+</symbol>
+<symbol name="CONN_03">
+<description>&lt;h3&gt;3 Pin Connection&lt;/h3&gt;</description>
+<wire x1="3.81" y1="-5.08" x2="-2.54" y2="-5.08" width="0.4064" layer="94"/>
+<wire x1="1.27" y1="2.54" x2="2.54" y2="2.54" width="0.6096" layer="94"/>
+<wire x1="1.27" y1="0" x2="2.54" y2="0" width="0.6096" layer="94"/>
+<wire x1="1.27" y1="-2.54" x2="2.54" y2="-2.54" width="0.6096" layer="94"/>
+<wire x1="-2.54" y1="5.08" x2="-2.54" y2="-5.08" width="0.4064" layer="94"/>
+<wire x1="3.81" y1="-5.08" x2="3.81" y2="5.08" width="0.4064" layer="94"/>
+<wire x1="-2.54" y1="5.08" x2="3.81" y2="5.08" width="0.4064" layer="94"/>
+<text x="-2.54" y="-7.366" size="1.778" layer="96" font="vector">&gt;VALUE</text>
+<text x="-2.54" y="5.588" size="1.778" layer="95" font="vector">&gt;NAME</text>
+<pin name="1" x="7.62" y="-2.54" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
+<pin name="2" x="7.62" y="0" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
+<pin name="3" x="7.62" y="2.54" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
 </symbol>
 </symbols>
 <devicesets>
@@ -20447,98 +21684,6 @@ Also note, the SNAP packages are for using a snappable style connector. We sell 
 <technology name="">
 <attribute name="PROD_ID" value="HW-08694" constant="no"/>
 </technology>
-</technologies>
-</device>
-</devices>
-</deviceset>
-<deviceset name="CONN_19" prefix="J" uservalue="yes">
-<description>&lt;h3&gt;Multi connection point. Often used as Generic Header-pin footprint for 0.1 inch spaced/style header connections&lt;/h3&gt;
-
-&lt;p&gt;&lt;/p&gt;
-&lt;b&gt;On any of the 0.1 inch spaced packages, you can populate with these:&lt;/b&gt;
-&lt;ul&gt;
-&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/116"&gt; Break Away Headers - Straight&lt;/a&gt; (PRT-00116)&lt;/li&gt;
-&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/553"&gt; Break Away Male Headers - Right Angle&lt;/a&gt; (PRT-00553)&lt;/li&gt;
-&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/115"&gt; Female Headers&lt;/a&gt; (PRT-00115)&lt;/li&gt;
-&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/117"&gt; Break Away Headers - Machine Pin&lt;/a&gt; (PRT-00117)&lt;/li&gt;
-&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/743"&gt; Break Away Female Headers - Swiss Machine Pin&lt;/a&gt; (PRT-00743)&lt;/li&gt;
-&lt;/ul&gt;
-
-&lt;p&gt;&lt;/p&gt;
-&lt;b&gt; For SCREWTERMINALS and SPRING TERMINALS visit here:&lt;/b&gt;
-&lt;ul&gt;
-&lt;li&gt;&lt;a href="https://www.sparkfun.com/search/results?term=Screw+Terminals"&gt; Screw Terimnals on SparkFun.com&lt;/a&gt; (5mm/3.5mm/2.54mm spacing)&lt;/li&gt;
-&lt;/ul&gt;
-
-&lt;p&gt;&lt;/p&gt;
-&lt;b&gt;This device is also useful as a general connection point to wire up your design to another part of your project. Our various solder wires solder well into these plated through hole pads.&lt;/b&gt;
-&lt;ul&gt;
-&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/11375"&gt; Hook-Up Wire - Assortment (Stranded, 22 AWG)&lt;/a&gt; (PRT-11375)&lt;/li&gt;
-&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/11367"&gt; Hook-Up Wire - Assortment (Solid Core, 22 AWG)&lt;/a&gt; (PRT-11367)&lt;/li&gt;
-&lt;li&gt;&lt;a href="https://www.sparkfun.com/categories/141"&gt; View the entire wire category on our website here&lt;/a&gt;&lt;/li&gt;
-&lt;p&gt;&lt;/p&gt;
-&lt;/ul&gt;
-
-&lt;p&gt;&lt;/p&gt;
-&lt;b&gt;Special notes:&lt;/b&gt;
-&lt;p&gt; &lt;/p&gt; Molex polarized connector foot print use with SKU : PRT-08231 with associated crimp pins and housings. 1MM SMD Version SKU: PRT-10208
-&lt;p&gt;&lt;/p&gt;
-NOTES ON THE VARIANTS LOCK and LOCK_LONGPADS...
-This footprint was designed to help hold the alignment of a through-hole component (i.e.  6-pin header) while soldering it into place. You may notice that each hole has been shifted either up or down by 0.005 of an inch from it's more standard position (which is a perfectly straight line).  This slight alteration caused the pins (the squares in the middle) to touch the edges of the holes.  Because they are alternating, it causes a "brace" to hold the component in place.  0.005 has proven to be the perfect amount of "off-center" position when using our standard breakaway headers. Although looks a little odd when you look at the bare footprint, once you have a header in there, the alteration is very hard to notice.  Also,if you push a header all the way into place, it is covered up entirely on the bottom side.</description>
-<gates>
-<gate name="G$1" symbol="CONN_19" x="0" y="0"/>
-</gates>
-<devices>
-<device name="" package="1X19">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="10" pad="10"/>
-<connect gate="G$1" pin="11" pad="11"/>
-<connect gate="G$1" pin="12" pad="12"/>
-<connect gate="G$1" pin="13" pad="13"/>
-<connect gate="G$1" pin="14" pad="14"/>
-<connect gate="G$1" pin="15" pad="15"/>
-<connect gate="G$1" pin="16" pad="16"/>
-<connect gate="G$1" pin="17" pad="17"/>
-<connect gate="G$1" pin="18" pad="18"/>
-<connect gate="G$1" pin="19" pad="19"/>
-<connect gate="G$1" pin="2" pad="2"/>
-<connect gate="G$1" pin="3" pad="3"/>
-<connect gate="G$1" pin="4" pad="4"/>
-<connect gate="G$1" pin="5" pad="5"/>
-<connect gate="G$1" pin="6" pad="6"/>
-<connect gate="G$1" pin="7" pad="7"/>
-<connect gate="G$1" pin="8" pad="8"/>
-<connect gate="G$1" pin="9" pad="9"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="1X19_NO_SILK" package="1X19_NO_SILK">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="10" pad="10"/>
-<connect gate="G$1" pin="11" pad="11"/>
-<connect gate="G$1" pin="12" pad="12"/>
-<connect gate="G$1" pin="13" pad="13"/>
-<connect gate="G$1" pin="14" pad="14"/>
-<connect gate="G$1" pin="15" pad="15"/>
-<connect gate="G$1" pin="16" pad="16"/>
-<connect gate="G$1" pin="17" pad="17"/>
-<connect gate="G$1" pin="18" pad="18"/>
-<connect gate="G$1" pin="19" pad="19"/>
-<connect gate="G$1" pin="2" pad="2"/>
-<connect gate="G$1" pin="3" pad="3"/>
-<connect gate="G$1" pin="4" pad="4"/>
-<connect gate="G$1" pin="5" pad="5"/>
-<connect gate="G$1" pin="6" pad="6"/>
-<connect gate="G$1" pin="7" pad="7"/>
-<connect gate="G$1" pin="8" pad="8"/>
-<connect gate="G$1" pin="9" pad="9"/>
-</connects>
-<technologies>
-<technology name=""/>
 </technologies>
 </device>
 </devices>
@@ -21203,6 +22348,694 @@ This footprint was designed to help hold the alignment of a through-hole compone
 <connect gate="G$1" pin="4" pad="4"/>
 <connect gate="G$1" pin="5" pad="5"/>
 <connect gate="G$1" pin="6" pad="6"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="CONN_07" prefix="J" uservalue="yes">
+<description>&lt;h3&gt;Multi connection point. Often used as Generic Header-pin footprint for 0.1 inch spaced/style header connections&lt;/h3&gt;
+
+&lt;p&gt;&lt;/p&gt;
+&lt;b&gt;On any of the 0.1 inch spaced packages, you can populate with these:&lt;/b&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/116"&gt; Break Away Headers - Straight&lt;/a&gt; (PRT-00116)&lt;/li&gt;
+&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/553"&gt; Break Away Male Headers - Right Angle&lt;/a&gt; (PRT-00553)&lt;/li&gt;
+&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/115"&gt; Female Headers&lt;/a&gt; (PRT-00115)&lt;/li&gt;
+&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/117"&gt; Break Away Headers - Machine Pin&lt;/a&gt; (PRT-00117)&lt;/li&gt;
+&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/743"&gt; Break Away Female Headers - Swiss Machine Pin&lt;/a&gt; (PRT-00743)&lt;/li&gt;
+&lt;/ul&gt;
+
+&lt;p&gt;&lt;/p&gt;
+&lt;b&gt; For SCREWTERMINALS and SPRING TERMINALS visit here:&lt;/b&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;a href="https://www.sparkfun.com/search/results?term=Screw+Terminals"&gt; Screw Terimnals on SparkFun.com&lt;/a&gt; (5mm/3.5mm/2.54mm spacing)&lt;/li&gt;
+&lt;/ul&gt;
+
+&lt;p&gt;&lt;/p&gt;
+&lt;b&gt;This device is also useful as a general connection point to wire up your design to another part of your project. Our various solder wires solder well into these plated through hole pads.&lt;/b&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/11375"&gt; Hook-Up Wire - Assortment (Stranded, 22 AWG)&lt;/a&gt; (PRT-11375)&lt;/li&gt;
+&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/11367"&gt; Hook-Up Wire - Assortment (Solid Core, 22 AWG)&lt;/a&gt; (PRT-11367)&lt;/li&gt;
+&lt;li&gt;&lt;a href="https://www.sparkfun.com/categories/141"&gt; View the entire wire category on our website here&lt;/a&gt;&lt;/li&gt;
+&lt;p&gt;&lt;/p&gt;
+&lt;/ul&gt;
+
+&lt;p&gt;&lt;/p&gt;
+&lt;b&gt;Special notes:&lt;/b&gt;
+&lt;p&gt; &lt;/p&gt; Molex polarized connector foot print use with SKU : PRT-08231 with associated crimp pins and housings. 1MM SMD Version SKU: PRT-10208
+&lt;p&gt;&lt;/p&gt;
+NOTES ON THE VARIANTS LOCK and LOCK_LONGPADS...
+This footprint was designed to help hold the alignment of a through-hole component (i.e.  6-pin header) while soldering it into place. You may notice that each hole has been shifted either up or down by 0.005 of an inch from it's more standard position (which is a perfectly straight line).  This slight alteration caused the pins (the squares in the middle) to touch the edges of the holes.  Because they are alternating, it causes a "brace" to hold the component in place.  0.005 has proven to be the perfect amount of "off-center" position when using our standard breakaway headers. Although looks a little odd when you look at the bare footprint, once you have a header in there, the alteration is very hard to notice.  Also,if you push a header all the way into place, it is covered up entirely on the bottom side.</description>
+<gates>
+<gate name="G$1" symbol="CONN_07" x="-2.54" y="0"/>
+</gates>
+<devices>
+<device name="" package="1X07">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="3" pad="3"/>
+<connect gate="G$1" pin="4" pad="4"/>
+<connect gate="G$1" pin="5" pad="5"/>
+<connect gate="G$1" pin="6" pad="6"/>
+<connect gate="G$1" pin="7" pad="7"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="LOCK" package="1X07_LOCK">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="3" pad="3"/>
+<connect gate="G$1" pin="4" pad="4"/>
+<connect gate="G$1" pin="5" pad="5"/>
+<connect gate="G$1" pin="6" pad="6"/>
+<connect gate="G$1" pin="7" pad="7"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="LOCK_LONGPADS" package="1X07_LOCK_LONGPADS">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="3" pad="3"/>
+<connect gate="G$1" pin="4" pad="4"/>
+<connect gate="G$1" pin="5" pad="5"/>
+<connect gate="G$1" pin="6" pad="6"/>
+<connect gate="G$1" pin="7" pad="7"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="LONGPADS" package="1X07_LONGPADS">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="3" pad="3"/>
+<connect gate="G$1" pin="4" pad="4"/>
+<connect gate="G$1" pin="5" pad="5"/>
+<connect gate="G$1" pin="6" pad="6"/>
+<connect gate="G$1" pin="7" pad="7"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="POGOPINS_HOLES_ONLY" package="1X07_HOLES_ONLY">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="3" pad="3"/>
+<connect gate="G$1" pin="4" pad="4"/>
+<connect gate="G$1" pin="5" pad="5"/>
+<connect gate="G$1" pin="6" pad="6"/>
+<connect gate="G$1" pin="7" pad="7"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="NO_SILK" package="1X07_NO_SILK">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="3" pad="3"/>
+<connect gate="G$1" pin="4" pad="4"/>
+<connect gate="G$1" pin="5" pad="5"/>
+<connect gate="G$1" pin="6" pad="6"/>
+<connect gate="G$1" pin="7" pad="7"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="CONN_04" prefix="J" uservalue="yes">
+<description>&lt;h3&gt;Multi connection point. Often used as Generic Header-pin footprint for 0.1 inch spaced/style header connections&lt;/h3&gt;
+
+&lt;p&gt;&lt;/p&gt;
+&lt;b&gt;On any of the 0.1 inch spaced packages, you can populate with these:&lt;/b&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/116"&gt; Break Away Headers - Straight&lt;/a&gt; (PRT-00116)&lt;/li&gt;
+&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/553"&gt; Break Away Male Headers - Right Angle&lt;/a&gt; (PRT-00553)&lt;/li&gt;
+&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/115"&gt; Female Headers&lt;/a&gt; (PRT-00115)&lt;/li&gt;
+&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/117"&gt; Break Away Headers - Machine Pin&lt;/a&gt; (PRT-00117)&lt;/li&gt;
+&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/743"&gt; Break Away Female Headers - Swiss Machine Pin&lt;/a&gt; (PRT-00743)&lt;/li&gt;
+&lt;/ul&gt;
+
+&lt;p&gt;&lt;/p&gt;
+&lt;b&gt; For SCREWTERMINALS and SPRING TERMINALS visit here:&lt;/b&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;a href="https://www.sparkfun.com/search/results?term=Screw+Terminals"&gt; Screw Terimnals on SparkFun.com&lt;/a&gt; (5mm/3.5mm/2.54mm spacing)&lt;/li&gt;
+&lt;/ul&gt;
+
+&lt;p&gt;&lt;/p&gt;
+&lt;b&gt;This device is also useful as a general connection point to wire up your design to another part of your project. Our various solder wires solder well into these plated through hole pads.&lt;/b&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/11375"&gt; Hook-Up Wire - Assortment (Stranded, 22 AWG)&lt;/a&gt; (PRT-11375)&lt;/li&gt;
+&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/11367"&gt; Hook-Up Wire - Assortment (Solid Core, 22 AWG)&lt;/a&gt; (PRT-11367)&lt;/li&gt;
+&lt;li&gt;&lt;a href="https://www.sparkfun.com/categories/141"&gt; View the entire wire category on our website here&lt;/a&gt;&lt;/li&gt;
+&lt;p&gt;&lt;/p&gt;
+&lt;/ul&gt;
+
+&lt;p&gt;&lt;/p&gt;
+&lt;b&gt;Special notes:&lt;/b&gt;
+&lt;p&gt; &lt;/p&gt; Molex polarized connector foot print use with SKU : PRT-08231 with associated crimp pins and housings. 1MM SMD Version SKU: PRT-10208</description>
+<gates>
+<gate name="G$1" symbol="CONN_04" x="-2.54" y="0"/>
+</gates>
+<devices>
+<device name="" package="1X04">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="3" pad="3"/>
+<connect gate="G$1" pin="4" pad="4"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="CONN-09696" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="POLAR" package="MOLEX-1X4">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="3" pad="3"/>
+<connect gate="G$1" pin="4" pad="4"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="CONN-08186" constant="no"/>
+<attribute name="SF_ID" value="PRT-08231" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="SCREW" package="SCREWTERMINAL-3.5MM-4">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="3" pad="3"/>
+<connect gate="G$1" pin="4" pad="4"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="2xCONN-08399" constant="no"/>
+<attribute name="SF_ID" value="2xPRT-08084" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="1.27MM" package="1X04_1.27MM">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="3" pad="3"/>
+<connect gate="G$1" pin="4" pad="4"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="LOCK" package="1X04_LOCK">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="3" pad="3"/>
+<connect gate="G$1" pin="4" pad="4"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="CONN-09696" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="LOCK_LONGPADS" package="1X04_LOCK_LONGPADS">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="3" pad="3"/>
+<connect gate="G$1" pin="4" pad="4"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="CONN-09696" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="POLAR_LOCK" package="MOLEX-1X4_LOCK">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="3" pad="3"/>
+<connect gate="G$1" pin="4" pad="4"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="CONN-08186" constant="no"/>
+<attribute name="SF_ID" value="PRT-08231" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="SMD" package="1X04_SMD_RA_MALE">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="3" pad="3"/>
+<connect gate="G$1" pin="4" pad="4"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="CONN-09140" constant="no"/>
+<attribute name="SF_ID" value="PRT-12638" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="LONGPADS" package="1X04_LONGPADS">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="3" pad="3"/>
+<connect gate="G$1" pin="4" pad="4"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="CONN-09696" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="1X04_NO_SILK" package="1X04_NO_SILK">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="3" pad="3"/>
+<connect gate="G$1" pin="4" pad="4"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="CONN-09696" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="JST-PTH" package="JST-4-PTH">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="3" pad="3"/>
+<connect gate="G$1" pin="4" pad="4"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="WIRE-13531" constant="no"/>
+<attribute name="SF_ID" value="PRT-09916" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="SCREW_LOCK" package="SCREWTERMINAL-3.5MM-4_LOCK">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="3" pad="3"/>
+<connect gate="G$1" pin="4" pad="4"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="SMD2" package="1X04_1MM_RA">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="3" pad="3"/>
+<connect gate="G$1" pin="4" pad="4"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="CONN-10310" constant="no"/>
+<attribute name="SF_ID" value="PRT-10208" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="SMD_STRAIGHT_COMBO" package="1X04_SMD_VERTICAL_COMBO">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="3" pad="3"/>
+<connect gate="G$1" pin="4" pad="4"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="CONN-08511"/>
+<attribute name="VALUE" value="1X04_SMD_STRAIGHT_COMBO"/>
+</technology>
+</technologies>
+</device>
+<device name="SMD_LONG" package="1X04_SMD_LONG">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="3" pad="3"/>
+<connect gate="G$1" pin="4" pad="4"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="CONN-09140" constant="no"/>
+<attribute name="SF_ID" value="PRT-12638" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="JST-PTH-VERT" package="JST-4-PTH-VERT">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="3" pad="3"/>
+<connect gate="G$1" pin="4" pad="4"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="CONN-13251"/>
+</technology>
+</technologies>
+</device>
+<device name="SMD_RA_FEMALE" package="1X04_SMD_RA_FEMALE">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="3" pad="3"/>
+<connect gate="G$1" pin="4" pad="4"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="CONN-12382" constant="no"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="CONN_03" prefix="J" uservalue="yes">
+<description>&lt;h3&gt;Multi connection point. Often used as Generic Header-pin footprint for 0.1 inch spaced/style header connections&lt;/h3&gt;
+
+&lt;p&gt;&lt;/p&gt;
+&lt;b&gt;On any of the 0.1 inch spaced packages, you can populate with these:&lt;/b&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/116"&gt; Break Away Headers - Straight&lt;/a&gt; (PRT-00116)&lt;/li&gt;
+&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/553"&gt; Break Away Male Headers - Right Angle&lt;/a&gt; (PRT-00553)&lt;/li&gt;
+&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/115"&gt; Female Headers&lt;/a&gt; (PRT-00115)&lt;/li&gt;
+&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/117"&gt; Break Away Headers - Machine Pin&lt;/a&gt; (PRT-00117)&lt;/li&gt;
+&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/743"&gt; Break Away Female Headers - Swiss Machine Pin&lt;/a&gt; (PRT-00743)&lt;/li&gt;
+&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/13875"&gt; Stackable Header - 3 Pin (Female, 0.1")&lt;/a&gt; (PRT-13875)&lt;/li&gt;
+&lt;/ul&gt;
+
+&lt;p&gt;&lt;/p&gt;
+&lt;b&gt; For SCREWTERMINALS and SPRING TERMINALS visit here:&lt;/b&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;a href="https://www.sparkfun.com/search/results?term=Screw+Terminals"&gt; Screw Terimnals on SparkFun.com&lt;/a&gt; (5mm/3.5mm/2.54mm spacing)&lt;/li&gt;
+&lt;/ul&gt;
+
+&lt;p&gt;&lt;/p&gt;
+&lt;b&gt;This device is also useful as a general connection point to wire up your design to another part of your project. Our various solder wires solder well into these plated through hole pads.&lt;/b&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/11375"&gt; Hook-Up Wire - Assortment (Stranded, 22 AWG)&lt;/a&gt; (PRT-11375)&lt;/li&gt;
+&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/11367"&gt; Hook-Up Wire - Assortment (Solid Core, 22 AWG)&lt;/a&gt; (PRT-11367)&lt;/li&gt;
+&lt;li&gt;&lt;a href="https://www.sparkfun.com/categories/141"&gt; View the entire wire category on our website here&lt;/a&gt;&lt;/li&gt;
+&lt;p&gt;&lt;/p&gt;
+&lt;/ul&gt;
+
+&lt;p&gt;&lt;/p&gt;
+&lt;b&gt;Special notes:&lt;/b&gt;
+&lt;p&gt; &lt;/p&gt;
+&lt;p&gt; &lt;/p&gt; Molex polarized connector foot print use with SKU : PRT-08232 with associated crimp pins and housings.</description>
+<gates>
+<gate name="J$1" symbol="CONN_03" x="-2.54" y="0"/>
+</gates>
+<devices>
+<device name="" package="1X03">
+<connects>
+<connect gate="J$1" pin="1" pad="1"/>
+<connect gate="J$1" pin="2" pad="2"/>
+<connect gate="J$1" pin="3" pad="3"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="XXX-00000" constant="no"/>
+<attribute name="VALUE" value="455-1750-1-ND" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="POLAR" package="MOLEX-1X3">
+<connects>
+<connect gate="J$1" pin="1" pad="1"/>
+<connect gate="J$1" pin="2" pad="2"/>
+<connect gate="J$1" pin="3" pad="3"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="CONN-08625" constant="no"/>
+<attribute name="SF_ID" value="PRT-08096" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="SCREW" package="SCREWTERMINAL-3.5MM-3">
+<connects>
+<connect gate="J$1" pin="1" pad="1"/>
+<connect gate="J$1" pin="2" pad="2"/>
+<connect gate="J$1" pin="3" pad="3"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="CONN-08288" constant="no"/>
+<attribute name="SF_ID" value="PRT-08235" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="LOCK" package="1X03_LOCK">
+<connects>
+<connect gate="J$1" pin="1" pad="1"/>
+<connect gate="J$1" pin="2" pad="2"/>
+<connect gate="J$1" pin="3" pad="3"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="LOCK_LONGPADS" package="1X03_LOCK_LONGPADS">
+<connects>
+<connect gate="J$1" pin="1" pad="1"/>
+<connect gate="J$1" pin="2" pad="2"/>
+<connect gate="J$1" pin="3" pad="3"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="POLAR_LOCK" package="MOLEX-1X3_LOCK">
+<connects>
+<connect gate="J$1" pin="1" pad="1"/>
+<connect gate="J$1" pin="2" pad="2"/>
+<connect gate="J$1" pin="3" pad="3"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="CONN-08625" constant="no"/>
+<attribute name="SF_ID" value="PRT-08096" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="SCREW_LOCK" package="SCREWTERMINAL-3.5MM-3_LOCK.007S">
+<connects>
+<connect gate="J$1" pin="1" pad="1"/>
+<connect gate="J$1" pin="2" pad="2"/>
+<connect gate="J$1" pin="3" pad="3"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="CONN-08288" constant="no"/>
+<attribute name="SF_ID" value="PRT-08235" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="1X03_NO_SILK" package="1X03_NO_SILK">
+<connects>
+<connect gate="J$1" pin="1" pad="1"/>
+<connect gate="J$1" pin="2" pad="2"/>
+<connect gate="J$1" pin="3" pad="3"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="LONGPADS" package="1X03_LONGPADS">
+<connects>
+<connect gate="J$1" pin="1" pad="1"/>
+<connect gate="J$1" pin="2" pad="2"/>
+<connect gate="J$1" pin="3" pad="3"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="JST-PTH" package="JST-3-PTH">
+<connects>
+<connect gate="J$1" pin="1" pad="1"/>
+<connect gate="J$1" pin="2" pad="2"/>
+<connect gate="J$1" pin="3" pad="3"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="WIRE-10037" constant="no"/>
+<attribute name="SF_ID" value="PRT-09915" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="POGO_PIN_HOLES_ONLY" package="1X03_PP_HOLES_ONLY">
+<connects>
+<connect gate="J$1" pin="1" pad="1"/>
+<connect gate="J$1" pin="2" pad="2"/>
+<connect gate="J$1" pin="3" pad="3"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="-SCREW-5MM" package="SCREWTERMINAL-5MM-3">
+<connects>
+<connect gate="J$1" pin="1" pad="1"/>
+<connect gate="J$1" pin="2" pad="2"/>
+<connect gate="J$1" pin="3" pad="3"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="CONN-10134" constant="no"/>
+<attribute name="SF_SKU" value="PRT-08433" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="LOCK_NO_SILK" package="1X03_LOCK_NO_SILK">
+<connects>
+<connect gate="J$1" pin="1" pad="1"/>
+<connect gate="J$1" pin="2" pad="2"/>
+<connect gate="J$1" pin="3" pad="3"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="JST-SMD" package="JST-3-SMD">
+<connects>
+<connect gate="J$1" pin="1" pad="3"/>
+<connect gate="J$1" pin="2" pad="2"/>
+<connect gate="J$1" pin="3" pad="1"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="CONN-12591" constant="no"/>
+<attribute name="VALUE" value="3-PIN SMD" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="SMD" package="1X03-1MM-RA">
+<connects>
+<connect gate="J$1" pin="1" pad="1"/>
+<connect gate="J$1" pin="2" pad="2"/>
+<connect gate="J$1" pin="3" pad="3"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="SMD_RA_FEMALE" package="1X03_SMD_RA_FEMALE">
+<connects>
+<connect gate="J$1" pin="1" pad="1"/>
+<connect gate="J$1" pin="2" pad="2"/>
+<connect gate="J$1" pin="3" pad="3"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="CONN-10926"/>
+<attribute name="VALUE" value="1x3 RA Female .1&quot;"/>
+</technology>
+</technologies>
+</device>
+<device name="SMD_RA_MALE" package="1X03_SMD_RA_MALE">
+<connects>
+<connect gate="J$1" pin="1" pad="1"/>
+<connect gate="J$1" pin="2" pad="2"/>
+<connect gate="J$1" pin="3" pad="3"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="CONN-10925"/>
+</technology>
+</technologies>
+</device>
+<device name="SMD_RA_MALE_POST" package="1X03_SMD_RA_MALE_POST">
+<connects>
+<connect gate="J$1" pin="1" pad="1"/>
+<connect gate="J$1" pin="2" pad="2"/>
+<connect gate="J$1" pin="3" pad="3"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="JST-PTH-VERT" package="JST-3-PTH-VERT">
+<connects>
+<connect gate="J$1" pin="1" pad="1"/>
+<connect gate="J$1" pin="2" pad="2"/>
+<connect gate="J$1" pin="3" pad="3"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="CONN-13230" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="1X03_SMD_RA_MALE_POST_SMALLER" package="1X03_SMD_RA_MALE_POST_SMALLER">
+<connects>
+<connect gate="J$1" pin="1" pad="1"/>
+<connect gate="J$1" pin="2" pad="2"/>
+<connect gate="J$1" pin="3" pad="3"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="CONN-11912" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="1X03_SMD_RA_MALE_POST_SMALLEST" package="1X03_SMD_RA_MALE_POST_SMALLEST">
+<connects>
+<connect gate="J$1" pin="1" pad="1"/>
+<connect gate="J$1" pin="2" pad="2"/>
+<connect gate="J$1" pin="3" pad="3"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="JST-PTH-NS" package="JST-3-PTH-NS">
+<connects>
+<connect gate="J$1" pin="1" pad="1"/>
+<connect gate="J$1" pin="2" pad="2"/>
+<connect gate="J$1" pin="3" pad="3"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="SCREW-NS" package="SCREWTERMINAL-3.5MM-3-NS">
+<connects>
+<connect gate="J$1" pin="1" pad="1"/>
+<connect gate="J$1" pin="2" pad="2"/>
+<connect gate="J$1" pin="3" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -22063,6 +23896,13 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <pin name="5V" x="0" y="0" visible="off" length="short" direction="sup" rot="R90"/>
 <text x="0" y="2.794" size="1.778" layer="96" align="bottom-center">&gt;VALUE</text>
 </symbol>
+<symbol name="VCC_2">
+<description>&lt;h3&gt;VCC2 Voltage Supply&lt;/h3&gt;</description>
+<wire x1="0.762" y1="1.27" x2="0" y2="2.54" width="0.254" layer="94"/>
+<wire x1="0" y1="2.54" x2="-0.762" y2="1.27" width="0.254" layer="94"/>
+<pin name="VCC_2" x="0" y="0" visible="off" length="short" direction="sup" rot="R90"/>
+<text x="0" y="2.794" size="1.778" layer="96" align="bottom-center">&gt;VALUE</text>
+</symbol>
 </symbols>
 <devicesets>
 <deviceset name="GND" prefix="GND">
@@ -22084,6 +23924,20 @@ You are welcome to use this library for commercial purposes. For attribution, we
 &lt;p&gt;Power supply symbol for a specifically-stated 5V source.&lt;/p&gt;</description>
 <gates>
 <gate name="G$1" symbol="5V" x="0" y="0"/>
+</gates>
+<devices>
+<device name="">
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="VCC_2" prefix="SUPPLY">
+<description>&lt;h3&gt;VCC2 Voltage Supply&lt;/h3&gt;
+&lt;p&gt;Secondary VCC voltage supply - Useful for a system with multiple VCC supplies.&lt;/p&gt;</description>
+<gates>
+<gate name="G$1" symbol="VCC_2" x="0" y="0"/>
 </gates>
 <devices>
 <device name="">
@@ -22721,6 +24575,12 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <vertex x="-0.1905" y="-0.127"/>
 </polygon>
 </package>
+<package name="SMT-JUMPER_2_NO_NO-SILK">
+<text x="0" y="1.143" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;NAME</text>
+<text x="0" y="-1.143" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;VALUE</text>
+<smd name="1" x="-0.4064" y="0" dx="0.635" dy="1.27" layer="1" cream="no"/>
+<smd name="2" x="0.4064" y="0" dx="0.635" dy="1.27" layer="1" cream="no"/>
+</package>
 <package name="SMT-JUMPER_2_NC_TRACE_NO-SILK">
 <smd name="1" x="-0.508" y="0" dx="0.635" dy="1.27" layer="1" cream="no"/>
 <smd name="2" x="0.508" y="0" dx="0.635" dy="1.27" layer="1" cream="no"/>
@@ -22734,8 +24594,77 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <vertex x="-0.1905" y="-0.127"/>
 </polygon>
 </package>
+<package name="SMT-JUMPER_2_NO_NO-SILK_ROUND">
+<smd name="1" x="-1.27" y="0" dx="0.3048" dy="0.1524" layer="1" roundness="20" rot="R270" stop="no" thermals="no" cream="no"/>
+<smd name="2" x="1.27" y="0" dx="0.3048" dy="0.1524" layer="1" roundness="20" rot="R90" stop="no" thermals="no" cream="no"/>
+<text x="0" y="1.9685" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;NAME</text>
+<text x="0" y="-1.9685" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;VALUE</text>
+<polygon width="0.00508125" layer="1">
+<vertex x="0.111125" y="-1.42875" curve="85"/>
+<vertex x="1.381125" y="0" curve="85"/>
+<vertex x="0.111125" y="1.42875"/>
+</polygon>
+<polygon width="0.00508125" layer="1">
+<vertex x="-0.111125" y="1.42875"/>
+<vertex x="-0.111125" y="-1.42875" curve="-85"/>
+<vertex x="-1.381125" y="0" curve="-85"/>
+</polygon>
+<polygon width="0.2032" layer="29">
+<vertex x="0" y="1.42875" curve="-90"/>
+<vertex x="1.42875" y="0" curve="-90"/>
+<vertex x="0" y="-1.42875" curve="-90"/>
+<vertex x="-1.42875" y="0" curve="-90"/>
+</polygon>
+</package>
+<package name="SMT-JUMPER_2_NO_SILK">
+<text x="0" y="1.143" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;NAME</text>
+<text x="0" y="-1.143" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;VALUE</text>
+<wire x1="0.8636" y1="-1.016" x2="-0.8636" y2="-1.016" width="0.1524" layer="21"/>
+<wire x1="0.8636" y1="1.016" x2="1.1176" y2="0.762" width="0.1524" layer="21" curve="-90"/>
+<wire x1="-1.1176" y1="0.762" x2="-0.8636" y2="1.016" width="0.1524" layer="21" curve="-90"/>
+<wire x1="-1.1176" y1="-0.762" x2="-0.8636" y2="-1.016" width="0.1524" layer="21" curve="90"/>
+<wire x1="0.8636" y1="-1.016" x2="1.1176" y2="-0.762" width="0.1524" layer="21" curve="90"/>
+<wire x1="1.1176" y1="-0.762" x2="1.1176" y2="0.762" width="0.1524" layer="21"/>
+<wire x1="-1.1176" y1="-0.762" x2="-1.1176" y2="0.762" width="0.1524" layer="21"/>
+<wire x1="-0.8636" y1="1.016" x2="0.8636" y2="1.016" width="0.1524" layer="21"/>
+<smd name="1" x="-0.4064" y="0" dx="0.635" dy="1.27" layer="1" cream="no"/>
+<smd name="2" x="0.4064" y="0" dx="0.635" dy="1.27" layer="1" cream="no"/>
+</package>
+<package name="SMT-JUMPER_2_NO_SILK_ROUND">
+<smd name="1" x="-1.27" y="0" dx="0.3048" dy="0.1524" layer="1" roundness="20" rot="R270" stop="no" thermals="no" cream="no"/>
+<smd name="2" x="1.27" y="0" dx="0.3048" dy="0.1524" layer="1" roundness="20" rot="R90" stop="no" thermals="no" cream="no"/>
+<text x="0" y="1.9685" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;NAME</text>
+<text x="0" y="-1.9685" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;VALUE</text>
+<polygon width="0.00508125" layer="1">
+<vertex x="0.111125" y="-1.42875" curve="85"/>
+<vertex x="1.381125" y="0" curve="85"/>
+<vertex x="0.111125" y="1.42875"/>
+</polygon>
+<polygon width="0.00508125" layer="1">
+<vertex x="-0.111125" y="1.42875"/>
+<vertex x="-0.111125" y="-1.42875" curve="-85"/>
+<vertex x="-1.381125" y="0" curve="-85"/>
+</polygon>
+<polygon width="0.2032" layer="29">
+<vertex x="0" y="1.42875" curve="-90"/>
+<vertex x="1.42875" y="0" curve="-90"/>
+<vertex x="0" y="-1.42875" curve="-90"/>
+<vertex x="-1.42875" y="0" curve="-90"/>
+</polygon>
+<circle x="0" y="0" radius="1.74625" width="0.2032" layer="21"/>
+</package>
 </packages>
 <symbols>
+<symbol name="SMT-JUMPER_2_NO">
+<wire x1="0.381" y1="0.635" x2="0.381" y2="-0.635" width="1.27" layer="94" curve="-180" cap="flat"/>
+<wire x1="-0.381" y1="-0.635" x2="-0.381" y2="0.635" width="1.27" layer="94" curve="-180" cap="flat"/>
+<wire x1="2.54" y1="0" x2="1.651" y2="0" width="0.1524" layer="94"/>
+<wire x1="-2.54" y1="0" x2="-1.651" y2="0" width="0.1524" layer="94"/>
+<text x="-2.54" y="2.54" size="1.778" layer="95" font="vector">&gt;NAME</text>
+<text x="-2.54" y="-2.54" size="1.778" layer="96" font="vector" align="top-left">&gt;VALUE</text>
+<pin name="2" x="5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1" rot="R180"/>
+<pin name="1" x="-5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1"/>
+</symbol>
 <symbol name="SMT-JUMPER_2_NC_TRACE">
 <wire x1="0.381" y1="0.635" x2="1.016" y2="0" width="1.27" layer="94" curve="-90" cap="flat"/>
 <wire x1="1.016" y1="0" x2="0.381" y2="-0.635" width="1.27" layer="94" curve="-90" cap="flat"/>
@@ -22750,6 +24679,56 @@ You are welcome to use this library for commercial purposes. For attribution, we
 </symbol>
 </symbols>
 <devicesets>
+<deviceset name="JUMPER-SMT_2_NO" prefix="JP">
+<description>&lt;h3&gt;Normally open jumper&lt;/h3&gt;
+&lt;p&gt;This jumper has two pads in close proximity to each other. Apply solder to close the connection.&lt;/p&gt;
+
+&lt;p&gt;Round pads are easier to solder for beginners, but are a lot larger.&lt;/p&gt;
+&lt;p&gt;SparkFun Product that uses the round pads:
+&lt;ul&gt;&lt;li&gt;&lt;a href="https://www.sparkfun.com/products/12781"&gt;SparkFun EL Sequencer&lt;/a&gt;&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<gates>
+<gate name="G$1" symbol="SMT-JUMPER_2_NO" x="0" y="0"/>
+</gates>
+<devices>
+<device name="_NO-SILK" package="SMT-JUMPER_2_NO_NO-SILK">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_NO-SILK_ROUND" package="SMT-JUMPER_2_NO_NO-SILK_ROUND">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_SILK" package="SMT-JUMPER_2_NO_SILK">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_SILK_ROUND" package="SMT-JUMPER_2_NO_SILK_ROUND">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
 <deviceset name="JUMPER-SMT_2_NC_TRACE" prefix="JP">
 <description>&lt;h3&gt;Normally closed trace jumper&lt;/h3&gt;
 &lt;p&gt;This jumper has a trace between two pads so it's normally closed (NC). Use a razor knife to open the connection. For best results follow the IPC guidelines for cutting traces:&lt;/p&gt;
@@ -22800,24 +24779,20 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <part name="ICSP" library="SparkFun-Connectors" deviceset="AVR_SPI_PROG_3X2" device="PTH" value="ICSP"/>
 <part name="R1" library="SparkFun-Resistors" deviceset="330OHM" device="-HORIZ-1/10W-5%" value="330"/>
 <part name="R2" library="SparkFun-Resistors" deviceset="330OHM" device="-HORIZ-1/10W-5%" value="330"/>
-<part name="LED1" library="SparkFun-LED" deviceset="LED" device="3MM"/>
-<part name="LED2" library="SparkFun-LED" deviceset="LED" device="3MM"/>
+<part name="L1" library="SparkFun-LED" deviceset="LED" device="3MM"/>
+<part name="L2" library="SparkFun-LED" deviceset="LED" device="3MM"/>
 <part name="GND2" library="SparkFun-PowerSymbols" deviceset="GND" device=""/>
 <part name="GND3" library="SparkFun-PowerSymbols" deviceset="GND" device=""/>
-<part name="JP4" library="SparkFun-Connectors" deviceset="CONN_01" device=""/>
-<part name="JP9" library="SparkFun-Connectors" deviceset="CONN_01" device=""/>
+<part name="JP_3" library="SparkFun-Connectors" deviceset="CONN_01" device=""/>
+<part name="JP_4" library="SparkFun-Connectors" deviceset="CONN_01" device=""/>
 <part name="JP12" library="SparkFun-Connectors" deviceset="CONN_08" device="&quot;"/>
 <part name="JP10" library="SparkFun-Connectors" deviceset="CONN_06" device="SILK_FEMALE_PTH"/>
 <part name="FRAME1" library="SparkFun-Aesthetics" deviceset="FRAME-LETTER" device=""/>
 <part name="GND1" library="SparkFun-PowerSymbols" deviceset="GND" device=""/>
-<part name="5V_RAIL" library="SparkFun-Connectors" deviceset="CONN_19" device=""/>
-<part name="GND_RAIL" library="SparkFun-Connectors" deviceset="CONN_19" device=""/>
-<part name="P+2" library="SparkFun-PowerSymbols" deviceset="5V" device="" value="5V"/>
-<part name="GND4" library="SparkFun-PowerSymbols" deviceset="GND" device=""/>
 <part name="BB1" library="SparkFun-Boards" deviceset="BREADBOARD" device="MINI"/>
 <part name="R4" library="SparkFun-Resistors" deviceset="10KOHM" device="-HORIZ-1/4W-5%" value="10k"/>
 <part name="GND5" library="SparkFun-PowerSymbols" deviceset="GND" device=""/>
-<part name="JP3" library="SparkFun-Connectors" deviceset="CONN_01" device=""/>
+<part name="JP_2" library="SparkFun-Connectors" deviceset="CONN_01" device=""/>
 <part name="U$1" library="SparkFun-Aesthetics" deviceset="SFE_LOGO_NAME_FLAME" device=".1_INCH"/>
 <part name="JP7" library="SparkFun-Connectors" deviceset="CONN_06" device="SILK_FEMALE_PTH"/>
 <part name="P+1" library="SparkFun-PowerSymbols" deviceset="5V" device="" value="5V"/>
@@ -22825,8 +24800,8 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <part name="JP8" library="TempLibrary" deviceset="ARDUINO_R3_SHIELD" device="R3_PROTO_SHIELD"/>
 <part name="JP11" library="SparkFun-Connectors" deviceset="CONN_08" device="&quot;"/>
 <part name="JP1" library="SparkFun-Connectors" deviceset="CONN_10" device="&quot;"/>
-<part name="S2" library="SparkFun-Switches" deviceset="MOMENTARY-SWITCH-SPST" device="-PTH-6.0MM-KIT"/>
-<part name="S4" library="SparkFun-Switches" deviceset="MOMENTARY-SWITCH-SPST" device="-PTH-6.0MM-KIT"/>
+<part name="SW2" library="SparkFun-Switches" deviceset="MOMENTARY-SWITCH-SPST" device="-PTH-6.0MM" value="MOMENTARY-SWITCH-SPST-PTH-6.0MM"/>
+<part name="S4" library="SparkFun-Switches" deviceset="MOMENTARY-SWITCH-SPST" device="-PTH-6.0MM" value="MOMENTARY-SWITCH-SPST-PTH-6.0MM"/>
 <part name="GND8" library="SparkFun-PowerSymbols" deviceset="GND" device=""/>
 <part name="GND9" library="SparkFun-PowerSymbols" deviceset="GND" device=""/>
 <part name="GND10" library="SparkFun-PowerSymbols" deviceset="GND" device=""/>
@@ -22841,792 +24816,892 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <part name="GND6" library="SparkFun-PowerSymbols" deviceset="GND" device=""/>
 <part name="GND7" library="SparkFun-PowerSymbols" deviceset="GND" device=""/>
 <part name="P+4" library="SparkFun-PowerSymbols" deviceset="5V" device="" value="5V"/>
+<part name="5V" library="SparkFun-Connectors" deviceset="CONN_01" device=""/>
+<part name="GND" library="SparkFun-Connectors" deviceset="CONN_01" device=""/>
+<part name="5V_RAIL" library="SparkFun-Connectors" deviceset="CONN_07" device="NO_SILK"/>
+<part name="GND_RAIL_1" library="SparkFun-Connectors" deviceset="CONN_07" device="NO_SILK"/>
+<part name="VDD_RAIL" library="SparkFun-Connectors" deviceset="CONN_04" device="1X04_NO_SILK"/>
+<part name="P+2" library="SparkFun-PowerSymbols" deviceset="5V" device="" value="5V"/>
+<part name="GND4" library="SparkFun-PowerSymbols" deviceset="GND" device=""/>
+<part name="GND_RAIL_2" library="SparkFun-Connectors" deviceset="CONN_03" device="1X03_NO_SILK"/>
+<part name="JP13" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL1"/>
+<part name="JP14" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL1"/>
+<part name="JP15" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL1"/>
+<part name="JP16" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL2"/>
+<part name="JP17" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL2"/>
+<part name="JP18" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL2"/>
+<part name="JP19" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL3"/>
+<part name="JP20" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL3"/>
+<part name="JP21" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL3"/>
+<part name="JP22" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL4"/>
+<part name="JP23" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL4"/>
+<part name="JP24" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL4"/>
+<part name="JP25" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL5"/>
+<part name="JP26" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL5"/>
+<part name="JP27" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL5"/>
+<part name="JP28" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL6"/>
+<part name="JP29" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL6"/>
+<part name="JP30" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL6"/>
+<part name="JP31" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL7"/>
+<part name="JP32" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL7"/>
+<part name="JP33" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL7"/>
+<part name="JP34" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL8"/>
+<part name="JP35" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL8"/>
+<part name="JP36" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL8"/>
+<part name="JP37" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL9"/>
+<part name="JP38" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL9"/>
+<part name="JP39" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL9"/>
+<part name="JP40" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL18"/>
+<part name="JP41" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL18"/>
+<part name="JP42" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL18"/>
+<part name="JP43" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL18"/>
+<part name="JP44" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL18"/>
+<part name="JP45" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL18"/>
+<part name="JP46" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL18"/>
+<part name="JP47" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL18"/>
+<part name="JP48" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL18"/>
+<part name="JP49" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL17"/>
+<part name="JP50" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL17"/>
+<part name="JP51" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL17"/>
+<part name="JP52" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL16"/>
+<part name="JP53" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL16"/>
+<part name="JP54" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL16"/>
+<part name="JP55" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL15"/>
+<part name="JP56" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL15"/>
+<part name="JP57" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL15"/>
+<part name="JP58" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL14"/>
+<part name="JP59" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL14"/>
+<part name="JP60" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL14"/>
+<part name="JP61" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL13"/>
+<part name="JP62" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL13"/>
+<part name="JP63" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL13"/>
+<part name="JP64" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL12"/>
+<part name="JP65" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL12"/>
+<part name="JP66" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL12"/>
+<part name="JP67" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL10"/>
+<part name="JP68" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL10"/>
+<part name="JP69" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL10"/>
+<part name="JP70" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL10"/>
+<part name="JP71" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL10"/>
+<part name="JP72" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL10"/>
+<part name="JP73" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL10"/>
+<part name="JP74" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL10"/>
+<part name="JP75" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL10"/>
+<part name="JP76" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL11"/>
+<part name="JP77" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL11"/>
+<part name="JP78" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL11"/>
+<part name="JP79" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL11"/>
+<part name="JP80" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL11"/>
+<part name="JP81" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL11"/>
+<part name="JP82" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL11"/>
+<part name="JP83" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL11"/>
+<part name="JP84" library="SparkFun-Jumpers" deviceset="JUMPER-SMT_2_NO" device="_NO-SILK" value="D_RAIL11"/>
+<part name="VDD" library="SparkFun-PowerSymbols" deviceset="VCC_2" device="" value="VDD"/>
 </parts>
 <sheets>
 <sheet>
 <plain>
 <text x="170.942" y="11.43" size="2.54" layer="94" font="vector">Nathan Seidle</text>
-<text x="238.76" y="7.62" size="2.54" layer="94" font="vector">v31</text>
+<text x="238.76" y="7.62" size="2.54" layer="94" font="vector">v32</text>
 <text x="170.688" y="7.62" size="1.778" layer="94" font="vector" ratio="7">Toni Klopfenstein &amp; Ho Yun "Bobby" Chan</text>
-<wire x1="172.72" y1="185.42" x2="172.72" y2="68.58" width="0.1524" layer="97" style="shortdash"/>
-<text x="43.18" y="175.26" size="2.032" layer="97" font="vector" ratio="15">Arduino Shield</text>
-<text x="121.92" y="175.26" size="2.032" layer="97" font="vector" ratio="15">Arduino Headers Connections</text>
-<text x="195.58" y="175.26" size="2.032" layer="97" font="vector" ratio="15">Prototyping Hardware</text>
-<text x="101.6" y="58.42" size="2.032" layer="97" font="vector" ratio="15">Breadboard Footprint</text>
-<text x="25.4" y="58.42" size="2.032" layer="97" font="vector" ratio="15">BlueSMiRF Footprint</text>
-<text x="40.64" y="10.16" size="1.778" layer="97" font="vector">Note: Disable jumpers 1-4 to 
+<text x="38.1" y="170.18" size="2.032" layer="97" font="vector" ratio="15">Arduino Shield</text>
+<text x="110.49" y="138.43" size="2.032" layer="97" font="vector" ratio="15">Power Rails</text>
+<text x="101.6" y="58.42" size="2.032" layer="97" font="vector" ratio="15">Prototyping Hardware</text>
+<text x="102.87" y="176.53" size="2.032" layer="97" font="vector" ratio="15">Breadboard Footprint</text>
+<text x="33.02" y="53.34" size="2.032" layer="97" font="vector" ratio="15">BlueSMiRF Footprint</text>
+<text x="45.72" y="5.08" size="1.778" layer="97" font="vector">Note: Disable jumpers 1-4 to 
 create customizable 
 6-pin header for prototyping.</text>
-<text x="43.18" y="116.84" size="1.651" layer="95" font="vector">Arduino_R3_Shield</text>
-<text x="17.78" y="88.9" size="1.778" layer="95" font="vector" rot="R90">Reset</text>
-<text x="27.94" y="170.18" size="1.778" layer="95" font="vector">A0</text>
-<text x="27.94" y="167.64" size="1.778" layer="95" font="vector">A1</text>
-<text x="27.94" y="165.1" size="1.778" layer="95" font="vector">A2</text>
-<text x="27.94" y="162.56" size="1.778" layer="95" font="vector">A3</text>
-<text x="27.94" y="157.48" size="1.778" layer="95" font="vector">A5</text>
-<text x="27.94" y="160.02" size="1.778" layer="95" font="vector">A4</text>
-<wire x1="0" y1="68.58" x2="91.44" y2="68.58" width="0.1524" layer="95" style="shortdash"/>
-<wire x1="91.44" y1="68.58" x2="114.3" y2="68.58" width="0.1524" layer="95" style="shortdash"/>
-<wire x1="114.3" y1="68.58" x2="147.32" y2="68.58" width="0.1524" layer="95" style="shortdash"/>
-<wire x1="147.32" y1="68.58" x2="248.92" y2="68.58" width="0.1524" layer="95" style="shortdash"/>
-<wire x1="147.32" y1="35.56" x2="147.32" y2="68.58" width="0.1524" layer="95" style="shortdash"/>
-<wire x1="91.44" y1="68.58" x2="91.44" y2="0" width="0.1524" layer="95" style="shortdash"/>
-<wire x1="114.3" y1="185.42" x2="114.3" y2="68.58" width="0.1524" layer="95" style="shortdash"/>
+<text x="38.1" y="111.76" size="1.651" layer="95" font="vector">Arduino_R3_Shield</text>
+<text x="12.7" y="83.82" size="1.778" layer="95" font="vector" rot="R90">Reset</text>
+<text x="15.24" y="157.48" size="1.778" layer="95" font="vector">A0</text>
+<text x="15.24" y="154.94" size="1.778" layer="95" font="vector">A1</text>
+<text x="15.24" y="152.4" size="1.778" layer="95" font="vector">A2</text>
+<text x="15.24" y="149.86" size="1.778" layer="95" font="vector">A3</text>
+<text x="15.24" y="144.78" size="1.778" layer="95" font="vector">A5</text>
+<text x="15.24" y="147.32" size="1.778" layer="95" font="vector">A4</text>
+<wire x1="0" y1="63.5" x2="91.44" y2="63.5" width="0.1524" layer="95" style="shortdash"/>
+<wire x1="91.44" y1="63.5" x2="99.06" y2="63.5" width="0.1524" layer="95" style="shortdash"/>
+<wire x1="91.44" y1="63.5" x2="91.44" y2="0" width="0.1524" layer="95" style="shortdash"/>
+<text x="69.85" y="43.18" size="1.778" layer="95" font="vector">SS_TX</text>
+<text x="72.39" y="30.48" size="1.778" layer="95" font="vector">SS_RX</text>
+<wire x1="99.06" y1="185.42" x2="99.06" y2="149.86" width="0.1524" layer="95" style="shortdash"/>
+<wire x1="99.06" y1="149.86" x2="99.06" y2="63.5" width="0.1524" layer="95" style="shortdash"/>
+<wire x1="99.06" y1="63.5" x2="139.7" y2="63.5" width="0.1524" layer="95" style="shortdash"/>
+<wire x1="147.32" y1="63.5" x2="248.92" y2="63.5" width="0.1524" layer="95" style="shortdash"/>
+<wire x1="147.32" y1="35.56" x2="147.32" y2="63.5" width="0.1524" layer="95" style="shortdash"/>
+<text x="149.86" y="165.1" size="2.032" layer="97" font="vector" ratio="15">Disconnected
+Breadboard
+Prototyping
+Area</text>
+<wire x1="139.7" y1="63.5" x2="139.7" y2="149.86" width="0.1524" layer="95" style="shortdash"/>
+<wire x1="139.7" y1="149.86" x2="139.7" y2="185.42" width="0.1524" layer="95" style="shortdash"/>
+<wire x1="99.06" y1="149.86" x2="139.7" y2="149.86" width="0.1524" layer="95" style="shortdash"/>
+<wire x1="147.32" y1="63.5" x2="139.7" y2="63.5" width="0.1524" layer="95" style="shortdash"/>
+<text x="95.25" y="50.8" size="1.778" layer="104" font="vector">D3_NC</text>
+<text x="110.49" y="50.8" size="1.778" layer="95" font="vector">D4_NC</text>
 </plain>
 <instances>
-<instance part="ICSP" gate="G$1" x="78.74" y="86.36"/>
-<instance part="R1" gate="G$1" x="220.98" y="111.76" rot="R90"/>
-<instance part="R2" gate="G$1" x="233.68" y="111.76" rot="R90"/>
-<instance part="LED1" gate="G$1" x="220.98" y="124.46"/>
-<instance part="LED2" gate="G$1" x="233.68" y="124.46"/>
-<instance part="GND2" gate="1" x="233.68" y="101.6"/>
-<instance part="GND3" gate="1" x="220.98" y="101.6"/>
-<instance part="JP4" gate="G$1" x="220.98" y="137.16" rot="R270"/>
-<instance part="JP9" gate="G$1" x="233.68" y="137.16" rot="R270"/>
-<instance part="JP12" gate="G$1" x="96.52" y="154.94" rot="R180"/>
-<instance part="JP10" gate="G$1" x="22.86" y="162.56"/>
+<instance part="ICSP" gate="G$1" x="53.34" y="83.82"/>
+<instance part="R1" gate="G$1" x="99.06" y="20.32" rot="R90"/>
+<instance part="R2" gate="G$1" x="111.76" y="20.32" rot="R90"/>
+<instance part="L1" gate="G$1" x="99.06" y="33.02"/>
+<instance part="L2" gate="G$1" x="111.76" y="33.02"/>
+<instance part="GND2" gate="1" x="111.76" y="10.16"/>
+<instance part="GND3" gate="1" x="99.06" y="10.16"/>
+<instance part="JP_3" gate="G$1" x="99.06" y="45.72" rot="R270"/>
+<instance part="JP_4" gate="G$1" x="111.76" y="45.72" rot="R270"/>
+<instance part="JP12" gate="G$1" x="91.44" y="149.86" rot="R180"/>
+<instance part="JP10" gate="G$1" x="7.62" y="149.86"/>
 <instance part="FRAME1" gate="G$1" x="0" y="0"/>
 <instance part="FRAME1" gate="V" x="147.32" y="0"/>
-<instance part="GND1" gate="1" x="20.32" y="78.74"/>
-<instance part="5V_RAIL" gate="G$1" x="124.46" y="121.92"/>
-<instance part="GND_RAIL" gate="G$1" x="147.32" y="121.92"/>
-<instance part="P+2" gate="G$1" x="137.16" y="149.86"/>
-<instance part="GND4" gate="1" x="160.02" y="91.44"/>
-<instance part="BB1" gate="G$1" x="116.84" y="38.1"/>
-<instance part="R4" gate="G$1" x="193.04" y="129.54" rot="R90"/>
-<instance part="GND5" gate="1" x="193.04" y="101.6"/>
-<instance part="JP3" gate="G$1" x="205.74" y="119.38" rot="R180"/>
-<instance part="U$1" gate="G$1" x="190.5" y="35.56"/>
-<instance part="JP7" gate="G$1" x="43.18" y="38.1"/>
-<instance part="P+1" gate="G$1" x="193.04" y="137.16"/>
+<instance part="GND1" gate="1" x="15.24" y="73.66"/>
+<instance part="BB1" gate="G$1" x="116.84" y="165.1"/>
+<instance part="R4" gate="G$1" x="127" y="38.1" rot="R90"/>
+<instance part="GND5" gate="1" x="127" y="5.08"/>
+<instance part="JP_2" gate="G$1" x="139.7" y="27.94" rot="R180"/>
+<instance part="U$1" gate="G$1" x="185.42" y="35.56"/>
+<instance part="JP7" gate="G$1" x="38.1" y="30.48"/>
+<instance part="P+1" gate="G$1" x="127" y="50.8"/>
 <instance part="U$2" gate="G$1" x="148.844" y="7.112"/>
-<instance part="JP8" gate="G$1" x="55.88" y="144.78" smashed="yes">
-<attribute name="NAME" x="46.228" y="165.862" size="1.778" layer="95" font="vector"/>
+<instance part="JP8" gate="G$1" x="50.8" y="139.7" smashed="yes">
+<attribute name="NAME" x="41.148" y="160.782" size="1.778" layer="95" font="vector"/>
 </instance>
-<instance part="JP11" gate="G$1" x="12.7" y="129.54"/>
-<instance part="JP1" gate="G$1" x="101.6" y="116.84" rot="R180"/>
-<instance part="S2" gate="G$1" x="193.04" y="111.76" smashed="yes" rot="R90">
-<attribute name="NAME" x="190.5" y="109.22" size="1.778" layer="95" font="vector" rot="R90"/>
+<instance part="JP11" gate="G$1" x="7.62" y="124.46"/>
+<instance part="JP1" gate="G$1" x="96.52" y="111.76" rot="R180"/>
+<instance part="SW2" gate="G$1" x="127" y="20.32" smashed="yes" rot="R90">
+<attribute name="NAME" x="132.08" y="17.78" size="1.778" layer="95" font="vector" rot="R90"/>
 </instance>
-<instance part="S4" gate="G$1" x="20.32" y="91.44" smashed="yes" rot="R90">
-<attribute name="NAME" x="25.4" y="88.9" size="1.778" layer="95" font="vector" rot="R90"/>
+<instance part="S4" gate="G$1" x="15.24" y="86.36" smashed="yes" rot="R90">
+<attribute name="NAME" x="20.32" y="83.82" size="1.778" layer="95" font="vector" rot="R90"/>
 </instance>
-<instance part="GND8" gate="1" x="40.64" y="114.3"/>
-<instance part="GND9" gate="1" x="86.36" y="106.68"/>
-<instance part="GND10" gate="1" x="96.52" y="78.74"/>
-<instance part="P+5" gate="G$1" x="96.52" y="93.98"/>
-<instance part="SJ1" gate="G$1" x="58.42" y="43.18" smashed="yes">
-<attribute name="NAME" x="60.96" y="43.18" size="1.778" layer="95" font="vector"/>
+<instance part="GND8" gate="1" x="35.56" y="109.22"/>
+<instance part="GND9" gate="1" x="81.28" y="101.6"/>
+<instance part="GND10" gate="1" x="71.12" y="76.2"/>
+<instance part="P+5" gate="G$1" x="71.12" y="91.44"/>
+<instance part="SJ1" gate="G$1" x="53.34" y="35.56" smashed="yes">
+<attribute name="NAME" x="55.88" y="35.56" size="1.778" layer="95" font="vector"/>
 </instance>
-<instance part="SJ2" gate="G$1" x="66.04" y="40.64" smashed="yes">
-<attribute name="NAME" x="68.58" y="40.64" size="1.778" layer="95" font="vector"/>
+<instance part="SJ2" gate="G$1" x="60.96" y="33.02" smashed="yes">
+<attribute name="NAME" x="63.5" y="33.02" size="1.778" layer="95" font="vector"/>
 </instance>
-<instance part="SJ3" gate="G$1" x="55.88" y="38.1" smashed="yes">
-<attribute name="NAME" x="58.42" y="38.1" size="1.778" layer="95" font="vector"/>
+<instance part="SJ3" gate="G$1" x="50.8" y="30.48" smashed="yes">
+<attribute name="NAME" x="53.34" y="30.48" size="1.778" layer="95" font="vector"/>
 </instance>
-<instance part="SJ4" gate="G$1" x="60.96" y="35.56" smashed="yes">
-<attribute name="NAME" x="63.5" y="35.56" size="1.778" layer="95" font="vector"/>
+<instance part="SJ4" gate="G$1" x="55.88" y="27.94" smashed="yes">
+<attribute name="NAME" x="58.42" y="27.94" size="1.778" layer="95" font="vector"/>
 </instance>
-<instance part="LOGO1" gate="G$1" x="172.72" y="48.26"/>
-<instance part="JP2" gate="G$1" x="33.02" y="38.1" rot="MR0"/>
-<instance part="P+3" gate="G$1" x="81.28" y="43.18"/>
-<instance part="GND6" gate="1" x="71.12" y="25.4"/>
-<instance part="GND7" gate="1" x="12.7" y="25.4"/>
-<instance part="P+4" gate="G$1" x="33.02" y="144.78"/>
+<instance part="LOGO1" gate="G$1" x="167.64" y="48.26"/>
+<instance part="JP2" gate="G$1" x="27.94" y="30.48" rot="MR0"/>
+<instance part="P+3" gate="G$1" x="87.63" y="50.8"/>
+<instance part="GND6" gate="1" x="66.04" y="17.78"/>
+<instance part="GND7" gate="1" x="7.62" y="17.78"/>
+<instance part="P+4" gate="G$1" x="27.94" y="139.7"/>
+<instance part="5V" gate="G$1" x="139.7" y="45.72" rot="R180"/>
+<instance part="GND" gate="G$1" x="139.7" y="12.7" rot="R180"/>
+<instance part="5V_RAIL" gate="G$1" x="107.95" y="109.22"/>
+<instance part="GND_RAIL_1" gate="G$1" x="125.73" y="109.22"/>
+<instance part="VDD_RAIL" gate="G$1" x="107.95" y="83.82"/>
+<instance part="P+2" gate="G$1" x="116.84" y="124.46"/>
+<instance part="GND4" gate="1" x="134.62" y="73.66"/>
+<instance part="GND_RAIL_2" gate="J$1" x="123.19" y="86.36"/>
+<instance part="JP13" gate="G$1" x="172.72" y="71.12"/>
+<instance part="JP14" gate="G$1" x="160.02" y="71.12"/>
+<instance part="JP15" gate="G$1" x="147.32" y="71.12"/>
+<instance part="JP16" gate="G$1" x="172.72" y="81.28"/>
+<instance part="JP17" gate="G$1" x="160.02" y="81.28"/>
+<instance part="JP18" gate="G$1" x="147.32" y="81.28"/>
+<instance part="JP19" gate="G$1" x="172.72" y="91.44"/>
+<instance part="JP20" gate="G$1" x="160.02" y="91.44"/>
+<instance part="JP21" gate="G$1" x="147.32" y="91.44"/>
+<instance part="JP22" gate="G$1" x="172.72" y="101.6"/>
+<instance part="JP23" gate="G$1" x="160.02" y="101.6"/>
+<instance part="JP24" gate="G$1" x="147.32" y="101.6"/>
+<instance part="JP25" gate="G$1" x="172.72" y="111.76"/>
+<instance part="JP26" gate="G$1" x="160.02" y="111.76"/>
+<instance part="JP27" gate="G$1" x="147.32" y="111.76"/>
+<instance part="JP28" gate="G$1" x="172.72" y="121.92"/>
+<instance part="JP29" gate="G$1" x="160.02" y="121.92"/>
+<instance part="JP30" gate="G$1" x="147.32" y="121.92"/>
+<instance part="JP31" gate="G$1" x="172.72" y="132.08"/>
+<instance part="JP32" gate="G$1" x="160.02" y="132.08"/>
+<instance part="JP33" gate="G$1" x="147.32" y="132.08"/>
+<instance part="JP34" gate="G$1" x="172.72" y="142.24"/>
+<instance part="JP35" gate="G$1" x="160.02" y="142.24"/>
+<instance part="JP36" gate="G$1" x="147.32" y="142.24"/>
+<instance part="JP37" gate="G$1" x="172.72" y="152.4"/>
+<instance part="JP38" gate="G$1" x="160.02" y="152.4"/>
+<instance part="JP39" gate="G$1" x="147.32" y="152.4"/>
+<instance part="JP40" gate="G$1" x="236.22" y="152.4"/>
+<instance part="JP41" gate="G$1" x="223.52" y="152.4"/>
+<instance part="JP42" gate="G$1" x="210.82" y="152.4"/>
+<instance part="JP43" gate="G$1" x="210.82" y="142.24"/>
+<instance part="JP44" gate="G$1" x="223.52" y="142.24"/>
+<instance part="JP45" gate="G$1" x="236.22" y="142.24"/>
+<instance part="JP46" gate="G$1" x="236.22" y="132.08"/>
+<instance part="JP47" gate="G$1" x="223.52" y="132.08"/>
+<instance part="JP48" gate="G$1" x="210.82" y="132.08"/>
+<instance part="JP49" gate="G$1" x="210.82" y="121.92"/>
+<instance part="JP50" gate="G$1" x="223.52" y="121.92"/>
+<instance part="JP51" gate="G$1" x="236.22" y="121.92"/>
+<instance part="JP52" gate="G$1" x="236.22" y="111.76"/>
+<instance part="JP53" gate="G$1" x="223.52" y="111.76"/>
+<instance part="JP54" gate="G$1" x="210.82" y="111.76"/>
+<instance part="JP55" gate="G$1" x="210.82" y="101.6"/>
+<instance part="JP56" gate="G$1" x="223.52" y="101.6"/>
+<instance part="JP57" gate="G$1" x="236.22" y="101.6"/>
+<instance part="JP58" gate="G$1" x="236.22" y="91.44"/>
+<instance part="JP59" gate="G$1" x="223.52" y="91.44"/>
+<instance part="JP60" gate="G$1" x="210.82" y="91.44"/>
+<instance part="JP61" gate="G$1" x="210.82" y="81.28"/>
+<instance part="JP62" gate="G$1" x="223.52" y="81.28"/>
+<instance part="JP63" gate="G$1" x="236.22" y="81.28"/>
+<instance part="JP64" gate="G$1" x="210.82" y="71.12"/>
+<instance part="JP65" gate="G$1" x="223.52" y="71.12"/>
+<instance part="JP66" gate="G$1" x="236.22" y="71.12"/>
+<instance part="JP67" gate="G$1" x="185.42" y="96.52" rot="R90"/>
+<instance part="JP68" gate="G$1" x="185.42" y="83.82" rot="R90"/>
+<instance part="JP69" gate="G$1" x="185.42" y="71.12" rot="R90"/>
+<instance part="JP70" gate="G$1" x="185.42" y="134.62" rot="R90"/>
+<instance part="JP71" gate="G$1" x="185.42" y="121.92" rot="R90"/>
+<instance part="JP72" gate="G$1" x="185.42" y="109.22" rot="R90"/>
+<instance part="JP73" gate="G$1" x="185.42" y="172.72" rot="R90"/>
+<instance part="JP74" gate="G$1" x="185.42" y="160.02" rot="R90"/>
+<instance part="JP75" gate="G$1" x="185.42" y="147.32" rot="R90"/>
+<instance part="JP76" gate="G$1" x="198.12" y="96.52" rot="R90"/>
+<instance part="JP77" gate="G$1" x="198.12" y="83.82" rot="R90"/>
+<instance part="JP78" gate="G$1" x="198.12" y="71.12" rot="R90"/>
+<instance part="JP79" gate="G$1" x="198.12" y="134.62" rot="R90"/>
+<instance part="JP80" gate="G$1" x="198.12" y="121.92" rot="R90"/>
+<instance part="JP81" gate="G$1" x="198.12" y="109.22" rot="R90"/>
+<instance part="JP82" gate="G$1" x="198.12" y="172.72" rot="R90"/>
+<instance part="JP83" gate="G$1" x="198.12" y="160.02" rot="R90"/>
+<instance part="JP84" gate="G$1" x="198.12" y="147.32" rot="R90"/>
+<instance part="VDD" gate="G$1" x="116.84" y="93.726"/>
 </instances>
 <busses>
 </busses>
 <nets>
 <net name="GND" class="1">
 <segment>
-<wire x1="233.68" y1="104.14" x2="233.68" y2="106.68" width="0.1524" layer="91"/>
+<wire x1="111.76" y1="12.7" x2="111.76" y2="15.24" width="0.1524" layer="91"/>
 <pinref part="R2" gate="G$1" pin="1"/>
 <pinref part="GND2" gate="1" pin="GND"/>
 </segment>
 <segment>
-<wire x1="220.98" y1="104.14" x2="220.98" y2="106.68" width="0.1524" layer="91"/>
+<wire x1="99.06" y1="12.7" x2="99.06" y2="15.24" width="0.1524" layer="91"/>
 <pinref part="R1" gate="G$1" pin="1"/>
 <pinref part="GND3" gate="1" pin="GND"/>
 </segment>
 <segment>
-<wire x1="91.44" y1="119.38" x2="86.36" y2="119.38" width="0.1524" layer="91"/>
+<wire x1="86.36" y1="114.3" x2="81.28" y2="114.3" width="0.1524" layer="91"/>
 <pinref part="JP1" gate="G$1" pin="7"/>
 <pinref part="GND9" gate="1" pin="GND"/>
-<wire x1="86.36" y1="109.22" x2="86.36" y2="119.38" width="0.1524" layer="91"/>
+<wire x1="81.28" y1="104.14" x2="81.28" y2="114.3" width="0.1524" layer="91"/>
 </segment>
 <segment>
-<wire x1="20.32" y1="86.36" x2="20.32" y2="81.28" width="0.1524" layer="91"/>
+<wire x1="15.24" y1="81.28" x2="15.24" y2="76.2" width="0.1524" layer="91"/>
 <pinref part="GND1" gate="1" pin="GND"/>
 <pinref part="S4" gate="G$1" pin="1"/>
 </segment>
 <segment>
-<wire x1="157.48" y1="137.16" x2="160.02" y2="137.16" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="137.16" x2="160.02" y2="134.62" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="134.62" x2="160.02" y2="132.08" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="132.08" x2="160.02" y2="129.54" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="129.54" x2="160.02" y2="127" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="127" x2="160.02" y2="124.46" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="124.46" x2="160.02" y2="121.92" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="121.92" x2="160.02" y2="119.38" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="119.38" x2="160.02" y2="116.84" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="116.84" x2="160.02" y2="114.3" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="114.3" x2="160.02" y2="111.76" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="111.76" x2="160.02" y2="109.22" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="109.22" x2="160.02" y2="106.68" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="106.68" x2="160.02" y2="104.14" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="104.14" x2="160.02" y2="101.6" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="101.6" x2="160.02" y2="99.06" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="99.06" x2="160.02" y2="93.98" width="0.1524" layer="91"/>
-<wire x1="157.48" y1="99.06" x2="160.02" y2="99.06" width="0.1524" layer="91"/>
-<wire x1="157.48" y1="101.6" x2="160.02" y2="101.6" width="0.1524" layer="91"/>
-<wire x1="157.48" y1="104.14" x2="160.02" y2="104.14" width="0.1524" layer="91"/>
-<wire x1="157.48" y1="106.68" x2="160.02" y2="106.68" width="0.1524" layer="91"/>
-<wire x1="157.48" y1="109.22" x2="160.02" y2="109.22" width="0.1524" layer="91"/>
-<wire x1="157.48" y1="111.76" x2="160.02" y2="111.76" width="0.1524" layer="91"/>
-<wire x1="157.48" y1="114.3" x2="160.02" y2="114.3" width="0.1524" layer="91"/>
-<wire x1="157.48" y1="116.84" x2="160.02" y2="116.84" width="0.1524" layer="91"/>
-<wire x1="157.48" y1="119.38" x2="160.02" y2="119.38" width="0.1524" layer="91"/>
-<wire x1="157.48" y1="121.92" x2="160.02" y2="121.92" width="0.1524" layer="91"/>
-<wire x1="157.48" y1="124.46" x2="160.02" y2="124.46" width="0.1524" layer="91"/>
-<wire x1="157.48" y1="127" x2="160.02" y2="127" width="0.1524" layer="91"/>
-<wire x1="157.48" y1="129.54" x2="160.02" y2="129.54" width="0.1524" layer="91"/>
-<wire x1="157.48" y1="132.08" x2="160.02" y2="132.08" width="0.1524" layer="91"/>
-<wire x1="157.48" y1="134.62" x2="160.02" y2="134.62" width="0.1524" layer="91"/>
-<junction x="160.02" y="99.06"/>
-<junction x="160.02" y="101.6"/>
-<junction x="160.02" y="104.14"/>
-<junction x="160.02" y="106.68"/>
-<junction x="160.02" y="109.22"/>
-<junction x="160.02" y="111.76"/>
-<junction x="160.02" y="114.3"/>
-<junction x="160.02" y="116.84"/>
-<junction x="160.02" y="119.38"/>
-<junction x="160.02" y="121.92"/>
-<junction x="160.02" y="124.46"/>
-<junction x="160.02" y="127"/>
-<junction x="160.02" y="129.54"/>
-<junction x="160.02" y="132.08"/>
-<junction x="160.02" y="134.62"/>
-<pinref part="GND_RAIL" gate="G$1" pin="16"/>
-<pinref part="GND_RAIL" gate="G$1" pin="1"/>
-<pinref part="GND_RAIL" gate="G$1" pin="2"/>
-<pinref part="GND_RAIL" gate="G$1" pin="3"/>
-<pinref part="GND_RAIL" gate="G$1" pin="4"/>
-<pinref part="GND_RAIL" gate="G$1" pin="5"/>
-<pinref part="GND_RAIL" gate="G$1" pin="6"/>
-<pinref part="GND_RAIL" gate="G$1" pin="7"/>
-<pinref part="GND_RAIL" gate="G$1" pin="8"/>
-<pinref part="GND_RAIL" gate="G$1" pin="9"/>
-<pinref part="GND_RAIL" gate="G$1" pin="10"/>
-<pinref part="GND_RAIL" gate="G$1" pin="11"/>
-<pinref part="GND_RAIL" gate="G$1" pin="12"/>
-<pinref part="GND_RAIL" gate="G$1" pin="13"/>
-<pinref part="GND_RAIL" gate="G$1" pin="14"/>
-<pinref part="GND_RAIL" gate="G$1" pin="15"/>
-<pinref part="GND4" gate="1" pin="GND"/>
-<pinref part="GND_RAIL" gate="G$1" pin="17"/>
-<wire x1="157.48" y1="139.7" x2="160.02" y2="139.7" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="139.7" x2="160.02" y2="137.16" width="0.1524" layer="91"/>
-<junction x="160.02" y="137.16"/>
-<pinref part="GND_RAIL" gate="G$1" pin="18"/>
-<wire x1="157.48" y1="142.24" x2="160.02" y2="142.24" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="142.24" x2="160.02" y2="139.7" width="0.1524" layer="91"/>
-<junction x="160.02" y="139.7"/>
-<pinref part="GND_RAIL" gate="G$1" pin="19"/>
-<wire x1="157.48" y1="144.78" x2="160.02" y2="144.78" width="0.1524" layer="91"/>
-<wire x1="160.02" y1="144.78" x2="160.02" y2="142.24" width="0.1524" layer="91"/>
-<junction x="160.02" y="142.24"/>
-</segment>
-<segment>
-<wire x1="193.04" y1="106.68" x2="193.04" y2="104.14" width="0.1524" layer="91"/>
+<wire x1="127" y1="15.24" x2="127" y2="12.7" width="0.1524" layer="91"/>
 <pinref part="GND5" gate="1" pin="GND"/>
-<pinref part="S2" gate="G$1" pin="1"/>
+<pinref part="SW2" gate="G$1" pin="1"/>
+<pinref part="GND" gate="G$1" pin="1"/>
+<wire x1="127" y1="12.7" x2="127" y2="7.62" width="0.1524" layer="91"/>
+<wire x1="132.08" y1="12.7" x2="127" y2="12.7" width="0.1524" layer="91"/>
+<junction x="127" y="12.7"/>
 </segment>
 <segment>
-<wire x1="88.9" y1="83.82" x2="96.52" y2="83.82" width="0.1524" layer="91"/>
+<wire x1="63.5" y1="81.28" x2="71.12" y2="81.28" width="0.1524" layer="91"/>
 <pinref part="ICSP" gate="G$1" pin="6"/>
 <pinref part="GND10" gate="1" pin="GND"/>
-<wire x1="96.52" y1="83.82" x2="96.52" y2="81.28" width="0.1524" layer="91"/>
+<wire x1="71.12" y1="81.28" x2="71.12" y2="78.74" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="JP8" gate="G$1" pin="GND@0"/>
-<wire x1="43.18" y1="121.92" x2="40.64" y2="121.92" width="0.1524" layer="91"/>
-<wire x1="40.64" y1="121.92" x2="40.64" y2="119.38" width="0.1524" layer="91"/>
+<wire x1="38.1" y1="116.84" x2="35.56" y2="116.84" width="0.1524" layer="91"/>
+<wire x1="35.56" y1="116.84" x2="35.56" y2="114.3" width="0.1524" layer="91"/>
 <pinref part="GND8" gate="1" pin="GND"/>
 <pinref part="JP8" gate="G$1" pin="GND@1"/>
-<wire x1="40.64" y1="119.38" x2="40.64" y2="116.84" width="0.1524" layer="91"/>
-<wire x1="43.18" y1="124.46" x2="40.64" y2="124.46" width="0.1524" layer="91"/>
-<wire x1="40.64" y1="124.46" x2="40.64" y2="121.92" width="0.1524" layer="91"/>
-<junction x="40.64" y="121.92"/>
+<wire x1="35.56" y1="114.3" x2="35.56" y2="111.76" width="0.1524" layer="91"/>
+<wire x1="38.1" y1="119.38" x2="35.56" y2="119.38" width="0.1524" layer="91"/>
+<wire x1="35.56" y1="119.38" x2="35.56" y2="116.84" width="0.1524" layer="91"/>
+<junction x="35.56" y="116.84"/>
 <pinref part="JP11" gate="G$1" pin="3"/>
 <pinref part="JP8" gate="G$1" pin="GND@2"/>
-<wire x1="17.78" y1="127" x2="40.64" y2="127" width="0.1524" layer="91"/>
-<wire x1="40.64" y1="127" x2="43.18" y2="127" width="0.1524" layer="91"/>
-<wire x1="40.64" y1="127" x2="40.64" y2="124.46" width="0.1524" layer="91"/>
-<junction x="40.64" y="127"/>
-<junction x="40.64" y="124.46"/>
+<wire x1="12.7" y1="121.92" x2="35.56" y2="121.92" width="0.1524" layer="91"/>
+<wire x1="35.56" y1="121.92" x2="38.1" y2="121.92" width="0.1524" layer="91"/>
+<wire x1="35.56" y1="121.92" x2="35.56" y2="119.38" width="0.1524" layer="91"/>
+<junction x="35.56" y="121.92"/>
+<junction x="35.56" y="119.38"/>
 <pinref part="JP11" gate="G$1" pin="2"/>
-<wire x1="17.78" y1="124.46" x2="35.56" y2="124.46" width="0.1524" layer="91"/>
-<wire x1="35.56" y1="124.46" x2="35.56" y2="119.38" width="0.1524" layer="91"/>
-<wire x1="35.56" y1="119.38" x2="40.64" y2="119.38" width="0.1524" layer="91"/>
-<junction x="40.64" y="119.38"/>
+<wire x1="12.7" y1="119.38" x2="30.48" y2="119.38" width="0.1524" layer="91"/>
+<wire x1="30.48" y1="119.38" x2="30.48" y2="114.3" width="0.1524" layer="91"/>
+<wire x1="30.48" y1="114.3" x2="35.56" y2="114.3" width="0.1524" layer="91"/>
+<junction x="35.56" y="114.3"/>
 </segment>
 <segment>
 <pinref part="SJ3" gate="G$1" pin="2"/>
-<wire x1="60.96" y1="38.1" x2="71.12" y2="38.1" width="0.1524" layer="91"/>
+<wire x1="55.88" y1="30.48" x2="66.04" y2="30.48" width="0.1524" layer="91"/>
 <pinref part="GND6" gate="1" pin="GND"/>
-<wire x1="71.12" y1="38.1" x2="71.12" y2="27.94" width="0.1524" layer="91"/>
+<wire x1="66.04" y1="30.48" x2="66.04" y2="20.32" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="JP7" gate="G$1" pin="3"/>
 <pinref part="SJ3" gate="G$1" pin="1"/>
-<wire x1="48.26" y1="38.1" x2="50.8" y2="38.1" width="0.1524" layer="91"/>
+<wire x1="43.18" y1="30.48" x2="45.72" y2="30.48" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="JP2" gate="G$1" pin="3"/>
 <pinref part="GND7" gate="1" pin="GND"/>
-<wire x1="27.94" y1="38.1" x2="12.7" y2="38.1" width="0.1524" layer="91"/>
-<wire x1="12.7" y1="38.1" x2="12.7" y2="27.94" width="0.1524" layer="91"/>
+<wire x1="22.86" y1="30.48" x2="7.62" y2="30.48" width="0.1524" layer="91"/>
+<wire x1="7.62" y1="30.48" x2="7.62" y2="20.32" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="GND_RAIL_1" gate="G$1" pin="7"/>
+<wire x1="130.81" y1="119.38" x2="134.62" y2="119.38" width="0.1524" layer="91"/>
+<wire x1="134.62" y1="119.38" x2="134.62" y2="116.84" width="0.1524" layer="91"/>
+<pinref part="GND_RAIL_1" gate="G$1" pin="6"/>
+<wire x1="134.62" y1="116.84" x2="130.81" y2="116.84" width="0.1524" layer="91"/>
+<pinref part="GND_RAIL_1" gate="G$1" pin="5"/>
+<wire x1="134.62" y1="116.84" x2="134.62" y2="114.3" width="0.1524" layer="91"/>
+<wire x1="134.62" y1="114.3" x2="130.81" y2="114.3" width="0.1524" layer="91"/>
+<junction x="134.62" y="116.84"/>
+<pinref part="GND_RAIL_1" gate="G$1" pin="4"/>
+<wire x1="134.62" y1="114.3" x2="134.62" y2="111.76" width="0.1524" layer="91"/>
+<wire x1="134.62" y1="111.76" x2="130.81" y2="111.76" width="0.1524" layer="91"/>
+<junction x="134.62" y="114.3"/>
+<pinref part="GND_RAIL_1" gate="G$1" pin="3"/>
+<wire x1="134.62" y1="111.76" x2="134.62" y2="109.22" width="0.1524" layer="91"/>
+<wire x1="134.62" y1="109.22" x2="130.81" y2="109.22" width="0.1524" layer="91"/>
+<junction x="134.62" y="111.76"/>
+<pinref part="GND_RAIL_1" gate="G$1" pin="2"/>
+<wire x1="134.62" y1="109.22" x2="134.62" y2="106.68" width="0.1524" layer="91"/>
+<wire x1="134.62" y1="106.68" x2="130.81" y2="106.68" width="0.1524" layer="91"/>
+<junction x="134.62" y="109.22"/>
+<pinref part="GND_RAIL_1" gate="G$1" pin="1"/>
+<wire x1="134.62" y1="106.68" x2="134.62" y2="104.14" width="0.1524" layer="91"/>
+<wire x1="134.62" y1="104.14" x2="130.81" y2="104.14" width="0.1524" layer="91"/>
+<junction x="134.62" y="106.68"/>
+<pinref part="GND4" gate="1" pin="GND"/>
+<wire x1="134.62" y1="104.14" x2="134.62" y2="88.9" width="0.1524" layer="91"/>
+<junction x="134.62" y="104.14"/>
+<pinref part="GND_RAIL_2" gate="J$1" pin="3"/>
+<wire x1="134.62" y1="88.9" x2="134.62" y2="86.36" width="0.1524" layer="91"/>
+<wire x1="134.62" y1="86.36" x2="134.62" y2="83.82" width="0.1524" layer="91"/>
+<wire x1="134.62" y1="83.82" x2="134.62" y2="76.2" width="0.1524" layer="91"/>
+<wire x1="130.81" y1="88.9" x2="134.62" y2="88.9" width="0.1524" layer="91"/>
+<junction x="134.62" y="88.9"/>
+<pinref part="GND_RAIL_2" gate="J$1" pin="2"/>
+<wire x1="134.62" y1="86.36" x2="130.81" y2="86.36" width="0.1524" layer="91"/>
+<junction x="134.62" y="86.36"/>
+<pinref part="GND_RAIL_2" gate="J$1" pin="1"/>
+<wire x1="130.81" y1="83.82" x2="134.62" y2="83.82" width="0.1524" layer="91"/>
+<junction x="134.62" y="83.82"/>
 </segment>
 </net>
 <net name="N$6" class="0">
 <segment>
-<wire x1="220.98" y1="119.38" x2="220.98" y2="116.84" width="0.1524" layer="91"/>
+<wire x1="99.06" y1="27.94" x2="99.06" y2="25.4" width="0.1524" layer="91"/>
 <pinref part="R1" gate="G$1" pin="2"/>
-<pinref part="LED1" gate="G$1" pin="C"/>
+<pinref part="L1" gate="G$1" pin="C"/>
 </segment>
 </net>
 <net name="N$7" class="0">
 <segment>
-<wire x1="233.68" y1="119.38" x2="233.68" y2="116.84" width="0.1524" layer="91"/>
+<wire x1="111.76" y1="27.94" x2="111.76" y2="25.4" width="0.1524" layer="91"/>
 <pinref part="R2" gate="G$1" pin="2"/>
-<pinref part="LED2" gate="G$1" pin="C"/>
-</segment>
-</net>
-<net name="LED1" class="0">
-<segment>
-<wire x1="220.98" y1="129.54" x2="220.98" y2="127" width="0.1524" layer="91"/>
-<pinref part="LED1" gate="G$1" pin="A"/>
-<pinref part="JP4" gate="G$1" pin="1"/>
-</segment>
-</net>
-<net name="LED2" class="0">
-<segment>
-<wire x1="233.68" y1="129.54" x2="233.68" y2="127" width="0.1524" layer="91"/>
-<pinref part="LED2" gate="G$1" pin="A"/>
-<pinref part="JP9" gate="G$1" pin="1"/>
+<pinref part="L2" gate="G$1" pin="C"/>
 </segment>
 </net>
 <net name="RX" class="0">
 <segment>
-<wire x1="91.44" y1="162.56" x2="68.58" y2="162.56" width="0.1524" layer="91"/>
-<label x="88.9" y="162.56" size="1.778" layer="95" font="vector" rot="MR0"/>
+<wire x1="86.36" y1="157.48" x2="63.5" y2="157.48" width="0.1524" layer="91"/>
+<label x="83.82" y="157.48" size="1.778" layer="95" font="vector" rot="MR0"/>
 <pinref part="JP12" gate="G$1" pin="1"/>
 <pinref part="JP8" gate="G$1" pin="RX"/>
-</segment>
-<segment>
-<pinref part="SJ2" gate="G$1" pin="2"/>
-<wire x1="71.12" y1="40.64" x2="73.66" y2="40.64" width="0.1524" layer="91"/>
-<label x="73.66" y="40.64" size="1.27" layer="95" font="vector" xref="yes"/>
 </segment>
 </net>
 <net name="TX" class="0">
 <segment>
-<label x="88.9" y="160.02" size="1.778" layer="95" font="vector" rot="MR0"/>
+<label x="83.82" y="154.94" size="1.778" layer="95" font="vector" rot="MR0"/>
 <pinref part="JP12" gate="G$1" pin="2"/>
 <pinref part="JP8" gate="G$1" pin="TX"/>
-<wire x1="68.58" y1="160.02" x2="91.44" y2="160.02" width="0.1524" layer="91"/>
-</segment>
-<segment>
-<pinref part="SJ1" gate="G$1" pin="2"/>
-<wire x1="63.5" y1="43.18" x2="73.66" y2="43.18" width="0.1524" layer="91"/>
-<label x="73.66" y="43.18" size="1.27" layer="95" font="vector" xref="yes"/>
+<wire x1="63.5" y1="154.94" x2="86.36" y2="154.94" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="D2" class="0">
 <segment>
-<wire x1="91.44" y1="157.48" x2="71.12" y2="157.48" width="0.1524" layer="91"/>
-<label x="88.9" y="157.48" size="1.778" layer="95" font="vector" rot="MR0"/>
+<wire x1="86.36" y1="152.4" x2="66.04" y2="152.4" width="0.1524" layer="91"/>
+<label x="83.82" y="152.4" size="1.778" layer="95" font="vector" rot="MR0"/>
 <pinref part="JP12" gate="G$1" pin="3"/>
 <pinref part="JP8" gate="G$1" pin="D2"/>
-<wire x1="68.58" y1="154.94" x2="71.12" y2="154.94" width="0.1524" layer="91"/>
-<wire x1="71.12" y1="154.94" x2="71.12" y2="157.48" width="0.1524" layer="91"/>
+<wire x1="63.5" y1="149.86" x2="66.04" y2="149.86" width="0.1524" layer="91"/>
+<wire x1="66.04" y1="149.86" x2="66.04" y2="152.4" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="D3" class="0">
 <segment>
-<wire x1="73.66" y1="154.94" x2="91.44" y2="154.94" width="0.1524" layer="91"/>
-<label x="88.9" y="154.94" size="1.778" layer="95" font="vector" rot="MR0"/>
+<wire x1="68.58" y1="149.86" x2="86.36" y2="149.86" width="0.1524" layer="91"/>
+<label x="83.82" y="149.86" size="1.778" layer="95" font="vector" rot="MR0"/>
 <pinref part="JP12" gate="G$1" pin="4"/>
 <pinref part="JP8" gate="G$1" pin="*D3"/>
-<wire x1="68.58" y1="152.4" x2="73.66" y2="152.4" width="0.1524" layer="91"/>
-<wire x1="73.66" y1="152.4" x2="73.66" y2="154.94" width="0.1524" layer="91"/>
+<wire x1="63.5" y1="147.32" x2="68.58" y2="147.32" width="0.1524" layer="91"/>
+<wire x1="68.58" y1="147.32" x2="68.58" y2="149.86" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="D4" class="0">
 <segment>
-<wire x1="91.44" y1="152.4" x2="76.2" y2="152.4" width="0.1524" layer="91"/>
-<label x="88.9" y="152.4" size="1.778" layer="95" font="vector" rot="MR0"/>
+<wire x1="86.36" y1="147.32" x2="71.12" y2="147.32" width="0.1524" layer="91"/>
+<label x="83.82" y="147.32" size="1.778" layer="95" font="vector" rot="MR0"/>
 <pinref part="JP12" gate="G$1" pin="5"/>
 <pinref part="JP8" gate="G$1" pin="D4"/>
-<wire x1="68.58" y1="149.86" x2="76.2" y2="149.86" width="0.1524" layer="91"/>
-<wire x1="76.2" y1="149.86" x2="76.2" y2="152.4" width="0.1524" layer="91"/>
+<wire x1="63.5" y1="144.78" x2="71.12" y2="144.78" width="0.1524" layer="91"/>
+<wire x1="71.12" y1="144.78" x2="71.12" y2="147.32" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="D5" class="0">
 <segment>
-<wire x1="78.74" y1="149.86" x2="91.44" y2="149.86" width="0.1524" layer="91"/>
-<label x="88.9" y="149.86" size="1.778" layer="95" font="vector" rot="MR0"/>
+<wire x1="73.66" y1="144.78" x2="86.36" y2="144.78" width="0.1524" layer="91"/>
+<label x="83.82" y="144.78" size="1.778" layer="95" font="vector" rot="MR0"/>
 <pinref part="JP12" gate="G$1" pin="6"/>
 <pinref part="JP8" gate="G$1" pin="*D5"/>
-<wire x1="68.58" y1="147.32" x2="78.74" y2="147.32" width="0.1524" layer="91"/>
-<wire x1="78.74" y1="147.32" x2="78.74" y2="149.86" width="0.1524" layer="91"/>
+<wire x1="63.5" y1="142.24" x2="73.66" y2="142.24" width="0.1524" layer="91"/>
+<wire x1="73.66" y1="142.24" x2="73.66" y2="144.78" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="D6" class="0">
 <segment>
-<wire x1="91.44" y1="147.32" x2="81.28" y2="147.32" width="0.1524" layer="91"/>
-<label x="88.9" y="147.32" size="1.778" layer="95" font="vector" rot="MR0"/>
+<wire x1="86.36" y1="142.24" x2="76.2" y2="142.24" width="0.1524" layer="91"/>
+<label x="83.82" y="142.24" size="1.778" layer="95" font="vector" rot="MR0"/>
 <pinref part="JP12" gate="G$1" pin="7"/>
 <pinref part="JP8" gate="G$1" pin="*D6"/>
-<wire x1="68.58" y1="144.78" x2="81.28" y2="144.78" width="0.1524" layer="91"/>
-<wire x1="81.28" y1="144.78" x2="81.28" y2="147.32" width="0.1524" layer="91"/>
+<wire x1="63.5" y1="139.7" x2="76.2" y2="139.7" width="0.1524" layer="91"/>
+<wire x1="76.2" y1="139.7" x2="76.2" y2="142.24" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="D7" class="0">
 <segment>
-<wire x1="83.82" y1="144.78" x2="91.44" y2="144.78" width="0.1524" layer="91"/>
-<label x="88.9" y="144.78" size="1.778" layer="95" font="vector" rot="MR0"/>
+<wire x1="78.74" y1="139.7" x2="86.36" y2="139.7" width="0.1524" layer="91"/>
+<label x="83.82" y="139.7" size="1.778" layer="95" font="vector" rot="MR0"/>
 <pinref part="JP12" gate="G$1" pin="8"/>
 <pinref part="JP8" gate="G$1" pin="D7"/>
-<wire x1="68.58" y1="142.24" x2="83.82" y2="142.24" width="0.1524" layer="91"/>
-<wire x1="83.82" y1="142.24" x2="83.82" y2="144.78" width="0.1524" layer="91"/>
+<wire x1="63.5" y1="137.16" x2="78.74" y2="137.16" width="0.1524" layer="91"/>
+<wire x1="78.74" y1="137.16" x2="78.74" y2="139.7" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="D8" class="0">
 <segment>
-<wire x1="91.44" y1="134.62" x2="86.36" y2="134.62" width="0.1524" layer="91"/>
-<label x="81.28" y="139.7" size="1.778" layer="95" font="vector" rot="MR0"/>
-<wire x1="86.36" y1="134.62" x2="86.36" y2="139.7" width="0.1524" layer="91"/>
+<wire x1="86.36" y1="129.54" x2="81.28" y2="129.54" width="0.1524" layer="91"/>
+<label x="76.2" y="134.62" size="1.778" layer="95" font="vector" rot="MR0"/>
+<wire x1="81.28" y1="129.54" x2="81.28" y2="134.62" width="0.1524" layer="91"/>
 <pinref part="JP8" gate="G$1" pin="D8"/>
-<wire x1="86.36" y1="139.7" x2="68.58" y2="139.7" width="0.1524" layer="91"/>
+<wire x1="81.28" y1="134.62" x2="63.5" y2="134.62" width="0.1524" layer="91"/>
 <pinref part="JP1" gate="G$1" pin="1"/>
 </segment>
 </net>
 <net name="D9" class="0">
 <segment>
-<wire x1="83.82" y1="132.08" x2="91.44" y2="132.08" width="0.1524" layer="91"/>
-<label x="81.28" y="137.16" size="1.778" layer="95" font="vector" rot="MR0"/>
-<wire x1="83.82" y1="132.08" x2="83.82" y2="137.16" width="0.1524" layer="91"/>
+<wire x1="78.74" y1="127" x2="86.36" y2="127" width="0.1524" layer="91"/>
+<label x="76.2" y="132.08" size="1.778" layer="95" font="vector" rot="MR0"/>
+<wire x1="78.74" y1="127" x2="78.74" y2="132.08" width="0.1524" layer="91"/>
 <pinref part="JP8" gate="G$1" pin="*D9"/>
-<wire x1="83.82" y1="137.16" x2="68.58" y2="137.16" width="0.1524" layer="91"/>
+<wire x1="78.74" y1="132.08" x2="63.5" y2="132.08" width="0.1524" layer="91"/>
 <pinref part="JP1" gate="G$1" pin="2"/>
 </segment>
 </net>
 <net name="D10" class="0">
 <segment>
-<wire x1="91.44" y1="129.54" x2="81.28" y2="129.54" width="0.1524" layer="91"/>
-<label x="88.9" y="129.54" size="1.778" layer="95" font="vector" rot="MR0"/>
-<wire x1="81.28" y1="129.54" x2="81.28" y2="134.62" width="0.1524" layer="91"/>
+<wire x1="86.36" y1="124.46" x2="76.2" y2="124.46" width="0.1524" layer="91"/>
+<label x="83.82" y="124.46" size="1.778" layer="95" font="vector" rot="MR0"/>
+<wire x1="76.2" y1="124.46" x2="76.2" y2="129.54" width="0.1524" layer="91"/>
 <pinref part="JP8" gate="G$1" pin="*D10"/>
-<wire x1="81.28" y1="134.62" x2="68.58" y2="134.62" width="0.1524" layer="91"/>
+<wire x1="76.2" y1="129.54" x2="63.5" y2="129.54" width="0.1524" layer="91"/>
 <pinref part="JP1" gate="G$1" pin="3"/>
+</segment>
+<segment>
+<pinref part="SJ2" gate="G$1" pin="2"/>
+<wire x1="66.04" y1="33.02" x2="81.28" y2="33.02" width="0.1524" layer="91"/>
+<label x="81.28" y="33.02" size="1.27" layer="95" font="vector" xref="yes"/>
 </segment>
 </net>
 <net name="D11" class="0">
 <segment>
-<wire x1="78.74" y1="127" x2="91.44" y2="127" width="0.1524" layer="91"/>
-<label x="88.9" y="127" size="1.778" layer="95" font="vector" rot="MR0"/>
-<wire x1="78.74" y1="127" x2="78.74" y2="132.08" width="0.1524" layer="91"/>
+<wire x1="73.66" y1="121.92" x2="86.36" y2="121.92" width="0.1524" layer="91"/>
+<label x="83.82" y="121.92" size="1.778" layer="95" font="vector" rot="MR0"/>
+<wire x1="73.66" y1="121.92" x2="73.66" y2="127" width="0.1524" layer="91"/>
 <pinref part="JP8" gate="G$1" pin="*D11"/>
-<wire x1="78.74" y1="132.08" x2="68.58" y2="132.08" width="0.1524" layer="91"/>
+<wire x1="73.66" y1="127" x2="63.5" y2="127" width="0.1524" layer="91"/>
 <pinref part="JP1" gate="G$1" pin="4"/>
+</segment>
+<segment>
+<pinref part="SJ1" gate="G$1" pin="2"/>
+<wire x1="58.42" y1="35.56" x2="63.5" y2="35.56" width="0.1524" layer="91"/>
+<wire x1="63.5" y1="35.56" x2="63.5" y2="45.72" width="0.1524" layer="91"/>
+<wire x1="63.5" y1="45.72" x2="78.74" y2="45.72" width="0.1524" layer="91"/>
+<label x="78.74" y="45.72" size="1.27" layer="95" font="vector" xref="yes"/>
 </segment>
 </net>
 <net name="D12" class="0">
 <segment>
-<wire x1="91.44" y1="124.46" x2="76.2" y2="124.46" width="0.1524" layer="91"/>
-<label x="88.9" y="124.46" size="1.778" layer="95" font="vector" rot="MR0"/>
-<wire x1="76.2" y1="124.46" x2="76.2" y2="129.54" width="0.1524" layer="91"/>
+<wire x1="86.36" y1="119.38" x2="71.12" y2="119.38" width="0.1524" layer="91"/>
+<label x="83.82" y="119.38" size="1.778" layer="95" font="vector" rot="MR0"/>
+<wire x1="71.12" y1="119.38" x2="71.12" y2="124.46" width="0.1524" layer="91"/>
 <pinref part="JP8" gate="G$1" pin="D12"/>
-<wire x1="76.2" y1="129.54" x2="68.58" y2="129.54" width="0.1524" layer="91"/>
+<wire x1="71.12" y1="124.46" x2="63.5" y2="124.46" width="0.1524" layer="91"/>
 <pinref part="JP1" gate="G$1" pin="5"/>
 </segment>
 </net>
 <net name="D13" class="0">
 <segment>
-<wire x1="73.66" y1="121.92" x2="91.44" y2="121.92" width="0.1524" layer="91"/>
-<label x="88.9" y="121.92" size="1.778" layer="95" font="vector" rot="MR0"/>
-<wire x1="73.66" y1="121.92" x2="73.66" y2="127" width="0.1524" layer="91"/>
+<wire x1="68.58" y1="116.84" x2="86.36" y2="116.84" width="0.1524" layer="91"/>
+<label x="83.82" y="116.84" size="1.778" layer="95" font="vector" rot="MR0"/>
+<wire x1="68.58" y1="116.84" x2="68.58" y2="121.92" width="0.1524" layer="91"/>
 <pinref part="JP8" gate="G$1" pin="D13"/>
-<wire x1="73.66" y1="127" x2="68.58" y2="127" width="0.1524" layer="91"/>
+<wire x1="68.58" y1="121.92" x2="63.5" y2="121.92" width="0.1524" layer="91"/>
 <pinref part="JP1" gate="G$1" pin="6"/>
 </segment>
 </net>
 <net name="AREF" class="0">
 <segment>
-<wire x1="78.74" y1="116.84" x2="91.44" y2="116.84" width="0.1524" layer="91"/>
+<wire x1="73.66" y1="111.76" x2="86.36" y2="111.76" width="0.1524" layer="91"/>
 <pinref part="JP1" gate="G$1" pin="8"/>
-<label x="78.74" y="116.84" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="73.66" y="111.76" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 <segment>
 <pinref part="JP8" gate="G$1" pin="AREF"/>
-<wire x1="43.18" y1="129.54" x2="40.64" y2="129.54" width="0.1524" layer="91"/>
-<label x="40.64" y="129.54" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<wire x1="38.1" y1="124.46" x2="35.56" y2="124.46" width="0.1524" layer="91"/>
+<label x="35.56" y="124.46" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="RESET" class="0">
 <segment>
-<wire x1="71.12" y1="83.82" x2="63.5" y2="83.82" width="0.1524" layer="91"/>
+<wire x1="45.72" y1="81.28" x2="38.1" y2="81.28" width="0.1524" layer="91"/>
 <pinref part="ICSP" gate="G$1" pin="5"/>
-<label x="63.5" y="83.82" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="38.1" y="81.28" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 <segment>
 <pinref part="JP11" gate="G$1" pin="6"/>
-<wire x1="17.78" y1="134.62" x2="27.94" y2="134.62" width="0.1524" layer="91"/>
-<wire x1="27.94" y1="134.62" x2="27.94" y2="139.7" width="0.1524" layer="91"/>
+<wire x1="12.7" y1="129.54" x2="22.86" y2="129.54" width="0.1524" layer="91"/>
+<wire x1="22.86" y1="129.54" x2="22.86" y2="134.62" width="0.1524" layer="91"/>
 <pinref part="JP8" gate="G$1" pin="RES"/>
-<wire x1="27.94" y1="139.7" x2="43.18" y2="139.7" width="0.1524" layer="91"/>
-<wire x1="27.94" y1="134.62" x2="27.94" y2="101.6" width="0.1524" layer="91"/>
-<junction x="27.94" y="134.62"/>
-<wire x1="20.32" y1="106.68" x2="20.32" y2="101.6" width="0.1524" layer="91"/>
+<wire x1="22.86" y1="134.62" x2="38.1" y2="134.62" width="0.1524" layer="91"/>
+<wire x1="22.86" y1="129.54" x2="22.86" y2="96.52" width="0.1524" layer="91"/>
+<junction x="22.86" y="129.54"/>
+<wire x1="15.24" y1="101.6" x2="15.24" y2="96.52" width="0.1524" layer="91"/>
 <pinref part="S4" gate="G$1" pin="2"/>
-<label x="20.32" y="106.68" size="1.27" layer="95" font="vector" rot="R90" xref="yes"/>
-<wire x1="20.32" y1="101.6" x2="20.32" y2="96.52" width="0.1524" layer="91"/>
-<wire x1="27.94" y1="101.6" x2="20.32" y2="101.6" width="0.1524" layer="91"/>
-<junction x="20.32" y="101.6"/>
+<label x="15.24" y="101.6" size="1.27" layer="95" font="vector" rot="R90" xref="yes"/>
+<wire x1="15.24" y1="96.52" x2="15.24" y2="91.44" width="0.1524" layer="91"/>
+<wire x1="22.86" y1="96.52" x2="15.24" y2="96.52" width="0.1524" layer="91"/>
+<junction x="15.24" y="96.52"/>
 </segment>
 </net>
 <net name="5V" class="1">
 <segment>
-<wire x1="134.62" y1="99.06" x2="137.16" y2="99.06" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="99.06" x2="137.16" y2="101.6" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="101.6" x2="137.16" y2="104.14" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="104.14" x2="137.16" y2="106.68" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="106.68" x2="137.16" y2="109.22" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="109.22" x2="137.16" y2="111.76" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="111.76" x2="137.16" y2="114.3" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="114.3" x2="137.16" y2="116.84" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="116.84" x2="137.16" y2="119.38" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="119.38" x2="137.16" y2="121.92" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="121.92" x2="137.16" y2="124.46" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="124.46" x2="137.16" y2="127" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="127" x2="137.16" y2="129.54" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="129.54" x2="137.16" y2="132.08" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="132.08" x2="137.16" y2="134.62" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="134.62" x2="137.16" y2="137.16" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="137.16" x2="137.16" y2="139.7" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="139.7" x2="137.16" y2="142.24" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="142.24" x2="137.16" y2="144.78" width="0.1524" layer="91"/>
-<wire x1="137.16" y1="144.78" x2="137.16" y2="149.86" width="0.1524" layer="91"/>
-<wire x1="134.62" y1="137.16" x2="137.16" y2="137.16" width="0.1524" layer="91"/>
-<wire x1="134.62" y1="134.62" x2="137.16" y2="134.62" width="0.1524" layer="91"/>
-<wire x1="134.62" y1="132.08" x2="137.16" y2="132.08" width="0.1524" layer="91"/>
-<wire x1="134.62" y1="129.54" x2="137.16" y2="129.54" width="0.1524" layer="91"/>
-<wire x1="134.62" y1="127" x2="137.16" y2="127" width="0.1524" layer="91"/>
-<wire x1="134.62" y1="124.46" x2="137.16" y2="124.46" width="0.1524" layer="91"/>
-<wire x1="134.62" y1="121.92" x2="137.16" y2="121.92" width="0.1524" layer="91"/>
-<wire x1="134.62" y1="119.38" x2="137.16" y2="119.38" width="0.1524" layer="91"/>
-<wire x1="134.62" y1="116.84" x2="137.16" y2="116.84" width="0.1524" layer="91"/>
-<wire x1="134.62" y1="114.3" x2="137.16" y2="114.3" width="0.1524" layer="91"/>
-<wire x1="134.62" y1="111.76" x2="137.16" y2="111.76" width="0.1524" layer="91"/>
-<wire x1="134.62" y1="109.22" x2="137.16" y2="109.22" width="0.1524" layer="91"/>
-<wire x1="134.62" y1="106.68" x2="137.16" y2="106.68" width="0.1524" layer="91"/>
-<wire x1="134.62" y1="104.14" x2="137.16" y2="104.14" width="0.1524" layer="91"/>
-<wire x1="134.62" y1="101.6" x2="137.16" y2="101.6" width="0.1524" layer="91"/>
-<junction x="137.16" y="137.16"/>
-<junction x="137.16" y="134.62"/>
-<junction x="137.16" y="132.08"/>
-<junction x="137.16" y="129.54"/>
-<junction x="137.16" y="127"/>
-<junction x="137.16" y="124.46"/>
-<junction x="137.16" y="121.92"/>
-<junction x="137.16" y="119.38"/>
-<junction x="137.16" y="116.84"/>
-<junction x="137.16" y="114.3"/>
-<junction x="137.16" y="111.76"/>
-<junction x="137.16" y="109.22"/>
-<junction x="137.16" y="106.68"/>
-<junction x="137.16" y="104.14"/>
-<junction x="137.16" y="101.6"/>
-<pinref part="5V_RAIL" gate="G$1" pin="1"/>
-<pinref part="5V_RAIL" gate="G$1" pin="16"/>
-<pinref part="5V_RAIL" gate="G$1" pin="15"/>
-<pinref part="5V_RAIL" gate="G$1" pin="14"/>
-<pinref part="5V_RAIL" gate="G$1" pin="13"/>
-<pinref part="5V_RAIL" gate="G$1" pin="12"/>
-<pinref part="5V_RAIL" gate="G$1" pin="11"/>
-<pinref part="5V_RAIL" gate="G$1" pin="10"/>
-<pinref part="5V_RAIL" gate="G$1" pin="9"/>
-<pinref part="5V_RAIL" gate="G$1" pin="8"/>
-<pinref part="5V_RAIL" gate="G$1" pin="7"/>
-<pinref part="5V_RAIL" gate="G$1" pin="6"/>
-<pinref part="5V_RAIL" gate="G$1" pin="5"/>
-<pinref part="5V_RAIL" gate="G$1" pin="4"/>
-<pinref part="5V_RAIL" gate="G$1" pin="3"/>
-<pinref part="5V_RAIL" gate="G$1" pin="2"/>
-<pinref part="P+2" gate="G$1" pin="5V"/>
-<pinref part="5V_RAIL" gate="G$1" pin="17"/>
-<wire x1="134.62" y1="139.7" x2="137.16" y2="139.7" width="0.1524" layer="91"/>
-<junction x="137.16" y="139.7"/>
-<pinref part="5V_RAIL" gate="G$1" pin="18"/>
-<wire x1="134.62" y1="142.24" x2="137.16" y2="142.24" width="0.1524" layer="91"/>
-<junction x="137.16" y="142.24"/>
-<pinref part="5V_RAIL" gate="G$1" pin="19"/>
-<wire x1="134.62" y1="144.78" x2="137.16" y2="144.78" width="0.1524" layer="91"/>
-<junction x="137.16" y="144.78"/>
-</segment>
-<segment>
-<wire x1="88.9" y1="88.9" x2="96.52" y2="88.9" width="0.1524" layer="91"/>
+<wire x1="63.5" y1="86.36" x2="71.12" y2="86.36" width="0.1524" layer="91"/>
 <pinref part="ICSP" gate="G$1" pin="2"/>
 <pinref part="P+5" gate="G$1" pin="5V"/>
-<wire x1="96.52" y1="88.9" x2="96.52" y2="93.98" width="0.1524" layer="91"/>
+<wire x1="71.12" y1="86.36" x2="71.12" y2="91.44" width="0.1524" layer="91"/>
 </segment>
 <segment>
-<wire x1="193.04" y1="137.16" x2="193.04" y2="134.62" width="0.1524" layer="91"/>
+<wire x1="127" y1="50.8" x2="127" y2="45.72" width="0.1524" layer="91"/>
 <pinref part="R4" gate="G$1" pin="2"/>
 <pinref part="P+1" gate="G$1" pin="5V"/>
+<pinref part="5V" gate="G$1" pin="1"/>
+<wire x1="127" y1="45.72" x2="127" y2="43.18" width="0.1524" layer="91"/>
+<wire x1="132.08" y1="45.72" x2="127" y2="45.72" width="0.1524" layer="91"/>
+<junction x="127" y="45.72"/>
 </segment>
 <segment>
 <pinref part="JP11" gate="G$1" pin="4"/>
-<wire x1="17.78" y1="129.54" x2="33.02" y2="129.54" width="0.1524" layer="91"/>
-<wire x1="33.02" y1="129.54" x2="33.02" y2="134.62" width="0.1524" layer="91"/>
+<wire x1="12.7" y1="124.46" x2="27.94" y2="124.46" width="0.1524" layer="91"/>
+<wire x1="27.94" y1="124.46" x2="27.94" y2="129.54" width="0.1524" layer="91"/>
 <pinref part="JP8" gate="G$1" pin="5V"/>
-<wire x1="33.02" y1="134.62" x2="43.18" y2="134.62" width="0.1524" layer="91"/>
+<wire x1="27.94" y1="129.54" x2="38.1" y2="129.54" width="0.1524" layer="91"/>
 <pinref part="P+4" gate="G$1" pin="5V"/>
-<wire x1="33.02" y1="144.78" x2="33.02" y2="134.62" width="0.1524" layer="91"/>
-<junction x="33.02" y="134.62"/>
+<wire x1="27.94" y1="139.7" x2="27.94" y2="129.54" width="0.1524" layer="91"/>
+<junction x="27.94" y="129.54"/>
 </segment>
 <segment>
 <pinref part="SJ4" gate="G$1" pin="2"/>
-<wire x1="66.04" y1="35.56" x2="81.28" y2="35.56" width="0.1524" layer="91"/>
-<wire x1="81.28" y1="35.56" x2="81.28" y2="43.18" width="0.1524" layer="91"/>
+<wire x1="60.96" y1="27.94" x2="87.63" y2="27.94" width="0.1524" layer="91"/>
+<wire x1="87.63" y1="27.94" x2="87.63" y2="50.8" width="0.1524" layer="91"/>
 <pinref part="P+3" gate="G$1" pin="5V"/>
 </segment>
-</net>
-<net name="BUTTON" class="0">
 <segment>
-<wire x1="193.04" y1="116.84" x2="193.04" y2="119.38" width="0.1524" layer="91"/>
-<label x="180.34" y="119.38" size="1.778" layer="95" font="vector"/>
-<pinref part="R4" gate="G$1" pin="1"/>
-<pinref part="S2" gate="G$1" pin="2"/>
-<pinref part="JP3" gate="G$1" pin="1"/>
-<wire x1="193.04" y1="119.38" x2="193.04" y2="124.46" width="0.1524" layer="91"/>
-<wire x1="198.12" y1="119.38" x2="193.04" y2="119.38" width="0.1524" layer="91"/>
-<junction x="193.04" y="119.38"/>
+<pinref part="5V_RAIL" gate="G$1" pin="7"/>
+<wire x1="113.03" y1="119.38" x2="116.84" y2="119.38" width="0.1524" layer="91"/>
+<pinref part="5V_RAIL" gate="G$1" pin="6"/>
+<wire x1="116.84" y1="119.38" x2="116.84" y2="116.84" width="0.1524" layer="91"/>
+<wire x1="116.84" y1="116.84" x2="113.03" y2="116.84" width="0.1524" layer="91"/>
+<pinref part="5V_RAIL" gate="G$1" pin="5"/>
+<wire x1="116.84" y1="116.84" x2="116.84" y2="114.3" width="0.1524" layer="91"/>
+<wire x1="116.84" y1="114.3" x2="113.03" y2="114.3" width="0.1524" layer="91"/>
+<junction x="116.84" y="116.84"/>
+<pinref part="5V_RAIL" gate="G$1" pin="4"/>
+<wire x1="116.84" y1="114.3" x2="116.84" y2="111.76" width="0.1524" layer="91"/>
+<wire x1="116.84" y1="111.76" x2="113.03" y2="111.76" width="0.1524" layer="91"/>
+<junction x="116.84" y="114.3"/>
+<pinref part="5V_RAIL" gate="G$1" pin="3"/>
+<wire x1="116.84" y1="111.76" x2="116.84" y2="109.22" width="0.1524" layer="91"/>
+<wire x1="116.84" y1="109.22" x2="113.03" y2="109.22" width="0.1524" layer="91"/>
+<junction x="116.84" y="111.76"/>
+<pinref part="5V_RAIL" gate="G$1" pin="2"/>
+<wire x1="116.84" y1="109.22" x2="116.84" y2="106.68" width="0.1524" layer="91"/>
+<wire x1="116.84" y1="106.68" x2="113.03" y2="106.68" width="0.1524" layer="91"/>
+<junction x="116.84" y="109.22"/>
+<pinref part="5V_RAIL" gate="G$1" pin="1"/>
+<wire x1="116.84" y1="106.68" x2="116.84" y2="104.14" width="0.1524" layer="91"/>
+<wire x1="116.84" y1="104.14" x2="113.03" y2="104.14" width="0.1524" layer="91"/>
+<junction x="116.84" y="106.68"/>
+<pinref part="P+2" gate="G$1" pin="5V"/>
+<wire x1="116.84" y1="119.38" x2="116.84" y2="124.46" width="0.1524" layer="91"/>
+<junction x="116.84" y="119.38"/>
 </segment>
 </net>
 <net name="MOSI_NC" class="0">
 <segment>
-<wire x1="88.9" y1="86.36" x2="96.52" y2="86.36" width="0.1524" layer="91"/>
+<wire x1="63.5" y1="83.82" x2="71.12" y2="83.82" width="0.1524" layer="91"/>
 <pinref part="ICSP" gate="G$1" pin="4"/>
-<label x="96.52" y="86.36" size="1.27" layer="95" font="vector" xref="yes"/>
+<label x="71.12" y="83.82" size="1.27" layer="95" font="vector" xref="yes"/>
 </segment>
 </net>
 <net name="MISO_NC" class="0">
 <segment>
-<wire x1="71.12" y1="88.9" x2="63.5" y2="88.9" width="0.1524" layer="91"/>
+<wire x1="45.72" y1="86.36" x2="38.1" y2="86.36" width="0.1524" layer="91"/>
 <pinref part="ICSP" gate="G$1" pin="1"/>
-<label x="63.5" y="88.9" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="38.1" y="86.36" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="SCK_NC" class="0">
 <segment>
-<wire x1="71.12" y1="86.36" x2="63.5" y2="86.36" width="0.1524" layer="91"/>
+<wire x1="45.72" y1="83.82" x2="38.1" y2="83.82" width="0.1524" layer="91"/>
 <pinref part="ICSP" gate="G$1" pin="3"/>
-<label x="63.5" y="86.36" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<label x="38.1" y="83.82" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="NC1" class="0">
 <segment>
-<wire x1="48.26" y1="33.02" x2="53.34" y2="33.02" width="0.1524" layer="91"/>
+<wire x1="43.18" y1="25.4" x2="48.26" y2="25.4" width="0.1524" layer="91"/>
 <pinref part="JP7" gate="G$1" pin="1"/>
-<label x="53.34" y="33.02" size="1.27" layer="95" font="vector" xref="yes"/>
+<label x="48.26" y="25.4" size="1.27" layer="95" font="vector" xref="yes"/>
 </segment>
 <segment>
 <pinref part="JP2" gate="G$1" pin="1"/>
-<wire x1="27.94" y1="33.02" x2="22.86" y2="33.02" width="0.1524" layer="91"/>
-<label x="22.86" y="33.02" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<wire x1="22.86" y1="25.4" x2="17.78" y2="25.4" width="0.1524" layer="91"/>
+<label x="17.78" y="25.4" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="NC2" class="0">
 <segment>
-<wire x1="48.26" y1="45.72" x2="50.8" y2="45.72" width="0.1524" layer="91"/>
+<wire x1="43.18" y1="38.1" x2="45.72" y2="38.1" width="0.1524" layer="91"/>
 <pinref part="JP7" gate="G$1" pin="6"/>
-<label x="50.8" y="45.72" size="1.27" layer="95" font="vector" xref="yes"/>
+<label x="45.72" y="38.1" size="1.27" layer="95" font="vector" xref="yes"/>
 </segment>
 <segment>
 <pinref part="JP2" gate="G$1" pin="6"/>
-<wire x1="27.94" y1="45.72" x2="22.86" y2="45.72" width="0.1524" layer="91"/>
-<label x="22.86" y="45.72" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<wire x1="22.86" y1="38.1" x2="17.78" y2="38.1" width="0.1524" layer="91"/>
+<label x="17.78" y="38.1" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="N$1" class="0">
 <segment>
 <pinref part="JP11" gate="G$1" pin="7"/>
-<wire x1="17.78" y1="137.16" x2="25.4" y2="137.16" width="0.1524" layer="91"/>
-<wire x1="25.4" y1="137.16" x2="25.4" y2="142.24" width="0.1524" layer="91"/>
+<wire x1="12.7" y1="132.08" x2="20.32" y2="132.08" width="0.1524" layer="91"/>
+<wire x1="20.32" y1="132.08" x2="20.32" y2="137.16" width="0.1524" layer="91"/>
 <pinref part="JP8" gate="G$1" pin="IOREF"/>
-<wire x1="25.4" y1="142.24" x2="43.18" y2="142.24" width="0.1524" layer="91"/>
+<wire x1="20.32" y1="137.16" x2="38.1" y2="137.16" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="3.3" class="0">
 <segment>
 <pinref part="JP11" gate="G$1" pin="5"/>
 <pinref part="JP8" gate="G$1" pin="3.3V"/>
-<wire x1="17.78" y1="132.08" x2="43.18" y2="132.08" width="0.1524" layer="91"/>
+<wire x1="12.7" y1="127" x2="38.1" y2="127" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="SDA" class="0">
 <segment>
 <pinref part="JP1" gate="G$1" pin="9"/>
-<wire x1="91.44" y1="114.3" x2="71.12" y2="114.3" width="0.1524" layer="91"/>
-<wire x1="71.12" y1="114.3" x2="71.12" y2="124.46" width="0.1524" layer="91"/>
+<wire x1="86.36" y1="109.22" x2="66.04" y2="109.22" width="0.1524" layer="91"/>
+<wire x1="66.04" y1="109.22" x2="66.04" y2="119.38" width="0.1524" layer="91"/>
 <pinref part="JP8" gate="G$1" pin="SDA"/>
-<wire x1="71.12" y1="124.46" x2="68.58" y2="124.46" width="0.1524" layer="91"/>
-<label x="78.74" y="114.3" size="1.778" layer="95" font="vector"/>
+<wire x1="66.04" y1="119.38" x2="63.5" y2="119.38" width="0.1524" layer="91"/>
+<label x="73.66" y="109.22" size="1.778" layer="95" font="vector"/>
 </segment>
 </net>
 <net name="SCL" class="0">
 <segment>
 <pinref part="JP8" gate="G$1" pin="SCL"/>
-<wire x1="68.58" y1="121.92" x2="68.58" y2="111.76" width="0.1524" layer="91"/>
+<wire x1="63.5" y1="116.84" x2="63.5" y2="106.68" width="0.1524" layer="91"/>
 <pinref part="JP1" gate="G$1" pin="10"/>
-<wire x1="68.58" y1="111.76" x2="91.44" y2="111.76" width="0.1524" layer="91"/>
-<label x="78.74" y="111.76" size="1.778" layer="95" font="vector"/>
+<wire x1="63.5" y1="106.68" x2="86.36" y2="106.68" width="0.1524" layer="91"/>
+<label x="73.66" y="106.68" size="1.778" layer="95" font="vector"/>
 </segment>
 </net>
 <net name="VIN" class="0">
 <segment>
 <pinref part="JP11" gate="G$1" pin="1"/>
-<wire x1="17.78" y1="121.92" x2="30.48" y2="121.92" width="0.1524" layer="91"/>
-<wire x1="30.48" y1="121.92" x2="30.48" y2="137.16" width="0.1524" layer="91"/>
+<wire x1="12.7" y1="116.84" x2="25.4" y2="116.84" width="0.1524" layer="91"/>
+<wire x1="25.4" y1="116.84" x2="25.4" y2="132.08" width="0.1524" layer="91"/>
 <pinref part="JP8" gate="G$1" pin="VIN"/>
-<wire x1="30.48" y1="137.16" x2="43.18" y2="137.16" width="0.1524" layer="91"/>
+<wire x1="25.4" y1="132.08" x2="38.1" y2="132.08" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="NC3" class="0">
 <segment>
 <pinref part="JP11" gate="G$1" pin="8"/>
-<wire x1="17.78" y1="139.7" x2="20.32" y2="139.7" width="0.1524" layer="91"/>
-<wire x1="20.32" y1="139.7" x2="20.32" y2="144.78" width="0.1524" layer="91"/>
-<wire x1="20.32" y1="144.78" x2="22.86" y2="144.78" width="0.1524" layer="91"/>
-<label x="22.86" y="144.78" size="1.27" layer="95" font="vector" xref="yes"/>
+<wire x1="12.7" y1="134.62" x2="15.24" y2="134.62" width="0.1524" layer="91"/>
+<wire x1="15.24" y1="134.62" x2="15.24" y2="139.7" width="0.1524" layer="91"/>
+<wire x1="15.24" y1="139.7" x2="17.78" y2="139.7" width="0.1524" layer="91"/>
+<label x="17.78" y="139.7" size="1.27" layer="95" font="vector" xref="yes"/>
 </segment>
 </net>
 <net name="RX-I" class="0">
 <segment>
 <pinref part="JP7" gate="G$1" pin="5"/>
 <pinref part="SJ1" gate="G$1" pin="1"/>
-<wire x1="53.34" y1="43.18" x2="48.26" y2="43.18" width="0.1524" layer="91"/>
+<wire x1="48.26" y1="35.56" x2="43.18" y2="35.56" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="JP2" gate="G$1" pin="5"/>
-<wire x1="27.94" y1="43.18" x2="22.86" y2="43.18" width="0.1524" layer="91"/>
-<label x="22.86" y="43.18" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<wire x1="22.86" y1="35.56" x2="17.78" y2="35.56" width="0.1524" layer="91"/>
+<label x="17.78" y="35.56" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="TX-O" class="0">
 <segment>
 <pinref part="JP7" gate="G$1" pin="4"/>
 <pinref part="SJ2" gate="G$1" pin="1"/>
-<wire x1="48.26" y1="40.64" x2="60.96" y2="40.64" width="0.1524" layer="91"/>
+<wire x1="43.18" y1="33.02" x2="55.88" y2="33.02" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="JP2" gate="G$1" pin="4"/>
-<wire x1="27.94" y1="40.64" x2="22.86" y2="40.64" width="0.1524" layer="91"/>
-<label x="22.86" y="40.64" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<wire x1="22.86" y1="33.02" x2="17.78" y2="33.02" width="0.1524" layer="91"/>
+<label x="17.78" y="33.02" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 </net>
 <net name="VCC" class="0">
 <segment>
 <pinref part="JP2" gate="G$1" pin="2"/>
-<wire x1="27.94" y1="35.56" x2="22.86" y2="35.56" width="0.1524" layer="91"/>
-<label x="22.86" y="35.56" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
+<wire x1="22.86" y1="27.94" x2="17.78" y2="27.94" width="0.1524" layer="91"/>
+<label x="17.78" y="27.94" size="1.27" layer="95" font="vector" rot="R180" xref="yes"/>
 </segment>
 <segment>
 <pinref part="JP7" gate="G$1" pin="2"/>
 <pinref part="SJ4" gate="G$1" pin="1"/>
-<wire x1="48.26" y1="35.56" x2="55.88" y2="35.56" width="0.1524" layer="91"/>
-</segment>
-</net>
-<net name="A0" class="0">
-<segment>
-<pinref part="JP10" gate="G$1" pin="6"/>
-<pinref part="JP8" gate="G$1" pin="A0"/>
-<wire x1="27.94" y1="170.18" x2="43.18" y2="170.18" width="0.1524" layer="91"/>
-<wire x1="43.18" y1="170.18" x2="43.18" y2="162.56" width="0.1524" layer="91"/>
+<wire x1="43.18" y1="27.94" x2="50.8" y2="27.94" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="A1" class="0">
 <segment>
 <pinref part="JP8" gate="G$1" pin="A1"/>
-<wire x1="43.18" y1="160.02" x2="40.64" y2="160.02" width="0.1524" layer="91"/>
-<wire x1="40.64" y1="160.02" x2="40.64" y2="167.64" width="0.1524" layer="91"/>
 <pinref part="JP10" gate="G$1" pin="5"/>
-<wire x1="40.64" y1="167.64" x2="27.94" y2="167.64" width="0.1524" layer="91"/>
+<wire x1="38.1" y1="154.94" x2="12.7" y2="154.94" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="A2" class="0">
 <segment>
-<pinref part="JP10" gate="G$1" pin="4"/>
-<wire x1="27.94" y1="165.1" x2="38.1" y2="165.1" width="0.1524" layer="91"/>
-<wire x1="38.1" y1="165.1" x2="38.1" y2="157.48" width="0.1524" layer="91"/>
 <pinref part="JP8" gate="G$1" pin="A2"/>
-<wire x1="38.1" y1="157.48" x2="43.18" y2="157.48" width="0.1524" layer="91"/>
-</segment>
-</net>
-<net name="A3" class="0">
-<segment>
-<pinref part="JP10" gate="G$1" pin="3"/>
-<wire x1="27.94" y1="162.56" x2="35.56" y2="162.56" width="0.1524" layer="91"/>
-<wire x1="35.56" y1="162.56" x2="35.56" y2="154.94" width="0.1524" layer="91"/>
-<pinref part="JP8" gate="G$1" pin="A3"/>
-<wire x1="35.56" y1="154.94" x2="43.18" y2="154.94" width="0.1524" layer="91"/>
-</segment>
-</net>
-<net name="A4" class="0">
-<segment>
-<pinref part="JP8" gate="G$1" pin="A4"/>
-<wire x1="43.18" y1="152.4" x2="33.02" y2="152.4" width="0.1524" layer="91"/>
-<wire x1="33.02" y1="152.4" x2="33.02" y2="160.02" width="0.1524" layer="91"/>
-<pinref part="JP10" gate="G$1" pin="2"/>
-<wire x1="33.02" y1="160.02" x2="27.94" y2="160.02" width="0.1524" layer="91"/>
+<pinref part="JP10" gate="G$1" pin="4"/>
+<wire x1="38.1" y1="152.4" x2="12.7" y2="152.4" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="A5" class="0">
 <segment>
 <pinref part="JP8" gate="G$1" pin="A5"/>
-<wire x1="30.48" y1="149.86" x2="43.18" y2="149.86" width="0.1524" layer="91"/>
-<wire x1="30.48" y1="149.86" x2="30.48" y2="157.48" width="0.1524" layer="91"/>
 <pinref part="JP10" gate="G$1" pin="1"/>
-<wire x1="30.48" y1="157.48" x2="27.94" y2="157.48" width="0.1524" layer="91"/>
+<wire x1="38.1" y1="144.78" x2="12.7" y2="144.78" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="N$3" class="0">
+<segment>
+<pinref part="JP8" gate="G$1" pin="A4"/>
+<pinref part="JP10" gate="G$1" pin="2"/>
+<wire x1="38.1" y1="147.32" x2="12.7" y2="147.32" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="N$4" class="0">
+<segment>
+<pinref part="JP8" gate="G$1" pin="A3"/>
+<pinref part="JP10" gate="G$1" pin="3"/>
+<wire x1="38.1" y1="149.86" x2="12.7" y2="149.86" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="N$2" class="0">
+<segment>
+<pinref part="JP8" gate="G$1" pin="A0"/>
+<pinref part="JP10" gate="G$1" pin="6"/>
+<wire x1="38.1" y1="157.48" x2="12.7" y2="157.48" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="VDD" class="0">
+<segment>
+<wire x1="116.84" y1="93.726" x2="116.84" y2="88.9" width="0.1524" layer="91"/>
+<pinref part="VDD_RAIL" gate="G$1" pin="3"/>
+<wire x1="116.84" y1="88.9" x2="116.84" y2="86.36" width="0.1524" layer="91"/>
+<wire x1="116.84" y1="86.36" x2="113.03" y2="86.36" width="0.1524" layer="91"/>
+<pinref part="VDD_RAIL" gate="G$1" pin="2"/>
+<wire x1="116.84" y1="86.36" x2="116.84" y2="83.82" width="0.1524" layer="91"/>
+<wire x1="116.84" y1="83.82" x2="113.03" y2="83.82" width="0.1524" layer="91"/>
+<junction x="116.84" y="86.36"/>
+<pinref part="VDD_RAIL" gate="G$1" pin="1"/>
+<wire x1="116.84" y1="83.82" x2="116.84" y2="81.28" width="0.1524" layer="91"/>
+<wire x1="116.84" y1="81.28" x2="113.03" y2="81.28" width="0.1524" layer="91"/>
+<junction x="116.84" y="83.82"/>
+<pinref part="VDD" gate="G$1" pin="VCC_2"/>
+<wire x1="113.284" y1="88.9" x2="116.84" y2="88.9" width="0.1524" layer="91"/>
+<junction x="116.84" y="88.9"/>
+</segment>
+</net>
+<net name="JP3" class="0">
+<segment>
+<wire x1="99.06" y1="38.1" x2="99.06" y2="35.56" width="0.1524" layer="91"/>
+<pinref part="L1" gate="G$1" pin="A"/>
+<pinref part="JP_3" gate="G$1" pin="1"/>
+</segment>
+</net>
+<net name="JP4" class="0">
+<segment>
+<wire x1="111.76" y1="38.1" x2="111.76" y2="35.56" width="0.1524" layer="91"/>
+<pinref part="L2" gate="G$1" pin="A"/>
+<pinref part="JP_4" gate="G$1" pin="1"/>
+</segment>
+</net>
+<net name="D2_NC" class="0">
+<segment>
+<wire x1="127" y1="25.4" x2="127" y2="27.94" width="0.1524" layer="91"/>
+<label x="134.62" y="31.75" size="1.778" layer="95" font="vector"/>
+<pinref part="R4" gate="G$1" pin="1"/>
+<pinref part="SW2" gate="G$1" pin="2"/>
+<pinref part="JP_2" gate="G$1" pin="1"/>
+<wire x1="127" y1="27.94" x2="127" y2="33.02" width="0.1524" layer="91"/>
+<wire x1="132.08" y1="27.94" x2="127" y2="27.94" width="0.1524" layer="91"/>
+<junction x="127" y="27.94"/>
 </segment>
 </net>
 </nets>
 </sheet>
 </sheets>
 <errors>
-<approved hash="106,1,71.12,88.9,MISO_NC,,,,,"/>
-<approved hash="106,1,88.9,86.36,MOSI_NC,,,,,"/>
-<approved hash="106,1,17.78,139.7,NC3,,,,,"/>
-<approved hash="106,1,71.12,86.36,SCK_NC,,,,,"/>
-<approved hash="113,1,219.02,123.19,LED1,,,,,"/>
-<approved hash="113,1,231.72,123.19,LED2,,,,,"/>
-<approved hash="113,1,222.318,132.757,JP4,,,,,"/>
-<approved hash="113,1,235.018,132.757,JP9,,,,,"/>
-<approved hash="113,1,94.6573,152.332,JP12,,,,,"/>
-<approved hash="113,1,24.7227,165.168,JP10,,,,,"/>
-<approved hash="113,1,131.403,123.258,5V_RAIL,,,,,"/>
-<approved hash="113,1,154.263,123.258,GND_RAIL,,,,,"/>
-<approved hash="113,1,201.337,118.042,JP3,,,,,"/>
-<approved hash="113,1,45.0427,40.7077,JP7,,,,,"/>
-<approved hash="113,1,14.5627,132.148,JP11,,,,,"/>
-<approved hash="113,1,94.6573,121.852,JP1,,,,,"/>
-<approved hash="115,1,50.8,43.18,RX-I,,,,,"/>
-<approved hash="115,1,49.53,38.1,GND,,,,,"/>
-<approved hash="115,1,54.61,40.64,TX-O,,,,,"/>
-<approved hash="115,1,52.07,35.56,VCC,,,,,"/>
+<approved hash="106,1,45.72,86.36,MISO_NC,,,,,"/>
+<approved hash="106,1,63.5,83.82,MOSI_NC,,,,,"/>
+<approved hash="106,1,12.7,134.62,NC3,,,,,"/>
+<approved hash="106,1,45.72,83.82,SCK_NC,,,,,"/>
+<approved hash="113,1,97.1,31.75,LED1,,,,,"/>
+<approved hash="113,1,109.8,31.75,LED2,,,,,"/>
+<approved hash="113,1,100.398,41.3173,JP4,,,,,"/>
+<approved hash="113,1,113.098,41.3173,JP9,,,,,"/>
+<approved hash="113,1,89.5773,147.252,JP12,,,,,"/>
+<approved hash="113,1,9.48267,152.468,JP10,,,,,"/>
+<approved hash="113,1,135.297,29.1423,JP3,,,,,"/>
+<approved hash="113,1,42.5027,35.6277,JP7,,,,,"/>
+<approved hash="113,1,9.48267,127.068,JP11,,,,,"/>
+<approved hash="113,1,89.5773,116.772,JP1,,,,,"/>
+<approved hash="113,1,135.297,46.9223,JP5,,,,,"/>
+<approved hash="113,1,135.297,13.9023,JP6,,,,,"/>
 </errors>
 </schematic>
 </drawing>


### PR DESCRIPTION
-Shifted the mini-breadboard footprint
-Moved Vcc and GND rails to bottom for access
-Added VDD as an option
-Added Disconnected Breadboard rails based on Jim’s Design (GPS Shield), best of both worlds
-Add 2x more through hole pins for prototyping area
-Shifted Prototyping Hardware Around
-Switch Hardware Serial to Software -Serial to prevent bricking UART device
-Added Vcc and GND traces through mouse bite just in case
-Adjusted Header D8-SCL  so that the shield can stack with a breadboard (Michelle’s Suggestion)
-Added little bit more silkscreen to distinguish location of stackable headers
-Moved Reset button up for better access
-Switched Momentary Push Button Package to Double PTH
-Update Schematic