### PR TITLE
Revision 32: Proto 2 QC Update

### DIFF
--- a/Hardware/.SparkFun_ProtoShield_Kit_rev32.brd.lck
+++ b/Hardware/.SparkFun_ProtoShield_Kit_rev32.brd.lck
@@ -1,0 +1,3 @@
+bobby.chan
+TS_BOBBY
+05.02.2018 14:14.36

--- a/Hardware/.SparkFun_ProtoShield_Kit_rev32.sch.lck
+++ b/Hardware/.SparkFun_ProtoShield_Kit_rev32.sch.lck
@@ -1,0 +1,3 @@
+bobby.chan
+TS_BOBBY
+05.02.2018 14:14.36

--- a/Hardware/SparkFun_ProtoShield_Kit_rev32.brd
+++ b/Hardware/SparkFun_ProtoShield_Kit_rev32.brd
@@ -31,8 +31,8 @@
 <layer number="21" name="tPlace" color="16" fill="1" visible="yes" active="yes"/>
 <layer number="22" name="bPlace" color="14" fill="1" visible="yes" active="yes"/>
 <layer number="23" name="tOrigins" color="15" fill="1" visible="yes" active="yes"/>
-<layer number="24" name="bOrigins" color="15" fill="1" visible="no" active="yes"/>
-<layer number="25" name="tNames" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="24" name="bOrigins" color="15" fill="1" visible="yes" active="yes"/>
+<layer number="25" name="tNames" color="7" fill="1" visible="no" active="yes"/>
 <layer number="26" name="bNames" color="7" fill="1" visible="no" active="yes"/>
 <layer number="27" name="tValues" color="7" fill="1" visible="no" active="yes"/>
 <layer number="28" name="bValues" color="7" fill="1" visible="no" active="yes"/>
@@ -48,13 +48,13 @@
 <layer number="38" name="bTest" color="7" fill="1" visible="no" active="yes"/>
 <layer number="39" name="tKeepout" color="4" fill="11" visible="no" active="yes"/>
 <layer number="40" name="bKeepout" color="1" fill="11" visible="no" active="yes"/>
-<layer number="41" name="tRestrict" color="4" fill="10" visible="yes" active="yes"/>
-<layer number="42" name="bRestrict" color="1" fill="10" visible="yes" active="yes"/>
+<layer number="41" name="tRestrict" color="4" fill="10" visible="no" active="yes"/>
+<layer number="42" name="bRestrict" color="1" fill="10" visible="no" active="yes"/>
 <layer number="43" name="vRestrict" color="2" fill="10" visible="no" active="yes"/>
-<layer number="44" name="Drills" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="44" name="Drills" color="7" fill="1" visible="no" active="yes"/>
 <layer number="45" name="Holes" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="46" name="Milling" color="3" fill="1" visible="no" active="yes"/>
-<layer number="47" name="Measures" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="47" name="Measures" color="7" fill="1" visible="no" active="yes"/>
 <layer number="48" name="Document" color="7" fill="1" visible="no" active="yes"/>
 <layer number="49" name="Reference" color="7" fill="1" visible="no" active="yes"/>
 <layer number="50" name="dxf" color="7" fill="1" visible="no" active="yes"/>
@@ -705,15 +705,12 @@
 <text x="9.017" y="0.889" size="0.8128" layer="21" font="vector" ratio="15">330</text>
 <text x="10.541" y="3.175" size="0.8128" layer="21" font="vector" ratio="15">330</text>
 <text x="38.7604" y="3.4036" size="0.8128" layer="21" font="vector" ratio="15">10k</text>
-<wire x1="24.765" y1="12.7" x2="31.115" y2="12.7" width="0.254" layer="22"/>
-<wire x1="31.115" y1="12.7" x2="31.75" y2="12.065" width="0.254" layer="22"/>
-<wire x1="31.75" y1="12.065" x2="31.75" y2="8.255" width="0.254" layer="22"/>
 <wire x1="31.75" y1="8.255" x2="31.115" y2="7.62" width="0.254" layer="22"/>
 <wire x1="31.115" y1="7.62" x2="24.765" y2="7.62" width="0.254" layer="22"/>
 <wire x1="24.765" y1="7.62" x2="24.13" y2="8.255" width="0.254" layer="22"/>
-<wire x1="24.13" y1="8.255" x2="24.13" y2="12.065" width="0.254" layer="22"/>
+<wire x1="24.13" y1="8.255" x2="24.13" y2="11.43" width="0.254" layer="22"/>
+<wire x1="24.13" y1="11.43" x2="24.13" y2="12.065" width="0.254" layer="22"/>
 <wire x1="24.765" y1="12.7" x2="24.13" y2="12.065" width="0.254" layer="22"/>
-<wire x1="29.7942" y1="13.0302" x2="31.0642" y2="13.0302" width="0.2032" layer="22"/>
 <wire x1="20.574" y1="60.579" x2="22.606" y2="60.579" width="0.254" layer="42"/>
 <wire x1="24.13" y1="58.801" x2="20.574" y2="58.801" width="0.254" layer="42"/>
 <wire x1="24.13" y1="58.801" x2="25.273" y2="59.944" width="0.254" layer="42"/>
@@ -733,21 +730,15 @@
 <wire x1="20.447" y1="58.801" x2="20.447" y2="59.182" width="0.254" layer="42"/>
 <text x="17.78" y="9.144" size="0.8128" layer="21" font="vector" ratio="15">VDD</text>
 <text x="9.906" y="11.684" size="0.8128" layer="21" font="vector" ratio="15">5V</text>
-<text x="34.544" y="11.684" size="0.8128" layer="21" font="vector" ratio="15">GND</text>
-<wire x1="26.924" y1="14.986" x2="26.924" y2="12.954" width="0.254" layer="21"/>
-<wire x1="26.924" y1="12.954" x2="29.464" y2="12.954" width="0.254" layer="21"/>
-<wire x1="26.924" y1="14.986" x2="44.196" y2="14.986" width="0.254" layer="21"/>
-<wire x1="44.196" y1="14.986" x2="44.196" y2="10.414" width="0.254" layer="21"/>
-<wire x1="44.196" y1="10.414" x2="37.084" y2="10.414" width="0.254" layer="21"/>
-<wire x1="37.084" y1="10.414" x2="37.084" y2="12.954" width="0.254" layer="21"/>
-<wire x1="37.084" y1="12.954" x2="31.496" y2="12.954" width="0.254" layer="21"/>
+<text x="34.163" y="11.557" size="0.8128" layer="21" font="vector" ratio="15">GND</text>
 <text x="23.749" y="3.1115" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">L1</text>
 <text x="26.289" y="3.1115" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">L2</text>
 <text x="29.337" y="3.1115" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">GND</text>
 <text x="31.369" y="3.1115" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">5V</text>
 <text x="31.115" y="58.293" size="0.8128" layer="22" font="vector" ratio="15" rot="MR90">TXO</text>
 <text x="31.115" y="61.214" size="0.8128" layer="22" font="vector" ratio="15" rot="MR90">RXI</text>
-<wire x1="8.89" y1="13.335" x2="8.89" y2="14.605" width="0.254" layer="22"/>
+<wire x1="8.89" y1="13.335" x2="8.89" y2="13.97" width="0.254" layer="22"/>
+<wire x1="8.89" y1="13.97" x2="8.89" y2="14.605" width="0.254" layer="22"/>
 <wire x1="8.89" y1="17.145" x2="8.89" y2="15.875" width="0.254" layer="22"/>
 <wire x1="8.89" y1="18.415" x2="8.89" y2="19.685" width="0.254" layer="22"/>
 <wire x1="8.89" y1="20.955" x2="8.89" y2="22.225" width="0.254" layer="22"/>
@@ -760,266 +751,7 @@
 <wire x1="8.89" y1="41.402" x2="8.89" y2="42.545" width="0.254" layer="22"/>
 <wire x1="8.89" y1="43.815" x2="8.89" y2="45.085" width="0.254" layer="22"/>
 <wire x1="8.89" y1="46.355" x2="8.89" y2="47.498" width="0.254" layer="22"/>
-<wire x1="15.24" y1="37.846" x2="22.86" y2="37.846" width="0.254" layer="21" style="shortdash"/>
-<wire x1="22.86" y1="37.846" x2="23.876" y2="36.83" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="23.876" y1="36.83" x2="22.86" y2="35.814" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="22.86" y1="35.814" x2="15.24" y2="35.814" width="0.254" layer="21" style="shortdash"/>
-<wire x1="15.24" y1="35.814" x2="14.224" y2="36.83" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="14.224" y1="36.83" x2="15.24" y2="37.846" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="15.24" y1="35.306" x2="22.86" y2="35.306" width="0.254" layer="21" style="shortdash"/>
-<wire x1="22.86" y1="35.306" x2="23.876" y2="34.29" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="23.876" y1="34.29" x2="22.86" y2="33.274" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="22.86" y1="33.274" x2="15.24" y2="33.274" width="0.254" layer="21" style="shortdash"/>
-<wire x1="15.24" y1="33.274" x2="14.224" y2="34.29" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="14.224" y1="34.29" x2="15.24" y2="35.306" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="15.24" y1="32.766" x2="22.86" y2="32.766" width="0.254" layer="21" style="shortdash"/>
-<wire x1="22.86" y1="32.766" x2="23.876" y2="31.75" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="23.876" y1="31.75" x2="22.86" y2="30.734" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="22.86" y1="30.734" x2="15.24" y2="30.734" width="0.254" layer="21" style="shortdash"/>
-<wire x1="15.24" y1="30.734" x2="14.224" y2="31.75" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="14.224" y1="31.75" x2="15.24" y2="32.766" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="15.24" y1="30.226" x2="22.86" y2="30.226" width="0.254" layer="21" style="shortdash"/>
-<wire x1="22.86" y1="30.226" x2="23.876" y2="29.21" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="23.876" y1="29.21" x2="22.86" y2="28.194" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="22.86" y1="28.194" x2="15.24" y2="28.194" width="0.254" layer="21" style="shortdash"/>
-<wire x1="15.24" y1="28.194" x2="14.224" y2="29.21" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="14.224" y1="29.21" x2="15.24" y2="30.226" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="15.24" y1="27.686" x2="22.86" y2="27.686" width="0.254" layer="21" style="shortdash"/>
-<wire x1="22.86" y1="27.686" x2="23.876" y2="26.67" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="23.876" y1="26.67" x2="22.86" y2="25.654" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="22.86" y1="25.654" x2="15.24" y2="25.654" width="0.254" layer="21" style="shortdash"/>
-<wire x1="15.24" y1="25.654" x2="14.224" y2="26.67" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="14.224" y1="26.67" x2="15.24" y2="27.686" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="15.24" y1="25.146" x2="22.86" y2="25.146" width="0.254" layer="21" style="shortdash"/>
-<wire x1="22.86" y1="25.146" x2="23.876" y2="24.13" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="23.876" y1="24.13" x2="22.86" y2="23.114" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="22.86" y1="23.114" x2="15.24" y2="23.114" width="0.254" layer="21" style="shortdash"/>
-<wire x1="15.24" y1="23.114" x2="14.224" y2="24.13" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="14.224" y1="24.13" x2="15.24" y2="25.146" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="15.24" y1="22.606" x2="22.86" y2="22.606" width="0.254" layer="21" style="shortdash"/>
-<wire x1="22.86" y1="22.606" x2="23.876" y2="21.59" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="23.876" y1="21.59" x2="22.86" y2="20.574" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="22.86" y1="20.574" x2="15.24" y2="20.574" width="0.254" layer="21" style="shortdash"/>
-<wire x1="15.24" y1="20.574" x2="14.224" y2="21.59" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="14.224" y1="21.59" x2="15.24" y2="22.606" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="15.24" y1="20.066" x2="22.86" y2="20.066" width="0.254" layer="21" style="shortdash"/>
-<wire x1="22.86" y1="20.066" x2="23.876" y2="19.05" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="23.876" y1="19.05" x2="22.86" y2="18.034" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="22.86" y1="18.034" x2="15.24" y2="18.034" width="0.254" layer="21" style="shortdash"/>
-<wire x1="15.24" y1="18.034" x2="14.224" y2="19.05" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="14.224" y1="19.05" x2="15.24" y2="20.066" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="15.24" y1="17.526" x2="22.86" y2="17.526" width="0.254" layer="21" style="shortdash"/>
-<wire x1="22.86" y1="17.526" x2="23.876" y2="16.51" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="23.876" y1="16.51" x2="22.86" y2="15.494" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="22.86" y1="15.494" x2="15.24" y2="15.494" width="0.254" layer="21" style="shortdash"/>
-<wire x1="15.24" y1="15.494" x2="14.224" y2="16.51" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="14.224" y1="16.51" x2="15.24" y2="17.526" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="22.86" y1="37.846" x2="15.24" y2="37.846" width="0.254" layer="22" style="shortdash"/>
-<wire x1="15.24" y1="37.846" x2="14.224" y2="36.83" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="14.224" y1="36.83" x2="15.24" y2="35.814" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="15.24" y1="35.814" x2="22.86" y2="35.814" width="0.254" layer="22" style="shortdash"/>
-<wire x1="22.86" y1="35.814" x2="23.876" y2="36.83" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="23.876" y1="36.83" x2="22.86" y2="37.846" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="22.86" y1="35.306" x2="15.24" y2="35.306" width="0.254" layer="22" style="shortdash"/>
-<wire x1="15.24" y1="35.306" x2="14.224" y2="34.29" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="14.224" y1="34.29" x2="15.24" y2="33.274" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="15.24" y1="33.274" x2="22.86" y2="33.274" width="0.254" layer="22" style="shortdash"/>
-<wire x1="22.86" y1="33.274" x2="23.876" y2="34.29" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="23.876" y1="34.29" x2="22.86" y2="35.306" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="22.86" y1="32.766" x2="15.24" y2="32.766" width="0.254" layer="22" style="shortdash"/>
-<wire x1="15.24" y1="32.766" x2="14.224" y2="31.75" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="14.224" y1="31.75" x2="15.24" y2="30.734" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="15.24" y1="30.734" x2="22.86" y2="30.734" width="0.254" layer="22" style="shortdash"/>
-<wire x1="22.86" y1="30.734" x2="23.876" y2="31.75" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="23.876" y1="31.75" x2="22.86" y2="32.766" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="22.86" y1="30.226" x2="15.24" y2="30.226" width="0.254" layer="22" style="shortdash"/>
-<wire x1="15.24" y1="30.226" x2="14.224" y2="29.21" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="14.224" y1="29.21" x2="15.24" y2="28.194" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="15.24" y1="28.194" x2="22.86" y2="28.194" width="0.254" layer="22" style="shortdash"/>
-<wire x1="22.86" y1="28.194" x2="23.876" y2="29.21" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="23.876" y1="29.21" x2="22.86" y2="30.226" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="22.86" y1="27.686" x2="15.24" y2="27.686" width="0.254" layer="22" style="shortdash"/>
-<wire x1="15.24" y1="27.686" x2="14.224" y2="26.67" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="14.224" y1="26.67" x2="15.24" y2="25.654" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="15.24" y1="25.654" x2="22.86" y2="25.654" width="0.254" layer="22" style="shortdash"/>
-<wire x1="22.86" y1="25.654" x2="23.876" y2="26.67" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="23.876" y1="26.67" x2="22.86" y2="27.686" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="22.86" y1="25.146" x2="15.24" y2="25.146" width="0.254" layer="22" style="shortdash"/>
-<wire x1="15.24" y1="25.146" x2="14.224" y2="24.13" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="14.224" y1="24.13" x2="15.24" y2="23.114" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="15.24" y1="23.114" x2="22.86" y2="23.114" width="0.254" layer="22" style="shortdash"/>
-<wire x1="22.86" y1="23.114" x2="23.876" y2="24.13" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="23.876" y1="24.13" x2="22.86" y2="25.146" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="22.86" y1="22.606" x2="15.24" y2="22.606" width="0.254" layer="22" style="shortdash"/>
-<wire x1="15.24" y1="22.606" x2="14.224" y2="21.59" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="14.224" y1="21.59" x2="15.24" y2="20.574" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="15.24" y1="20.574" x2="22.86" y2="20.574" width="0.254" layer="22" style="shortdash"/>
-<wire x1="22.86" y1="20.574" x2="23.876" y2="21.59" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="23.876" y1="21.59" x2="22.86" y2="22.606" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="22.86" y1="20.066" x2="15.24" y2="20.066" width="0.254" layer="22" style="shortdash"/>
-<wire x1="15.24" y1="20.066" x2="14.224" y2="19.05" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="14.224" y1="19.05" x2="15.24" y2="18.034" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="15.24" y1="18.034" x2="22.86" y2="18.034" width="0.254" layer="22" style="shortdash"/>
-<wire x1="22.86" y1="18.034" x2="23.876" y2="19.05" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="23.876" y1="19.05" x2="22.86" y2="20.066" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="30.48" y1="37.846" x2="38.1" y2="37.846" width="0.254" layer="21" style="shortdash"/>
-<wire x1="38.1" y1="37.846" x2="39.116" y2="36.83" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="39.116" y1="36.83" x2="38.1" y2="35.814" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="38.1" y1="35.814" x2="30.48" y2="35.814" width="0.254" layer="21" style="shortdash"/>
-<wire x1="30.48" y1="35.814" x2="29.464" y2="36.83" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="29.464" y1="36.83" x2="30.48" y2="37.846" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="30.48" y1="35.306" x2="38.1" y2="35.306" width="0.254" layer="21" style="shortdash"/>
-<wire x1="38.1" y1="35.306" x2="39.116" y2="34.29" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="39.116" y1="34.29" x2="38.1" y2="33.274" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="38.1" y1="33.274" x2="30.48" y2="33.274" width="0.254" layer="21" style="shortdash"/>
-<wire x1="30.48" y1="33.274" x2="29.464" y2="34.29" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="29.464" y1="34.29" x2="30.48" y2="35.306" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="30.48" y1="32.766" x2="38.1" y2="32.766" width="0.254" layer="21" style="shortdash"/>
-<wire x1="38.1" y1="32.766" x2="39.116" y2="31.75" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="39.116" y1="31.75" x2="38.1" y2="30.734" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="38.1" y1="30.734" x2="30.48" y2="30.734" width="0.254" layer="21" style="shortdash"/>
-<wire x1="30.48" y1="30.734" x2="29.464" y2="31.75" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="29.464" y1="31.75" x2="30.48" y2="32.766" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="30.48" y1="30.226" x2="38.1" y2="30.226" width="0.254" layer="21" style="shortdash"/>
-<wire x1="38.1" y1="30.226" x2="39.116" y2="29.21" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="39.116" y1="29.21" x2="38.1" y2="28.194" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="38.1" y1="28.194" x2="30.48" y2="28.194" width="0.254" layer="21" style="shortdash"/>
-<wire x1="30.48" y1="28.194" x2="29.464" y2="29.21" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="29.464" y1="29.21" x2="30.48" y2="30.226" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="30.48" y1="27.686" x2="38.1" y2="27.686" width="0.254" layer="21" style="shortdash"/>
-<wire x1="38.1" y1="27.686" x2="39.116" y2="26.67" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="39.116" y1="26.67" x2="38.1" y2="25.654" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="38.1" y1="25.654" x2="30.48" y2="25.654" width="0.254" layer="21" style="shortdash"/>
-<wire x1="30.48" y1="25.654" x2="29.464" y2="26.67" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="29.464" y1="26.67" x2="30.48" y2="27.686" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="30.48" y1="25.146" x2="38.1" y2="25.146" width="0.254" layer="21" style="shortdash"/>
-<wire x1="38.1" y1="25.146" x2="39.116" y2="24.13" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="39.116" y1="24.13" x2="38.1" y2="23.114" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="38.1" y1="23.114" x2="30.48" y2="23.114" width="0.254" layer="21" style="shortdash"/>
-<wire x1="30.48" y1="23.114" x2="29.464" y2="24.13" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="29.464" y1="24.13" x2="30.48" y2="25.146" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="30.48" y1="22.606" x2="38.1" y2="22.606" width="0.254" layer="21" style="shortdash"/>
-<wire x1="38.1" y1="22.606" x2="39.116" y2="21.59" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="39.116" y1="21.59" x2="38.1" y2="20.574" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="38.1" y1="20.574" x2="30.48" y2="20.574" width="0.254" layer="21" style="shortdash"/>
-<wire x1="30.48" y1="20.574" x2="29.464" y2="21.59" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="29.464" y1="21.59" x2="30.48" y2="22.606" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="30.48" y1="20.066" x2="38.1" y2="20.066" width="0.254" layer="21" style="shortdash"/>
-<wire x1="38.1" y1="20.066" x2="39.116" y2="19.05" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="39.116" y1="19.05" x2="38.1" y2="18.034" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="38.1" y1="18.034" x2="30.48" y2="18.034" width="0.254" layer="21" style="shortdash"/>
-<wire x1="30.48" y1="18.034" x2="29.464" y2="19.05" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="29.464" y1="19.05" x2="30.48" y2="20.066" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="30.48" y1="17.526" x2="38.1" y2="17.526" width="0.254" layer="21" style="shortdash"/>
-<wire x1="38.1" y1="17.526" x2="39.116" y2="16.51" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="39.116" y1="16.51" x2="38.1" y2="15.494" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="38.1" y1="15.494" x2="30.48" y2="15.494" width="0.254" layer="21" style="shortdash"/>
-<wire x1="30.48" y1="15.494" x2="29.464" y2="16.51" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="29.464" y1="16.51" x2="30.48" y2="17.526" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="26.416" y1="39.37" x2="26.416" y2="16.51" width="0.254" layer="21" style="shortdash"/>
-<wire x1="26.416" y1="16.51" x2="25.4" y2="15.494" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="25.4" y1="15.494" x2="24.384" y2="16.51" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="24.384" y1="16.51" x2="24.384" y2="39.37" width="0.254" layer="21" style="shortdash"/>
-<wire x1="24.384" y1="39.37" x2="25.4" y2="40.386" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="25.4" y1="40.386" x2="26.416" y2="39.37" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="28.956" y1="16.51" x2="27.94" y2="15.494" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="27.94" y1="15.494" x2="26.924" y2="16.51" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="26.924" y1="16.51" x2="26.924" y2="39.37" width="0.254" layer="21" style="shortdash"/>
-<wire x1="26.924" y1="39.37" x2="27.94" y2="40.386" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="27.94" y1="40.386" x2="28.956" y2="39.37" width="0.254" layer="21" style="shortdash" curve="-90"/>
-<wire x1="28.956" y1="39.37" x2="28.956" y2="16.51" width="0.254" layer="21" style="shortdash"/>
-<wire x1="38.1" y1="37.846" x2="30.48" y2="37.846" width="0.254" layer="22" style="shortdash"/>
-<wire x1="30.48" y1="37.846" x2="29.464" y2="36.83" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="29.464" y1="36.83" x2="30.48" y2="35.814" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="30.48" y1="35.814" x2="38.1" y2="35.814" width="0.254" layer="22" style="shortdash"/>
-<wire x1="38.1" y1="35.814" x2="39.116" y2="36.83" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="39.116" y1="36.83" x2="38.1" y2="37.846" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="38.1" y1="35.306" x2="30.48" y2="35.306" width="0.254" layer="22" style="shortdash"/>
-<wire x1="30.48" y1="35.306" x2="29.464" y2="34.29" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="29.464" y1="34.29" x2="30.48" y2="33.274" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="30.48" y1="33.274" x2="38.1" y2="33.274" width="0.254" layer="22" style="shortdash"/>
-<wire x1="38.1" y1="33.274" x2="39.116" y2="34.29" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="39.116" y1="34.29" x2="38.1" y2="35.306" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="38.1" y1="32.766" x2="30.48" y2="32.766" width="0.254" layer="22" style="shortdash"/>
-<wire x1="30.48" y1="32.766" x2="29.464" y2="31.75" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="29.464" y1="31.75" x2="30.48" y2="30.734" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="30.48" y1="30.734" x2="38.1" y2="30.734" width="0.254" layer="22" style="shortdash"/>
-<wire x1="38.1" y1="30.734" x2="39.116" y2="31.75" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="39.116" y1="31.75" x2="38.1" y2="32.766" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="38.1" y1="30.226" x2="30.48" y2="30.226" width="0.254" layer="22" style="shortdash"/>
-<wire x1="30.48" y1="30.226" x2="29.464" y2="29.21" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="29.464" y1="29.21" x2="30.48" y2="28.194" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="30.48" y1="28.194" x2="38.1" y2="28.194" width="0.254" layer="22" style="shortdash"/>
-<wire x1="38.1" y1="28.194" x2="39.116" y2="29.21" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="39.116" y1="29.21" x2="38.1" y2="30.226" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="38.1" y1="27.686" x2="30.48" y2="27.686" width="0.254" layer="22" style="shortdash"/>
-<wire x1="30.48" y1="27.686" x2="29.464" y2="26.67" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="29.464" y1="26.67" x2="30.48" y2="25.654" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="30.48" y1="25.654" x2="38.1" y2="25.654" width="0.254" layer="22" style="shortdash"/>
-<wire x1="38.1" y1="25.654" x2="39.116" y2="26.67" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="39.116" y1="26.67" x2="38.1" y2="27.686" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="38.1" y1="25.146" x2="30.48" y2="25.146" width="0.254" layer="22" style="shortdash"/>
-<wire x1="30.48" y1="25.146" x2="29.464" y2="24.13" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="29.464" y1="24.13" x2="30.48" y2="23.114" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="30.48" y1="23.114" x2="38.1" y2="23.114" width="0.254" layer="22" style="shortdash"/>
-<wire x1="38.1" y1="23.114" x2="39.116" y2="24.13" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="39.116" y1="24.13" x2="38.1" y2="25.146" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="38.1" y1="22.606" x2="30.48" y2="22.606" width="0.254" layer="22" style="shortdash"/>
-<wire x1="30.48" y1="22.606" x2="29.464" y2="21.59" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="29.464" y1="21.59" x2="30.48" y2="20.574" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="30.48" y1="20.574" x2="38.1" y2="20.574" width="0.254" layer="22" style="shortdash"/>
-<wire x1="38.1" y1="20.574" x2="39.116" y2="21.59" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="39.116" y1="21.59" x2="38.1" y2="22.606" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="38.1" y1="20.066" x2="30.48" y2="20.066" width="0.254" layer="22" style="shortdash"/>
-<wire x1="30.48" y1="20.066" x2="29.464" y2="19.05" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="29.464" y1="19.05" x2="30.48" y2="18.034" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="30.48" y1="18.034" x2="38.1" y2="18.034" width="0.254" layer="22" style="shortdash"/>
-<wire x1="38.1" y1="18.034" x2="39.116" y2="19.05" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="39.116" y1="19.05" x2="38.1" y2="20.066" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="30.48" y1="15.494" x2="38.1" y2="15.494" width="0.254" layer="22" style="shortdash"/>
-<wire x1="38.1" y1="15.494" x2="39.116" y2="16.51" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="39.116" y1="16.51" x2="38.1" y2="17.526" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="38.1" y1="17.526" x2="30.48" y2="17.526" width="0.254" layer="22" style="shortdash"/>
-<wire x1="30.48" y1="17.526" x2="29.464" y2="16.51" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="29.464" y1="16.51" x2="30.48" y2="15.494" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="15.24" y1="15.494" x2="22.86" y2="15.494" width="0.254" layer="22" style="shortdash"/>
-<wire x1="22.86" y1="15.494" x2="23.876" y2="16.51" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="23.876" y1="16.51" x2="22.86" y2="17.526" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="22.86" y1="17.526" x2="15.24" y2="17.526" width="0.254" layer="22" style="shortdash"/>
-<wire x1="15.24" y1="17.526" x2="14.224" y2="16.51" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="14.224" y1="16.51" x2="15.24" y2="15.494" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="25.4" y1="15.494" x2="26.416" y2="16.51" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="26.416" y1="16.51" x2="26.416" y2="39.37" width="0.254" layer="22" style="shortdash"/>
-<wire x1="26.416" y1="39.37" x2="25.4" y2="40.386" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="25.4" y1="40.386" x2="24.384" y2="39.37" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="24.384" y1="39.37" x2="24.384" y2="16.51" width="0.254" layer="22" style="shortdash"/>
-<wire x1="24.384" y1="16.51" x2="25.4" y2="15.494" width="0.254" layer="22" style="shortdash" curve="90"/>
-<wire x1="27.94" y1="15.494" x2="26.924" y2="16.51" width="0.254" layer="22" style="shortdash" curve="-90"/>
-<wire x1="26.924" y1="16.51" x2="26.924" y2="39.37" width="0.254" layer="22" style="shortdash"/>
-<wire x1="26.924" y1="39.37" x2="27.94" y2="40.386" width="0.254" layer="22" style="shortdash" curve="-90"/>
-<wire x1="27.94" y1="40.386" x2="28.956" y2="39.37" width="0.254" layer="22" style="shortdash" curve="-90"/>
-<wire x1="28.956" y1="39.37" x2="28.956" y2="16.51" width="0.254" layer="22" style="shortdash"/>
-<wire x1="28.956" y1="16.51" x2="27.94" y2="15.494" width="0.254" layer="22" style="shortdash" curve="-90"/>
-<wire x1="44.196" y1="14.986" x2="26.924" y2="14.986" width="0.254" layer="22"/>
-<wire x1="26.924" y1="14.986" x2="26.924" y2="12.954" width="0.254" layer="22"/>
-<wire x1="26.924" y1="12.954" x2="29.464" y2="12.954" width="0.254" layer="22"/>
-<wire x1="31.496" y1="12.954" x2="37.084" y2="12.954" width="0.254" layer="22"/>
-<wire x1="37.084" y1="12.954" x2="37.084" y2="10.414" width="0.254" layer="22"/>
-<wire x1="37.084" y1="10.414" x2="44.196" y2="10.414" width="0.254" layer="22"/>
-<wire x1="44.196" y1="10.414" x2="44.196" y2="14.986" width="0.254" layer="22"/>
-<wire x1="10.16" y1="14.986" x2="25.4" y2="14.986" width="0.254" layer="21"/>
-<wire x1="25.4" y1="14.986" x2="26.416" y2="13.97" width="0.254" layer="21" curve="-90"/>
-<wire x1="26.416" y1="13.97" x2="25.4" y2="12.954" width="0.254" layer="21" curve="-90"/>
-<wire x1="25.4" y1="12.954" x2="10.16" y2="12.954" width="0.254" layer="21"/>
-<wire x1="10.16" y1="12.954" x2="9.144" y2="13.97" width="0.254" layer="21" curve="-90"/>
-<wire x1="9.144" y1="13.97" x2="10.16" y2="14.986" width="0.254" layer="21" curve="-90"/>
-<wire x1="15.24" y1="12.446" x2="22.86" y2="12.446" width="0.254" layer="21"/>
-<wire x1="22.86" y1="12.446" x2="23.876" y2="11.43" width="0.254" layer="21" curve="-90"/>
-<wire x1="23.876" y1="11.43" x2="22.86" y2="10.414" width="0.254" layer="21" curve="-90"/>
-<wire x1="22.86" y1="10.414" x2="15.24" y2="10.414" width="0.254" layer="21"/>
-<wire x1="15.24" y1="10.414" x2="14.224" y2="11.43" width="0.254" layer="21" curve="-90"/>
-<wire x1="14.224" y1="11.43" x2="15.24" y2="12.446" width="0.254" layer="21" curve="-90"/>
-<text x="36.576" y="11.684" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">GND</text>
+<text x="36.195" y="11.557" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">GND</text>
 <text x="19.812" y="9.144" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">VDD</text>
 <text x="11.176" y="11.684" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">5V</text>
 <wire x1="51.435" y1="10.16" x2="52.07" y2="10.795" width="0.254" layer="22"/>
@@ -1065,20 +797,6 @@
 <wire x1="3.175" y1="12.7" x2="3.81" y2="12.065" width="0.254" layer="22"/>
 <wire x1="1.27" y1="12.065" x2="1.905" y2="12.7" width="0.254" layer="22"/>
 <wire x1="3.175" y1="10.16" x2="3.81" y2="10.795" width="0.254" layer="22"/>
-<wire x1="22.86" y1="12.446" x2="15.24" y2="12.446" width="0.254" layer="22"/>
-<wire x1="15.24" y1="12.446" x2="14.224" y2="11.43" width="0.254" layer="22" curve="90"/>
-<wire x1="14.224" y1="11.43" x2="15.24" y2="10.414" width="0.254" layer="22" curve="90"/>
-<wire x1="15.24" y1="10.414" x2="22.987" y2="10.414" width="0.254" layer="22"/>
-<wire x1="22.987" y1="10.414" x2="23.876" y2="11.303" width="0.254" layer="22" curve="90"/>
-<wire x1="23.876" y1="11.303" x2="23.876" y2="11.43" width="0.254" layer="22"/>
-<wire x1="23.876" y1="11.43" x2="22.86" y2="12.446" width="0.254" layer="22" curve="90"/>
-<wire x1="10.16" y1="14.986" x2="9.144" y2="13.97" width="0.254" layer="22" curve="90"/>
-<wire x1="9.144" y1="13.97" x2="10.16" y2="12.954" width="0.254" layer="22" curve="90"/>
-<wire x1="10.16" y1="12.954" x2="25.527" y2="12.954" width="0.254" layer="22"/>
-<wire x1="25.527" y1="12.954" x2="26.416" y2="13.843" width="0.254" layer="22" curve="90"/>
-<wire x1="26.416" y1="13.843" x2="26.416" y2="13.97" width="0.254" layer="22"/>
-<wire x1="26.416" y1="13.97" x2="25.4" y2="14.986" width="0.254" layer="22" curve="90"/>
-<wire x1="25.4" y1="14.986" x2="10.16" y2="14.986" width="0.254" layer="22"/>
 <wire x1="3.81" y1="27.94" x2="1.27" y2="27.94" width="0.254" layer="21"/>
 <wire x1="1.27" y1="27.94" x2="1.27" y2="48.26" width="0.254" layer="21"/>
 <wire x1="1.27" y1="48.26" x2="3.81" y2="48.26" width="0.254" layer="21"/>
@@ -1980,6 +1698,291 @@
 <text x="12.573" y="3.175" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">330</text>
 <text x="4.826" y="4.064" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">-</text>
 <text x="21.336" y="0.508" size="0.8128" layer="22" font="vector" ratio="15" rot="MR0">-</text>
+<wire x1="10.16" y1="15.24" x2="8.89" y2="13.97" width="0.2032" layer="21" curve="90"/>
+<wire x1="8.89" y1="13.97" x2="10.16" y2="12.7" width="0.2032" layer="21" curve="90"/>
+<wire x1="10.16" y1="12.7" x2="15.24" y2="12.7" width="0.2032" layer="21"/>
+<wire x1="22.86" y1="12.7" x2="25.4" y2="12.7" width="0.2032" layer="21"/>
+<wire x1="25.4" y1="12.7" x2="26.67" y2="13.97" width="0.2032" layer="21" curve="90"/>
+<wire x1="26.67" y1="13.97" x2="25.4" y2="15.24" width="0.2032" layer="21" curve="90"/>
+<wire x1="25.4" y1="15.24" x2="10.16" y2="15.24" width="0.2032" layer="21"/>
+<wire x1="10.16" y1="15.24" x2="8.89" y2="13.97" width="0.2032" layer="22" curve="90"/>
+<wire x1="8.89" y1="13.97" x2="10.16" y2="12.7" width="0.2032" layer="22" curve="90"/>
+<wire x1="10.16" y1="12.7" x2="15.24" y2="12.7" width="0.2032" layer="22"/>
+<wire x1="22.86" y1="12.7" x2="24.765" y2="12.7" width="0.2032" layer="22"/>
+<wire x1="24.765" y1="12.7" x2="25.4" y2="12.7" width="0.2032" layer="22"/>
+<wire x1="25.4" y1="12.7" x2="26.67" y2="13.97" width="0.2032" layer="22" curve="90"/>
+<wire x1="26.67" y1="13.97" x2="25.4" y2="15.24" width="0.2032" layer="22" curve="90"/>
+<wire x1="25.4" y1="15.24" x2="10.16" y2="15.24" width="0.2032" layer="22"/>
+<wire x1="15.24" y1="12.7" x2="13.97" y2="11.43" width="0.2032" layer="21" curve="90"/>
+<wire x1="13.97" y1="11.43" x2="15.24" y2="10.16" width="0.2032" layer="21" curve="90"/>
+<wire x1="15.24" y1="10.16" x2="22.86" y2="10.16" width="0.2032" layer="21"/>
+<wire x1="22.86" y1="10.16" x2="24.13" y2="11.43" width="0.2032" layer="21" curve="90"/>
+<wire x1="24.13" y1="11.43" x2="22.86" y2="12.7" width="0.2032" layer="21" curve="90"/>
+<wire x1="22.86" y1="12.7" x2="15.24" y2="12.7" width="0.2032" layer="21"/>
+<wire x1="15.24" y1="12.7" x2="13.97" y2="11.43" width="0.2032" layer="22" curve="90"/>
+<wire x1="13.97" y1="11.43" x2="15.24" y2="10.16" width="0.2032" layer="22" curve="90"/>
+<wire x1="15.24" y1="10.16" x2="22.86" y2="10.16" width="0.2032" layer="22"/>
+<wire x1="22.86" y1="10.16" x2="24.13" y2="11.43" width="0.2032" layer="22" curve="90"/>
+<wire x1="24.13" y1="11.43" x2="22.86" y2="12.7" width="0.2032" layer="22" curve="90"/>
+<wire x1="22.86" y1="12.7" x2="15.24" y2="12.7" width="0.2032" layer="22"/>
+<wire x1="31.75" y1="8.255" x2="31.75" y2="12.065" width="0.254" layer="22"/>
+<wire x1="31.75" y1="12.065" x2="31.115" y2="12.7" width="0.254" layer="22"/>
+<wire x1="31.115" y1="12.7" x2="26.67" y2="12.7" width="0.254" layer="22"/>
+<wire x1="26.67" y1="12.7" x2="24.765" y2="12.7" width="0.254" layer="22"/>
+<wire x1="26.67" y1="15.24" x2="26.67" y2="12.7" width="0.2032" layer="21"/>
+<wire x1="26.67" y1="12.7" x2="36.83" y2="12.7" width="0.2032" layer="21"/>
+<wire x1="37.211" y1="10.16" x2="44.323" y2="10.16" width="0.2032" layer="21"/>
+<wire x1="44.323" y1="10.16" x2="44.323" y2="15.24" width="0.2032" layer="21"/>
+<wire x1="44.323" y1="15.24" x2="26.67" y2="15.24" width="0.2032" layer="21"/>
+<wire x1="36.83" y1="12.7" x2="36.83" y2="10.541" width="0.2032" layer="21"/>
+<wire x1="36.83" y1="10.541" x2="37.211" y2="10.16" width="0.2032" layer="21"/>
+<wire x1="26.67" y1="12.7" x2="36.83" y2="12.7" width="0.2032" layer="22"/>
+<wire x1="36.83" y1="12.7" x2="36.83" y2="10.541" width="0.2032" layer="22"/>
+<wire x1="36.83" y1="10.541" x2="37.211" y2="10.16" width="0.2032" layer="22"/>
+<wire x1="37.211" y1="10.16" x2="44.323" y2="10.16" width="0.2032" layer="22"/>
+<wire x1="44.323" y1="10.16" x2="44.323" y2="15.24" width="0.2032" layer="22"/>
+<wire x1="44.323" y1="15.24" x2="26.67" y2="15.24" width="0.2032" layer="22"/>
+<wire x1="26.67" y1="15.24" x2="26.67" y2="12.7" width="0.2032" layer="22"/>
+<wire x1="15.24" y1="17.653" x2="14.097" y2="16.51" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="14.097" y1="16.51" x2="15.24" y2="15.367" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="15.24" y1="15.367" x2="22.86" y2="15.367" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="22.86" y1="15.367" x2="24.003" y2="16.51" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="24.003" y1="16.51" x2="22.86" y2="17.653" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="22.86" y1="17.653" x2="15.24" y2="17.653" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="22.86" y1="17.653" x2="24.003" y2="16.51" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="24.003" y1="16.51" x2="22.86" y2="15.367" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="22.86" y1="15.367" x2="15.24" y2="15.367" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="15.24" y1="15.367" x2="14.097" y2="16.51" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="14.097" y1="16.51" x2="15.24" y2="17.653" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="15.24" y1="17.653" x2="22.86" y2="17.653" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="15.24" y1="20.193" x2="14.097" y2="19.05" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="14.097" y1="19.05" x2="15.24" y2="17.907" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="15.24" y1="17.907" x2="22.86" y2="17.907" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="22.86" y1="17.907" x2="24.003" y2="19.05" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="24.003" y1="19.05" x2="22.86" y2="20.193" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="22.86" y1="20.193" x2="15.24" y2="20.193" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="22.86" y1="20.193" x2="24.003" y2="19.05" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="24.003" y1="19.05" x2="22.86" y2="17.907" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="22.86" y1="17.907" x2="15.24" y2="17.907" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="15.24" y1="17.907" x2="14.097" y2="19.05" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="14.097" y1="19.05" x2="15.24" y2="20.193" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="15.24" y1="20.193" x2="22.86" y2="20.193" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="15.24" y1="22.733" x2="14.097" y2="21.59" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="14.097" y1="21.59" x2="15.24" y2="20.447" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="15.24" y1="20.447" x2="22.86" y2="20.447" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="22.86" y1="20.447" x2="24.003" y2="21.59" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="24.003" y1="21.59" x2="22.86" y2="22.733" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="22.86" y1="22.733" x2="15.24" y2="22.733" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="22.86" y1="22.733" x2="24.003" y2="21.59" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="24.003" y1="21.59" x2="22.86" y2="20.447" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="22.86" y1="20.447" x2="15.24" y2="20.447" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="15.24" y1="20.447" x2="14.097" y2="21.59" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="14.097" y1="21.59" x2="15.24" y2="22.733" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="15.24" y1="22.733" x2="22.86" y2="22.733" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="15.24" y1="25.273" x2="14.097" y2="24.13" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="14.097" y1="24.13" x2="15.24" y2="22.987" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="15.24" y1="22.987" x2="22.86" y2="22.987" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="22.86" y1="22.987" x2="24.003" y2="24.13" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="24.003" y1="24.13" x2="22.86" y2="25.273" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="22.86" y1="25.273" x2="15.24" y2="25.273" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="22.86" y1="25.273" x2="24.003" y2="24.13" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="24.003" y1="24.13" x2="22.86" y2="22.987" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="22.86" y1="22.987" x2="15.24" y2="22.987" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="15.24" y1="22.987" x2="14.097" y2="24.13" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="14.097" y1="24.13" x2="15.24" y2="25.273" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="15.24" y1="25.273" x2="22.86" y2="25.273" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="15.24" y1="27.813" x2="14.097" y2="26.67" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="14.097" y1="26.67" x2="15.24" y2="25.527" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="15.24" y1="25.527" x2="22.86" y2="25.527" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="22.86" y1="25.527" x2="24.003" y2="26.67" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="24.003" y1="26.67" x2="22.86" y2="27.813" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="22.86" y1="27.813" x2="15.24" y2="27.813" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="22.86" y1="27.813" x2="24.003" y2="26.67" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="24.003" y1="26.67" x2="22.86" y2="25.527" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="22.86" y1="25.527" x2="15.24" y2="25.527" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="15.24" y1="25.527" x2="14.097" y2="26.67" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="14.097" y1="26.67" x2="15.24" y2="27.813" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="15.24" y1="27.813" x2="22.86" y2="27.813" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="15.24" y1="30.353" x2="14.097" y2="29.21" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="14.097" y1="29.21" x2="15.24" y2="28.067" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="15.24" y1="28.067" x2="22.86" y2="28.067" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="22.86" y1="28.067" x2="24.003" y2="29.21" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="24.003" y1="29.21" x2="22.86" y2="30.353" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="22.86" y1="30.353" x2="15.24" y2="30.353" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="22.86" y1="30.353" x2="24.003" y2="29.21" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="24.003" y1="29.21" x2="22.86" y2="28.067" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="22.86" y1="28.067" x2="15.24" y2="28.067" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="15.24" y1="28.067" x2="14.097" y2="29.21" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="14.097" y1="29.21" x2="15.24" y2="30.353" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="15.24" y1="30.353" x2="22.86" y2="30.353" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="15.24" y1="32.893" x2="14.097" y2="31.75" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="14.097" y1="31.75" x2="15.24" y2="30.607" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="15.24" y1="30.607" x2="22.86" y2="30.607" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="22.86" y1="30.607" x2="24.003" y2="31.75" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="24.003" y1="31.75" x2="22.86" y2="32.893" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="22.86" y1="32.893" x2="15.24" y2="32.893" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="22.86" y1="32.893" x2="24.003" y2="31.75" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="24.003" y1="31.75" x2="22.86" y2="30.607" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="22.86" y1="30.607" x2="15.24" y2="30.607" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="15.24" y1="30.607" x2="14.097" y2="31.75" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="14.097" y1="31.75" x2="15.24" y2="32.893" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="15.24" y1="32.893" x2="22.86" y2="32.893" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="15.24" y1="35.433" x2="14.097" y2="34.29" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="14.097" y1="34.29" x2="15.24" y2="33.147" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="15.24" y1="33.147" x2="22.86" y2="33.147" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="22.86" y1="33.147" x2="24.003" y2="34.29" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="24.003" y1="34.29" x2="22.86" y2="35.433" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="22.86" y1="35.433" x2="15.24" y2="35.433" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="22.86" y1="35.433" x2="24.003" y2="34.29" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="24.003" y1="34.29" x2="22.86" y2="33.147" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="22.86" y1="33.147" x2="15.24" y2="33.147" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="15.24" y1="33.147" x2="14.097" y2="34.29" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="14.097" y1="34.29" x2="15.24" y2="35.433" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="15.24" y1="35.433" x2="22.86" y2="35.433" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="15.24" y1="37.973" x2="14.097" y2="36.83" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="14.097" y1="36.83" x2="15.24" y2="35.687" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="15.24" y1="35.687" x2="22.86" y2="35.687" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="22.86" y1="35.687" x2="24.003" y2="36.83" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="24.003" y1="36.83" x2="22.86" y2="37.973" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="22.86" y1="37.973" x2="15.24" y2="37.973" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="22.86" y1="37.973" x2="24.003" y2="36.83" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="24.003" y1="36.83" x2="22.86" y2="35.687" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="22.86" y1="35.687" x2="15.24" y2="35.687" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="15.24" y1="35.687" x2="14.097" y2="36.83" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="14.097" y1="36.83" x2="15.24" y2="37.973" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="15.24" y1="37.973" x2="22.86" y2="37.973" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="30.48" y1="17.653" x2="29.337" y2="16.51" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="29.337" y1="16.51" x2="30.48" y2="15.367" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="30.48" y1="15.367" x2="38.1" y2="15.367" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="38.1" y1="15.367" x2="39.243" y2="16.51" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="39.243" y1="16.51" x2="38.1" y2="17.653" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="38.1" y1="17.653" x2="30.48" y2="17.653" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="38.1" y1="17.653" x2="39.243" y2="16.51" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="39.243" y1="16.51" x2="38.1" y2="15.367" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="38.1" y1="15.367" x2="30.48" y2="15.367" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="30.48" y1="15.367" x2="29.337" y2="16.51" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="29.337" y1="16.51" x2="30.48" y2="17.653" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="30.48" y1="17.653" x2="38.1" y2="17.653" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="30.48" y1="20.193" x2="29.337" y2="19.05" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="29.337" y1="19.05" x2="30.48" y2="17.907" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="30.48" y1="17.907" x2="38.1" y2="17.907" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="38.1" y1="17.907" x2="39.243" y2="19.05" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="39.243" y1="19.05" x2="38.1" y2="20.193" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="38.1" y1="20.193" x2="30.48" y2="20.193" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="38.1" y1="20.193" x2="39.243" y2="19.05" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="39.243" y1="19.05" x2="38.1" y2="17.907" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="38.1" y1="17.907" x2="30.48" y2="17.907" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="30.48" y1="17.907" x2="29.337" y2="19.05" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="29.337" y1="19.05" x2="30.48" y2="20.193" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="30.48" y1="20.193" x2="38.1" y2="20.193" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="30.48" y1="22.733" x2="29.337" y2="21.59" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="29.337" y1="21.59" x2="30.48" y2="20.447" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="30.48" y1="20.447" x2="38.1" y2="20.447" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="38.1" y1="20.447" x2="39.243" y2="21.59" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="39.243" y1="21.59" x2="38.1" y2="22.733" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="38.1" y1="22.733" x2="30.48" y2="22.733" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="38.1" y1="22.733" x2="39.243" y2="21.59" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="39.243" y1="21.59" x2="38.1" y2="20.447" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="38.1" y1="20.447" x2="30.48" y2="20.447" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="30.48" y1="20.447" x2="29.337" y2="21.59" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="29.337" y1="21.59" x2="30.48" y2="22.733" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="30.48" y1="22.733" x2="38.1" y2="22.733" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="30.48" y1="25.273" x2="29.337" y2="24.13" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="29.337" y1="24.13" x2="30.48" y2="22.987" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="30.48" y1="22.987" x2="38.1" y2="22.987" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="38.1" y1="22.987" x2="39.243" y2="24.13" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="39.243" y1="24.13" x2="38.1" y2="25.273" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="38.1" y1="25.273" x2="30.48" y2="25.273" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="38.1" y1="25.273" x2="39.243" y2="24.13" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="39.243" y1="24.13" x2="38.1" y2="22.987" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="38.1" y1="22.987" x2="30.48" y2="22.987" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="30.48" y1="22.987" x2="29.337" y2="24.13" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="29.337" y1="24.13" x2="30.48" y2="25.273" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="30.48" y1="25.273" x2="38.1" y2="25.273" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="30.48" y1="27.813" x2="29.337" y2="26.67" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="29.337" y1="26.67" x2="30.48" y2="25.527" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="30.48" y1="25.527" x2="38.1" y2="25.527" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="38.1" y1="25.527" x2="39.243" y2="26.67" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="39.243" y1="26.67" x2="38.1" y2="27.813" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="38.1" y1="27.813" x2="30.48" y2="27.813" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="38.1" y1="27.813" x2="39.243" y2="26.67" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="39.243" y1="26.67" x2="38.1" y2="25.527" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="38.1" y1="25.527" x2="30.48" y2="25.527" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="30.48" y1="25.527" x2="29.337" y2="26.67" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="29.337" y1="26.67" x2="30.48" y2="27.813" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="30.48" y1="27.813" x2="38.1" y2="27.813" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="30.48" y1="30.353" x2="29.337" y2="29.21" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="29.337" y1="29.21" x2="30.48" y2="28.067" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="30.48" y1="28.067" x2="38.1" y2="28.067" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="38.1" y1="28.067" x2="39.243" y2="29.21" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="39.243" y1="29.21" x2="38.1" y2="30.353" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="38.1" y1="30.353" x2="30.48" y2="30.353" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="38.1" y1="30.353" x2="39.243" y2="29.21" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="39.243" y1="29.21" x2="38.1" y2="28.067" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="38.1" y1="28.067" x2="30.48" y2="28.067" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="30.48" y1="28.067" x2="29.337" y2="29.21" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="29.337" y1="29.21" x2="30.48" y2="30.353" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="30.48" y1="30.353" x2="38.1" y2="30.353" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="30.48" y1="32.893" x2="29.337" y2="31.75" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="29.337" y1="31.75" x2="30.48" y2="30.607" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="30.48" y1="30.607" x2="38.1" y2="30.607" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="38.1" y1="30.607" x2="39.243" y2="31.75" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="39.243" y1="31.75" x2="38.1" y2="32.893" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="38.1" y1="32.893" x2="30.48" y2="32.893" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="38.1" y1="32.893" x2="39.243" y2="31.75" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="39.243" y1="31.75" x2="38.1" y2="30.607" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="38.1" y1="30.607" x2="30.48" y2="30.607" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="30.48" y1="30.607" x2="29.337" y2="31.75" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="29.337" y1="31.75" x2="30.48" y2="32.893" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="30.48" y1="32.893" x2="38.1" y2="32.893" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="30.48" y1="35.433" x2="29.337" y2="34.29" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="29.337" y1="34.29" x2="30.48" y2="33.147" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="30.48" y1="33.147" x2="38.1" y2="33.147" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="38.1" y1="33.147" x2="39.243" y2="34.29" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="39.243" y1="34.29" x2="38.1" y2="35.433" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="38.1" y1="35.433" x2="30.48" y2="35.433" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="38.1" y1="35.433" x2="39.243" y2="34.29" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="39.243" y1="34.29" x2="38.1" y2="33.147" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="38.1" y1="33.147" x2="30.48" y2="33.147" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="30.48" y1="33.147" x2="29.337" y2="34.29" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="29.337" y1="34.29" x2="30.48" y2="35.433" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="30.48" y1="35.433" x2="38.1" y2="35.433" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="30.48" y1="37.973" x2="29.337" y2="36.83" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="29.337" y1="36.83" x2="30.48" y2="35.687" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="30.48" y1="35.687" x2="38.1" y2="35.687" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="38.1" y1="35.687" x2="39.243" y2="36.83" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="39.243" y1="36.83" x2="38.1" y2="37.973" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="38.1" y1="37.973" x2="30.48" y2="37.973" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="38.1" y1="37.973" x2="39.243" y2="36.83" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="39.243" y1="36.83" x2="38.1" y2="35.687" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="38.1" y1="35.687" x2="30.48" y2="35.687" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="30.48" y1="35.687" x2="29.337" y2="36.83" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="29.337" y1="36.83" x2="30.48" y2="37.973" width="0.2032" layer="21" style="shortdash" curve="-90"/>
+<wire x1="30.48" y1="37.973" x2="38.1" y2="37.973" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="25.4" y1="15.367" x2="26.543" y2="16.51" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="26.543" y1="16.51" x2="26.543" y2="39.37" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="26.543" y1="39.37" x2="25.4" y2="40.513" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="25.4" y1="40.513" x2="24.257" y2="39.243" width="0.2032" layer="22" style="shortdash" curve="96.025575"/>
+<wire x1="24.257" y1="39.243" x2="24.257" y2="16.51" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="24.257" y1="16.51" x2="25.4" y2="15.367" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="25.4" y1="15.367" x2="26.543" y2="16.51" width="0.2032" layer="21" style="shortdash" curve="90"/>
+<wire x1="26.543" y1="16.51" x2="26.543" y2="39.37" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="26.543" y1="39.37" x2="25.4" y2="40.513" width="0.2032" layer="21" style="shortdash" curve="90"/>
+<wire x1="25.4" y1="40.513" x2="24.257" y2="39.243" width="0.2032" layer="21" style="shortdash" curve="96.025575"/>
+<wire x1="24.257" y1="39.243" x2="24.257" y2="16.51" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="24.257" y1="16.51" x2="25.4" y2="15.367" width="0.2032" layer="21" style="shortdash" curve="90"/>
+<wire x1="27.94" y1="15.367" x2="29.083" y2="16.51" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="29.083" y1="16.51" x2="29.083" y2="39.37" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="29.083" y1="39.37" x2="27.94" y2="40.513" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="27.94" y1="40.513" x2="26.797" y2="39.37" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="26.797" y1="39.37" x2="26.797" y2="16.51" width="0.2032" layer="22" style="shortdash"/>
+<wire x1="26.797" y1="16.51" x2="27.94" y2="15.367" width="0.2032" layer="22" style="shortdash" curve="90"/>
+<wire x1="27.94" y1="15.367" x2="29.083" y2="16.51" width="0.2032" layer="21" style="shortdash" curve="90"/>
+<wire x1="29.083" y1="16.51" x2="29.083" y2="39.37" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="29.083" y1="39.37" x2="27.94" y2="40.513" width="0.2032" layer="21" style="shortdash" curve="90"/>
+<wire x1="27.94" y1="40.513" x2="26.797" y2="39.37" width="0.2032" layer="21" style="shortdash" curve="90"/>
+<wire x1="26.797" y1="39.37" x2="26.797" y2="16.51" width="0.2032" layer="21" style="shortdash"/>
+<wire x1="26.797" y1="16.51" x2="27.94" y2="15.367" width="0.2032" layer="21" style="shortdash" curve="90"/>
 </plain>
 <libraries>
 <library name="SparkFun-Aesthetics">
@@ -4611,16 +4614,16 @@ These rules have been curated by SparkFuns DFM commitee. After doing much resear
 <wire x1="28.665" y1="7.112" x2="30.43" y2="8.877" width="0.254" layer="1"/>
 <wire x1="30.7975" y1="1.4605" x2="30.7975" y2="4.064" width="0.254" layer="1"/>
 <wire x1="21.1455" y1="4.318" x2="24.384" y2="4.318" width="0.2032" layer="1"/>
-<wire x1="24.384" y1="4.318" x2="24.638" y2="4.064" width="0.2032" layer="1"/>
+<wire x1="24.384" y1="4.318" x2="25.4" y2="3.302" width="0.2032" layer="1"/>
 <wire x1="32.004" y1="3.81" x2="35.8775" y2="3.81" width="0.254" layer="1"/>
-<wire x1="32.004" y1="3.81" x2="31.75" y2="4.064" width="0.254" layer="1"/>
-<wire x1="24.638" y1="4.064" x2="30.734" y2="4.064" width="0.2032" layer="1"/>
-<wire x1="31.75" y1="4.064" x2="30.7975" y2="4.064" width="0.254" layer="1"/>
 <wire x1="20.32" y1="13.97" x2="22.86" y2="13.97" width="0" layer="19" extent="1-1"/>
 <wire x1="17.78" y1="13.97" x2="20.32" y2="13.97" width="0" layer="19" extent="1-1"/>
 <wire x1="15.24" y1="13.97" x2="17.78" y2="13.97" width="0" layer="19" extent="1-1"/>
 <wire x1="12.7" y1="13.97" x2="15.24" y2="13.97" width="0" layer="19" extent="1-1"/>
 <wire x1="25.4" y1="13.97" x2="22.86" y2="13.97" width="0" layer="19" extent="1-1"/>
+<wire x1="32.004" y1="3.81" x2="31.75" y2="4.064" width="0.254" layer="1"/>
+<wire x1="31.75" y1="4.064" x2="30.7975" y2="4.064" width="0.254" layer="1"/>
+<wire x1="25.4" y1="3.302" x2="30.734" y2="3.302" width="0.2032" layer="1"/>
 </signal>
 <signal name="N$18">
 <via x="38.1" y="16.51" extent="1-16" drill="1.016" diameter="1.8796"/>
@@ -5593,6 +5596,8 @@ These rules have been curated by SparkFuns DFM commitee. After doing much resear
 <approved hash="4,16,39a37d764cf93e28"/>
 <approved hash="4,16,02470cb005cd061e"/>
 <approved hash="4,16,4be51f9411cc4899"/>
+<approved hash="3,1,6286d9401f821f41"/>
+<approved hash="3,1,de6160a167e0d920"/>
 <approved hash="3,1,00de8d1e8d5c009c"/>
 <approved hash="3,1,68e62ba61ba2a7ba"/>
 <approved hash="3,1,706d932d90af73ef"/>
@@ -5600,8 +5605,8 @@ These rules have been curated by SparkFuns DFM commitee. After doing much resear
 <approved hash="3,1,f59e505e503cf5fc"/>
 <approved hash="3,1,eb5af55a3666369e"/>
 <approved hash="3,1,ef526cd26d34eeb4"/>
-<approved hash="3,1,6286d9401f821f41"/>
-<approved hash="3,1,de6160a167e0d920"/>
+<approved hash="3,1,c9fef418d5c4dc3c"/>
+<approved hash="3,1,0893a653b9511791"/>
 <approved hash="4,1,f92577767afec2a9"/>
 <approved hash="4,1,39a37d764cf93e28"/>
 <approved hash="4,1,b9a236713bf9822e"/>

--- a/Hardware/SparkFun_ProtoShield_Kit_rev32.sch
+++ b/Hardware/SparkFun_ProtoShield_Kit_rev32.sch
@@ -24930,10 +24930,10 @@ create customizable
 <wire x1="99.06" y1="63.5" x2="139.7" y2="63.5" width="0.1524" layer="95" style="shortdash"/>
 <wire x1="147.32" y1="63.5" x2="248.92" y2="63.5" width="0.1524" layer="95" style="shortdash"/>
 <wire x1="147.32" y1="35.56" x2="147.32" y2="63.5" width="0.1524" layer="95" style="shortdash"/>
-<text x="149.86" y="165.1" size="2.032" layer="97" font="vector" ratio="15">Disconnected
-Breadboard
+<text x="147.32" y="165.1" size="2.032" layer="97" font="vector" ratio="15">Breadboard
 Prototyping
-Area</text>
+Area w/ Normally
+Open Jumper Pads</text>
 <wire x1="139.7" y1="63.5" x2="139.7" y2="149.86" width="0.1524" layer="95" style="shortdash"/>
 <wire x1="139.7" y1="149.86" x2="139.7" y2="185.42" width="0.1524" layer="95" style="shortdash"/>
 <wire x1="99.06" y1="149.86" x2="139.7" y2="149.86" width="0.1524" layer="95" style="shortdash"/>
@@ -25686,22 +25686,175 @@ Area</text>
 </sheet>
 </sheets>
 <errors>
+<approved hash="101,1,177.8,71.12,JP13,2,,,,"/>
+<approved hash="101,1,167.64,71.12,JP13,1,,,,"/>
+<approved hash="101,1,165.1,71.12,JP14,2,,,,"/>
+<approved hash="101,1,154.94,71.12,JP14,1,,,,"/>
+<approved hash="101,1,152.4,71.12,JP15,2,,,,"/>
+<approved hash="101,1,142.24,71.12,JP15,1,,,,"/>
+<approved hash="101,1,177.8,81.28,JP16,2,,,,"/>
+<approved hash="101,1,167.64,81.28,JP16,1,,,,"/>
+<approved hash="101,1,165.1,81.28,JP17,2,,,,"/>
+<approved hash="101,1,154.94,81.28,JP17,1,,,,"/>
+<approved hash="101,1,152.4,81.28,JP18,2,,,,"/>
+<approved hash="101,1,142.24,81.28,JP18,1,,,,"/>
+<approved hash="101,1,177.8,91.44,JP19,2,,,,"/>
+<approved hash="101,1,167.64,91.44,JP19,1,,,,"/>
+<approved hash="101,1,165.1,91.44,JP20,2,,,,"/>
+<approved hash="101,1,154.94,91.44,JP20,1,,,,"/>
+<approved hash="101,1,152.4,91.44,JP21,2,,,,"/>
+<approved hash="101,1,142.24,91.44,JP21,1,,,,"/>
+<approved hash="101,1,177.8,101.6,JP22,2,,,,"/>
+<approved hash="101,1,167.64,101.6,JP22,1,,,,"/>
+<approved hash="101,1,165.1,101.6,JP23,2,,,,"/>
+<approved hash="101,1,154.94,101.6,JP23,1,,,,"/>
+<approved hash="101,1,152.4,101.6,JP24,2,,,,"/>
+<approved hash="101,1,142.24,101.6,JP24,1,,,,"/>
+<approved hash="101,1,177.8,111.76,JP25,2,,,,"/>
+<approved hash="101,1,167.64,111.76,JP25,1,,,,"/>
+<approved hash="101,1,165.1,111.76,JP26,2,,,,"/>
+<approved hash="101,1,154.94,111.76,JP26,1,,,,"/>
+<approved hash="101,1,152.4,111.76,JP27,2,,,,"/>
+<approved hash="101,1,142.24,111.76,JP27,1,,,,"/>
+<approved hash="101,1,177.8,121.92,JP28,2,,,,"/>
+<approved hash="101,1,167.64,121.92,JP28,1,,,,"/>
+<approved hash="101,1,165.1,121.92,JP29,2,,,,"/>
+<approved hash="101,1,154.94,121.92,JP29,1,,,,"/>
+<approved hash="101,1,152.4,121.92,JP30,2,,,,"/>
+<approved hash="101,1,142.24,121.92,JP30,1,,,,"/>
+<approved hash="101,1,177.8,132.08,JP31,2,,,,"/>
+<approved hash="101,1,167.64,132.08,JP31,1,,,,"/>
+<approved hash="101,1,165.1,132.08,JP32,2,,,,"/>
+<approved hash="101,1,154.94,132.08,JP32,1,,,,"/>
+<approved hash="101,1,152.4,132.08,JP33,2,,,,"/>
+<approved hash="101,1,142.24,132.08,JP33,1,,,,"/>
+<approved hash="101,1,177.8,142.24,JP34,2,,,,"/>
+<approved hash="101,1,167.64,142.24,JP34,1,,,,"/>
+<approved hash="101,1,165.1,142.24,JP35,2,,,,"/>
+<approved hash="101,1,154.94,142.24,JP35,1,,,,"/>
+<approved hash="101,1,152.4,142.24,JP36,2,,,,"/>
+<approved hash="101,1,142.24,142.24,JP36,1,,,,"/>
+<approved hash="101,1,177.8,152.4,JP37,2,,,,"/>
+<approved hash="101,1,167.64,152.4,JP37,1,,,,"/>
+<approved hash="101,1,165.1,152.4,JP38,2,,,,"/>
+<approved hash="101,1,154.94,152.4,JP38,1,,,,"/>
+<approved hash="101,1,152.4,152.4,JP39,2,,,,"/>
+<approved hash="101,1,142.24,152.4,JP39,1,,,,"/>
+<approved hash="101,1,241.3,152.4,JP40,2,,,,"/>
+<approved hash="101,1,231.14,152.4,JP40,1,,,,"/>
+<approved hash="101,1,228.6,152.4,JP41,2,,,,"/>
+<approved hash="101,1,218.44,152.4,JP41,1,,,,"/>
+<approved hash="101,1,215.9,152.4,JP42,2,,,,"/>
+<approved hash="101,1,205.74,152.4,JP42,1,,,,"/>
+<approved hash="101,1,215.9,142.24,JP43,2,,,,"/>
+<approved hash="101,1,205.74,142.24,JP43,1,,,,"/>
+<approved hash="101,1,228.6,142.24,JP44,2,,,,"/>
+<approved hash="101,1,218.44,142.24,JP44,1,,,,"/>
+<approved hash="101,1,241.3,142.24,JP45,2,,,,"/>
+<approved hash="101,1,231.14,142.24,JP45,1,,,,"/>
+<approved hash="101,1,241.3,132.08,JP46,2,,,,"/>
+<approved hash="101,1,231.14,132.08,JP46,1,,,,"/>
+<approved hash="101,1,228.6,132.08,JP47,2,,,,"/>
+<approved hash="101,1,218.44,132.08,JP47,1,,,,"/>
+<approved hash="101,1,215.9,132.08,JP48,2,,,,"/>
+<approved hash="101,1,205.74,132.08,JP48,1,,,,"/>
+<approved hash="101,1,215.9,121.92,JP49,2,,,,"/>
+<approved hash="101,1,205.74,121.92,JP49,1,,,,"/>
+<approved hash="101,1,228.6,121.92,JP50,2,,,,"/>
+<approved hash="101,1,218.44,121.92,JP50,1,,,,"/>
+<approved hash="101,1,241.3,121.92,JP51,2,,,,"/>
+<approved hash="101,1,231.14,121.92,JP51,1,,,,"/>
+<approved hash="101,1,241.3,111.76,JP52,2,,,,"/>
+<approved hash="101,1,231.14,111.76,JP52,1,,,,"/>
+<approved hash="101,1,228.6,111.76,JP53,2,,,,"/>
+<approved hash="101,1,218.44,111.76,JP53,1,,,,"/>
+<approved hash="101,1,215.9,111.76,JP54,2,,,,"/>
+<approved hash="101,1,205.74,111.76,JP54,1,,,,"/>
+<approved hash="101,1,215.9,101.6,JP55,2,,,,"/>
+<approved hash="101,1,205.74,101.6,JP55,1,,,,"/>
+<approved hash="101,1,228.6,101.6,JP56,2,,,,"/>
+<approved hash="101,1,218.44,101.6,JP56,1,,,,"/>
+<approved hash="101,1,241.3,101.6,JP57,2,,,,"/>
+<approved hash="101,1,231.14,101.6,JP57,1,,,,"/>
+<approved hash="101,1,241.3,91.44,JP58,2,,,,"/>
+<approved hash="101,1,231.14,91.44,JP58,1,,,,"/>
+<approved hash="101,1,228.6,91.44,JP59,2,,,,"/>
+<approved hash="101,1,218.44,91.44,JP59,1,,,,"/>
+<approved hash="101,1,215.9,91.44,JP60,2,,,,"/>
+<approved hash="101,1,205.74,91.44,JP60,1,,,,"/>
+<approved hash="101,1,215.9,81.28,JP61,2,,,,"/>
+<approved hash="101,1,205.74,81.28,JP61,1,,,,"/>
+<approved hash="101,1,228.6,81.28,JP62,2,,,,"/>
+<approved hash="101,1,218.44,81.28,JP62,1,,,,"/>
+<approved hash="101,1,241.3,81.28,JP63,2,,,,"/>
+<approved hash="101,1,231.14,81.28,JP63,1,,,,"/>
+<approved hash="101,1,215.9,71.12,JP64,2,,,,"/>
+<approved hash="101,1,205.74,71.12,JP64,1,,,,"/>
+<approved hash="101,1,228.6,71.12,JP65,2,,,,"/>
+<approved hash="101,1,218.44,71.12,JP65,1,,,,"/>
+<approved hash="101,1,241.3,71.12,JP66,2,,,,"/>
+<approved hash="101,1,231.14,71.12,JP66,1,,,,"/>
+<approved hash="101,1,185.42,101.6,JP67,2,,,,"/>
+<approved hash="101,1,185.42,91.44,JP67,1,,,,"/>
+<approved hash="101,1,185.42,88.9,JP68,2,,,,"/>
+<approved hash="101,1,185.42,78.74,JP68,1,,,,"/>
+<approved hash="101,1,185.42,76.2,JP69,2,,,,"/>
+<approved hash="101,1,185.42,66.04,JP69,1,,,,"/>
+<approved hash="101,1,185.42,139.7,JP70,2,,,,"/>
+<approved hash="101,1,185.42,129.54,JP70,1,,,,"/>
+<approved hash="101,1,185.42,127,JP71,2,,,,"/>
+<approved hash="101,1,185.42,116.84,JP71,1,,,,"/>
+<approved hash="101,1,185.42,114.3,JP72,2,,,,"/>
+<approved hash="101,1,185.42,104.14,JP72,1,,,,"/>
+<approved hash="101,1,185.42,177.8,JP73,2,,,,"/>
+<approved hash="101,1,185.42,167.64,JP73,1,,,,"/>
+<approved hash="101,1,185.42,165.1,JP74,2,,,,"/>
+<approved hash="101,1,185.42,154.94,JP74,1,,,,"/>
+<approved hash="101,1,185.42,152.4,JP75,2,,,,"/>
+<approved hash="101,1,185.42,142.24,JP75,1,,,,"/>
+<approved hash="101,1,198.12,101.6,JP76,2,,,,"/>
+<approved hash="101,1,198.12,91.44,JP76,1,,,,"/>
+<approved hash="101,1,198.12,88.9,JP77,2,,,,"/>
+<approved hash="101,1,198.12,78.74,JP77,1,,,,"/>
+<approved hash="101,1,198.12,76.2,JP78,2,,,,"/>
+<approved hash="101,1,198.12,66.04,JP78,1,,,,"/>
+<approved hash="101,1,198.12,139.7,JP79,2,,,,"/>
+<approved hash="101,1,198.12,129.54,JP79,1,,,,"/>
+<approved hash="101,1,198.12,127,JP80,2,,,,"/>
+<approved hash="101,1,198.12,116.84,JP80,1,,,,"/>
+<approved hash="101,1,198.12,114.3,JP81,2,,,,"/>
+<approved hash="101,1,198.12,104.14,JP81,1,,,,"/>
+<approved hash="101,1,198.12,177.8,JP82,2,,,,"/>
+<approved hash="101,1,198.12,167.64,JP82,1,,,,"/>
+<approved hash="101,1,198.12,165.1,JP83,2,,,,"/>
+<approved hash="101,1,198.12,154.94,JP83,1,,,,"/>
+<approved hash="101,1,198.12,152.4,JP84,2,,,,"/>
+<approved hash="101,1,198.12,142.24,JP84,1,,,,"/>
+<approved hash="102,1,116.84,93.726,VCC_2,VDD,,,,"/>
 <approved hash="106,1,45.72,86.36,MISO_NC,,,,,"/>
 <approved hash="106,1,63.5,83.82,MOSI_NC,,,,,"/>
 <approved hash="106,1,12.7,134.62,NC3,,,,,"/>
 <approved hash="106,1,45.72,83.82,SCK_NC,,,,,"/>
-<approved hash="113,1,97.1,31.75,LED1,,,,,"/>
-<approved hash="113,1,109.8,31.75,LED2,,,,,"/>
-<approved hash="113,1,100.398,41.3173,JP4,,,,,"/>
-<approved hash="113,1,113.098,41.3173,JP9,,,,,"/>
+<approved hash="113,1,97.1,31.75,L1,,,,,"/>
+<approved hash="113,1,109.8,31.75,L2,,,,,"/>
+<approved hash="113,1,100.398,41.3173,JP_3,,,,,"/>
+<approved hash="113,1,113.098,41.3173,JP_4,,,,,"/>
 <approved hash="113,1,89.5773,147.252,JP12,,,,,"/>
 <approved hash="113,1,9.48267,152.468,JP10,,,,,"/>
-<approved hash="113,1,135.297,29.1423,JP3,,,,,"/>
-<approved hash="113,1,42.5027,35.6277,JP7,,,,,"/>
+<approved hash="113,1,135.297,26.6023,JP_2,,,,,"/>
+<approved hash="113,1,39.9627,33.0877,JP7,,,,,"/>
 <approved hash="113,1,9.48267,127.068,JP11,,,,,"/>
 <approved hash="113,1,89.5773,116.772,JP1,,,,,"/>
-<approved hash="113,1,135.297,46.9223,JP5,,,,,"/>
-<approved hash="113,1,135.297,13.9023,JP6,,,,,"/>
+<approved hash="113,1,135.297,44.3823,5V,,,,,"/>
+<approved hash="113,1,135.297,11.3623,GND,,,,,"/>
+<approved hash="113,1,109.813,113.098,5V_RAIL,,,,,"/>
+<approved hash="113,1,128.563,113.098,GND_RAIL_1,,,,,"/>
+<approved hash="113,1,109.813,86.4277,VDD_RAIL,,,,,"/>
+<approved hash="113,1,128.563,87.6977,GND_RAIL_2,,,,,"/>
+<approved hash="115,1,44.45,30.48,GND,,,,,"/>
+<approved hash="115,1,46.99,27.94,VCC,,,,,"/>
+<approved hash="115,1,45.72,35.56,RX-I,,,,,"/>
+<approved hash="115,1,49.53,33.02,TX-O,,,,,"/>
 </errors>
 </schematic>
 </drawing>


### PR DESCRIPTION
-Adjust normally open (NO) jumper pad rails so the silkscreen is not over the vias to prevent errors.
-Adjust the "+" 5V trace intersection for the prototyping hardware.